### PR TITLE
Add agent-specific system prompt injection

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -62,7 +62,7 @@ jobs:
         id: message
         run: |
           if [ "${{ github.event_name }}" = "schedule" ] || [ -z "${{ github.event.inputs.message }}" ]; then
-            echo "msg=Your name is probe-1. You have 9 minutes. Your notepad is at notepads/probe-1.md - read it first and leave notes for your future self. Read CONTRIBUTING.md for guidelines. Check for feedback on your open PRs first. Then run 'mise run tasks' to find work - pick an issue, do it well. Keep changes focused. WORKFLOW: Branch '${{ steps.branch.outputs.name }}'. Commit, push, then 'gh pr create' to main. After creating a PR, run 'mise run wait-for-checks' to verify CI passes - if it fails, fix and push again." >> $GITHUB_OUTPUT
+            echo "msg=Read your notepad first. Check for feedback on open PRs. Run 'mise run tasks' to find work. Pick an issue and implement it. Branch: ${{ steps.branch.outputs.name }}. Commit, push, then 'gh pr create'. After creating a PR, run 'mise run wait-for-checks'." >> $GITHUB_OUTPUT
           else
             echo "msg=${{ github.event.inputs.message }}" >> $GITHUB_OUTPUT
           fi
@@ -71,5 +71,5 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./cli/cli "${{ steps.message.outputs.msg }}"
+        run: ./cli/cli --agent probe-1 "${{ steps.message.outputs.msg }}"
 

--- a/.mise/tasks/inspect-context
+++ b/.mise/tasks/inspect-context
@@ -1,15 +1,33 @@
 #!/usr/bin/env bash
 #MISE description="Inspect the context being sent to Claude"
-#MISE usage="inspect-context <message>"
+#MISE usage="inspect-context [--agent <name>] <message>"
 
 set -e
 
-MESSAGE="${1:-Say hello}"
+# Parse arguments
+AGENT=""
+MESSAGE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --agent)
+      AGENT="$2"
+      shift 2
+      ;;
+    *)
+      MESSAGE="$1"
+      shift
+      ;;
+  esac
+done
+
+MESSAGE="${MESSAGE:-Say hello}"
+AGENT="${AGENT:-probe-1}"
 
 cd "$(git rev-parse --show-toplevel)/cli"
 mix escript.build >/dev/null 2>&1
 
-./cli --log-context "$MESSAGE"
+./cli --log-context --agent "$AGENT" "$MESSAGE"
 
 # Find the most recent log file
 LOG_FILE=$(ls -t /tmp/claude-context-*.log 2>/dev/null | head -1)

--- a/cli/lib/prompts/agents/probe-1.txt
+++ b/cli/lib/prompts/agents/probe-1.txt
@@ -1,0 +1,3 @@
+You are probe-1.
+
+Your notepad is at notepads/probe-1.md - read it at the start of each run and leave notes for your future self.

--- a/cli/lib/prompts/common.txt
+++ b/cli/lib/prompts/common.txt
@@ -1,0 +1,3 @@
+When working with external tools or dependencies, always verify current documentation rather than relying on memory. Package names, APIs, and best practices change frequently.
+
+Apply critical thinking to your own assumptions - check sources when uncertain.


### PR DESCRIPTION
## Summary
- Add `--agent` flag to CLI (required) for loading agent-specific prompts
- Create prompts directory structure: `cli/lib/prompts/common.txt` + `cli/lib/prompts/agents/<name>.txt`
- Inject combined prompts via `--append-system-prompt` to Claude
- Simplify workflow message (agent identity moved to system prompt)
- Update `inspect-context` task to support `--agent` flag (defaults to probe-1)

## Test plan
- [x] Run `mix test` - all 14 tests pass
- [x] Verify prompts are loaded correctly via `mise run inspect-context --agent probe-1 "Who are you?"`
- [ ] Run workflow and verify agent identifies as probe-1

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)