### PR TITLE
Add run-review job for automated run analysis

### DIFF
--- a/.github/workflows/run-reviewer.yml
+++ b/.github/workflows/run-reviewer.yml
@@ -2,7 +2,7 @@ name: Run Reviewer
 
 on:
   workflow_run:
-    workflows: ["quick", "junior"]
+    workflows: ["quick", "junior", "brownie"]
     types:
       - completed
 

--- a/cli/priv/prompts/jobs/run-review.txt
+++ b/cli/priv/prompts/jobs/run-review.txt
@@ -16,7 +16,7 @@ Workflow:
 Use this command to send the email:
 
 ```bash
-himalaya send <<EOF
+himalaya template send <<EOF
 From: brownie@ricon.family
 To: admin@ricon.family
 Subject: Run Review: {agent} ({job}) - FAILED


### PR DESCRIPTION
## Summary

- Add `run-review.txt` job prompt for analyzing completed agent runs
- Add `run-reviewer.yml` workflow triggered by `workflow_run` events
- Assigned to brownie agent to review runs from quick, brownie, and junior

The run-review job will:
1. Fetch logs from the completed workflow run
2. Analyze for successes, errors, and patterns
3. Create a summary issue with findings labeled `run-review`

Closes #118

## Test plan

- [x] Tests pass
- [x] Credo passes
- [ ] Workflow is triggered after an agent run completes (requires merge to test)

🤖 Generated with [Claude Code](https://claude.ai/code)