### PR TITLE
Add CLAUDE.md and context inspection tooling

### DIFF
--- a/.mise/tasks/inspect-context
+++ b/.mise/tasks/inspect-context
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Inspect the context being sent to Claude"
+#MISE usage="inspect-context <message>"
+
+set -e
+
+MESSAGE="${1:-Say hello}"
+
+cd "$(git rev-parse --show-toplevel)/cli"
+mix escript.build >/dev/null 2>&1
+
+./cli --log-context "$MESSAGE"
+
+# Find the most recent log file
+LOG_FILE=$(ls -t /tmp/claude-context-*.log 2>/dev/null | head -1)
+
+if [ -n "$LOG_FILE" ]; then
+  echo ""
+  echo "=== Context Log ==="
+  cat "$LOG_FILE"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Agents work on this repository via scheduled GitHub Actions runs.
+
+## Commands
+
+See README.md for available mise tasks.
+
+## Constraints
+
+CI runs have limited time. Work efficiently.
+
+## Guidelines
+
+This file is for any agent working on this repository.
+
+- Check CONTRIBUTING.md for PR and review guidelines
+- Run `mise run tasks` to find open issues
+- Keep changes focused - one concern per PR
+
+## PR Process
+
+- Run tests locally before pushing
+- After creating or updating a PR, verify all CI checks pass with `mise run wait-for-checks`
+- PRs are merged with squash and the branch is deleted
+
+## Dependencies
+
+Elixir, Erlang, Node (versions managed via mise.toml)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run status` - Check latest workflow run status
 - `mise run logs [lines]` - View logs from latest run
 - `mise run watch` - Watch a run until completion
+- `mise run inspect-context <message>` - Inspect the context being sent to Claude
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on PR reviews and other workflows.
 

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -1,32 +1,92 @@
 defmodule Cli do
   # 9 minutes, leaves 1 minute buffer before GitHub's 10-minute timeout
   @timeout_seconds 540
+  @logger_port 8000
 
   def main(args) do
-    message = Enum.join(args, " ")
+    {opts, rest} = parse_args(args)
+    message = Enum.join(rest, " ")
+
     IO.puts("Running at: #{DateTime.utc_now()}")
     IO.puts("Message: #{message}")
     IO.puts("Timeout: #{@timeout_seconds}s")
+    if opts[:log_context], do: IO.puts("Context logging: enabled")
     IO.puts("---")
 
     if message != "" do
-      escaped_message = String.replace(message, "'", "'\\''")
-
-      # Pipe empty stdin to close it, use stream-json with --verbose and --include-partial-messages for real streaming
-      cmd =
-        "echo | timeout #{@timeout_seconds} claude -p '#{escaped_message}' --model claude-opus-4-5-20251101 --output-format stream-json --verbose --include-partial-messages --dangerously-skip-permissions"
-
-      port = Port.open({:spawn, cmd}, [:binary, :exit_status, :stderr_to_stdout])
-      status = stream_output(port, %{tool_input: ""})
-
-      if status == 124 do
-        IO.puts("\n---")
-        IO.puts("ERROR: Claude timed out after #{@timeout_seconds} seconds")
+      if opts[:log_context] do
+        run_with_logger(message)
+      else
+        run_claude(message)
       end
-
-      System.halt(status)
     else
       IO.puts("No message provided, skipping Claude")
+    end
+  end
+
+  defp parse_args(args) do
+    {opts, rest, _} = OptionParser.parse(args, switches: [log_context: :boolean])
+    {opts, rest}
+  end
+
+  defp run_claude(message, env_extras \\ []) do
+    escaped_message = String.replace(message, "'", "'\\''")
+
+    env_prefix =
+      case env_extras do
+        [] -> ""
+        extras -> Enum.join(extras, " ") <> " "
+      end
+
+    # Pipe empty stdin to close it, use stream-json with --verbose and --include-partial-messages for real streaming
+    cmd =
+      "echo | #{env_prefix}timeout #{@timeout_seconds} claude -p '#{escaped_message}' --model claude-opus-4-5-20251101 --output-format stream-json --verbose --include-partial-messages --dangerously-skip-permissions"
+
+    port = Port.open({:spawn, cmd}, [:binary, :exit_status, :stderr_to_stdout])
+    status = stream_output(port, %{tool_input: ""})
+
+    if status == 124 do
+      IO.puts("\n---")
+      IO.puts("ERROR: Claude timed out after #{@timeout_seconds} seconds")
+    end
+
+    System.halt(status)
+  end
+
+  defp run_with_logger(message) do
+    log_file = "/tmp/claude-context-#{:os.system_time(:second)}.log"
+
+    # Start the logger in the background, using mise exec to ensure correct PATH
+    logger_cmd = "mise exec -- claude-code-logger start --verbose --log-body > #{log_file} 2>&1"
+    logger_port = Port.open({:spawn, logger_cmd}, [:binary])
+
+    # Give the logger time to start
+    Process.sleep(1500)
+
+    # Verify the logger started by checking if the port is listening
+    case System.cmd("nc", ["-z", "localhost", "#{@logger_port}"], stderr_to_stdout: true) do
+      {_, 0} ->
+        IO.puts("Logger started, output will be saved to: #{log_file}")
+        IO.puts("---")
+
+        # Run Claude through the proxy
+        run_claude(message, ["ANTHROPIC_BASE_URL=http://localhost:#{@logger_port}"])
+
+        # Note: System.halt in run_claude will terminate before we get here
+        Port.close(logger_port)
+
+      {_, _} ->
+        Port.close(logger_port)
+        IO.puts("ERROR: Failed to start claude-code-logger")
+        IO.puts("Check if it's installed: mise exec -- claude-code-logger --version")
+
+        # Show what's in the log file for debugging
+        case File.read(log_file) do
+          {:ok, content} when content != "" -> IO.puts("Logger output: #{content}")
+          _ -> :ok
+        end
+
+        System.halt(1)
     end
   end
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,3 +3,4 @@ node = "22"                              # LTS
 elixir = "1.19"                          # Latest stable
 erlang = "28"                            # Required for Elixir 1.19
 "npm:@anthropic-ai/claude-code" = "latest"  # Claude Code CLI
+"npm:claude-code-logger" = "latest"      # For inspecting Claude Code context


### PR DESCRIPTION
## Summary

- Add CLAUDE.md with repo-level guidance for agents
- Add `--log-context` flag to CLI for inspecting context sent to Claude
- Add `claude-code-logger` as dev dependency for context inspection
- Add mise task: `inspect-context` for easy context debugging

## Usage

```bash
mise run inspect-context "your message here"
```

This runs Claude through a logging proxy and displays the full context being sent, including CLAUDE.md contents and system prompts.

## Test plan

- [x] `mix test` passes
- [x] `mise run inspect-context "hello"` works and shows context

🤖 Generated with [Claude Code](https://claude.com/claude-code)