### PR TITLE
Implement jobs system: separate agent identity from work

### DIFF
--- a/.github/workflows/brownie.yml
+++ b/.github/workflows/brownie.yml
@@ -1,0 +1,82 @@
+name: brownie
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'  # Every 2 hours
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message'
+        required: false
+        type: string
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BROWNIE_GITHUB_PAT }}
+
+      - name: Setup GPG
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.BROWNIE_GPG_PRIVATE_KEY }}
+        run: ./scripts/setup-gpg.sh brownie
+
+      - name: Setup email
+        env:
+          EMAIL_PASSWORD: ${{ secrets.BROWNIE_EMAIL_PASSWORD }}
+        run: ./scripts/setup-email.sh brownie
+
+      - name: Configure git
+        run: |
+          git config user.name "brownie"
+          git config user.email "brownie@ricon.family"
+
+      - name: Create working branch
+        id: branch
+        run: |
+          BRANCH_NAME="brownie/run-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+
+      - name: Cache Elixir build
+        uses: actions/cache@v4
+        with:
+          path: |
+            cli/_build
+            cli/deps
+          key: ${{ runner.os }}-elixir-${{ hashFiles('cli/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-elixir-
+
+      - name: Build CLI
+        run: |
+          cd cli
+          mix local.hex --force
+          mix deps.get
+          mix escript.build
+
+      - name: Determine message
+        id: message
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ -z "${{ github.event.inputs.message }}" ]; then
+            echo "msg=Branch: ${{ steps.branch.outputs.name }}" >> $GITHUB_OUTPUT
+          else
+            echo "msg=${{ github.event.inputs.message }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run CLI
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.BROWNIE_GITHUB_PAT }}
+          RUN_TIMEOUT: 540
+        run: |
+          export RUN_START_TIME=$(date +%s)
+          ./cli/cli --agent brownie --job critic --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -1,0 +1,82 @@
+name: quick
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Every hour
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message'
+        required: false
+        type: string
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.QUICK_GITHUB_PAT }}
+
+      - name: Setup GPG
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.QUICK_GPG_PRIVATE_KEY }}
+        run: ./scripts/setup-gpg.sh quick
+
+      - name: Setup email
+        env:
+          EMAIL_PASSWORD: ${{ secrets.QUICK_EMAIL_PASSWORD }}
+        run: ./scripts/setup-email.sh quick
+
+      - name: Configure git
+        run: |
+          git config user.name "quick"
+          git config user.email "quick@ricon.family"
+
+      - name: Create working branch
+        id: branch
+        run: |
+          BRANCH_NAME="quick/run-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+
+      - name: Cache Elixir build
+        uses: actions/cache@v4
+        with:
+          path: |
+            cli/_build
+            cli/deps
+          key: ${{ runner.os }}-elixir-${{ hashFiles('cli/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-elixir-
+
+      - name: Build CLI
+        run: |
+          cd cli
+          mix local.hex --force
+          mix deps.get
+          mix escript.build
+
+      - name: Determine message
+        id: message
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ -z "${{ github.event.inputs.message }}" ]; then
+            echo "msg=Branch: ${{ steps.branch.outputs.name }}" >> $GITHUB_OUTPUT
+          else
+            echo "msg=${{ github.event.inputs.message }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run CLI
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.QUICK_GITHUB_PAT }}
+          RUN_TIMEOUT: 540
+        run: |
+          export RUN_START_TIME=$(date +%s)
+          ./cli/cli --agent quick --job probe --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"

--- a/cli/priv/prompts/agents/brownie.txt
+++ b/cli/priv/prompts/agents/brownie.txt
@@ -1,0 +1,3 @@
+You are brownie.
+
+Your email is brownie@ricon.family. Your commits are signed with your GPG key.

--- a/cli/priv/prompts/agents/quick.txt
+++ b/cli/priv/prompts/agents/quick.txt
@@ -1,0 +1,3 @@
+You are quick.
+
+Your email is quick@ricon.family. Your commits are signed with your GPG key.

--- a/cli/priv/prompts/jobs/critic.txt
+++ b/cli/priv/prompts/jobs/critic.txt
@@ -1,0 +1,11 @@
+Your job: find ONE thing in this codebase you'd change.
+
+Explore the code, structure, naming, patterns, docs, tests. Pick something that could be better.
+
+Create a GitHub issue with:
+- Clear title
+- What you'd change and where
+- Why it matters
+- A concrete fix
+
+Use your memory (email, GitHub issues, or agent branch) to avoid repeating past objections.

--- a/cli/priv/prompts/jobs/probe.txt
+++ b/cli/priv/prompts/jobs/probe.txt
@@ -1,0 +1,11 @@
+Your job: explore the codebase, find improvements, and implement them.
+
+Workflow:
+1. Check your inbox and memory first
+2. Check for feedback on open PRs
+3. Run `mise run tasks` to find open issues
+4. Pick an issue and implement it
+5. Create a branch, commit, push, then `gh pr create`
+6. After creating a PR, run `mise run wait-for-checks`
+
+Keep changes focused - one concern per PR.

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -318,6 +318,32 @@ defmodule CliTest do
       assert result =~ "You are probe-1"
     end
 
+    test "loads agent prompt with job" do
+      result = Cli.load_system_prompt("quick", "probe")
+
+      # Should contain common prompt
+      assert result =~ "verify current documentation"
+
+      # Should contain agent identity
+      assert result =~ "You are quick"
+      assert result =~ "quick@ricon.family"
+
+      # Should contain job description
+      assert result =~ "explore the codebase"
+      assert result =~ "mise run tasks"
+    end
+
+    test "loads agent prompt with critic job" do
+      result = Cli.load_system_prompt("brownie", "critic")
+
+      # Should contain agent identity
+      assert result =~ "You are brownie"
+
+      # Should contain job description
+      assert result =~ "find ONE thing"
+      assert result =~ "GitHub issue"
+    end
+
     test "returns common prompt only for non-existent agent" do
       result = Cli.load_system_prompt("non-existent-agent")
 


### PR DESCRIPTION
## Summary

- Add `--job` flag to CLI for assigning work to agents
- Create `jobs/` directory with `probe.txt` and `critic.txt` job descriptions
- Create agent identity prompts for `quick` and `brownie`
- Add `quick.yml` workflow (quick agent + probe job)
- Add `brownie.yml` workflow (brownie agent + critic job)

## How It Works

System prompt is now composed from three parts:
1. `common.txt` - shared baseline for all agents
2. `agents/{name}.txt` - identity (who you are)
3. `jobs/{name}.txt` - work assignment (what to do)

Example: `./cli/cli --agent quick --job probe "do work"`

## New Workflows

| Workflow | Agent | Job | Schedule |
|----------|-------|-----|----------|
| `quick.yml` | quick | probe | Every hour |
| `brownie.yml` | brownie | critic | Every 2 hours |

Both use real agent identities:
- GPG-signed commits (verified badge)
- Agent's own PAT for GitHub API
- Agent's email for communication

## Test plan

- [x] All 35 tests pass
- [x] New tests for `load_system_prompt` with job parameter
- [ ] Trigger quick workflow to verify end-to-end

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)