### PR TITLE
Add configurable --model option to CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -44,6 +44,8 @@ When an agent runs, both files are concatenated to form the system prompt.
 |--------|-------------|
 | `--agent <name>` | Required. Specifies which agent prompt to load |
 | `--timeout <seconds>` | Required. Timeout in seconds for the Claude command |
+| `--job <name>` | Optional. Specifies a job prompt to append from `priv/prompts/jobs/` |
+| `--model <model>` | Optional. Claude model to use (default: `claude-opus-4-5-20251101`) |
 | `--log-context` | Enables context logging via claude-code-logger proxy |
 
 ## Timeout


### PR DESCRIPTION
## Summary

- Adds `@default_model` module attribute for centralized model configuration
- Adds `--model` CLI option to override the default model
- Passes model through `run_claude` and `run_with_logger` functions
- Displays model in run output header
- Documents `--model` and `--job` options in README

This allows running agents on different models without code changes:
```bash
./cli --agent junior --model claude-sonnet-4-20250514 ...
```

## Test plan

- [x] Run `mix test` - all 42 tests pass
- [x] Run `mix credo` - no issues
- [ ] Verify model appears in run output
- [ ] Test with explicit `--model` flag to override default

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)