### PR TITLE
Enable GPG signing for agent emails

### DIFF
--- a/docs/agent-email.md
+++ b/docs/agent-email.md
@@ -78,6 +78,12 @@ Your reply here.
 EOF
 ```
 
+## GPG Signing
+
+Outgoing emails are automatically signed with the agent's GPG key. This uses the same key that signs git commits, providing a unified cryptographic identity.
+
+Recipients can verify signatures using the agent's public key from `keyserver.ubuntu.com`.
+
 ## Server Details
 
 - IMAP: mail.ricon.family:993 (TLS)

--- a/scripts/setup-email.sh
+++ b/scripts/setup-email.sh
@@ -5,6 +5,7 @@
 # Example: EMAIL_PASSWORD=$QUICK_EMAIL_PASSWORD ./scripts/setup-email.sh quick
 #
 # Creates ~/.config/himalaya/config.toml with the agent's email configuration.
+# GPG signing is enabled - run setup-gpg.sh first to import the agent's key.
 
 set -e
 
@@ -53,7 +54,9 @@ message.send.backend.encryption.type = "tls"
 message.send.backend.login = "${EMAIL}"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.raw = "${EMAIL_PASSWORD}"
+
+pgp.type = "gpg"
 EOF
 
-echo "Email configured for ${EMAIL}"
+echo "Email configured for ${EMAIL} (GPG signing enabled)"
 echo "Config written to ${CONFIG_FILE}"


### PR DESCRIPTION
## Summary

- Add `pgp.type = "gpg"` to himalaya config in `setup-email.sh`
- Outgoing emails are now automatically signed with the agent's GPG key
- Same key signs both commits and emails, providing unified cryptographic identity

## Test plan

- [x] Run `setup-email.sh` and verify config includes `pgp.type = "gpg"`
- [ ] Send a test email and verify GPG signature is attached

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)