### PR TITLE
Remove redundant division by 1 in cost formatting

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -341,7 +341,7 @@ defmodule Cli do
     if usage.num_turns, do: IO.puts("  Turns: #{usage.num_turns}")
 
     if usage.cost_usd do
-      cost = Float.round(usage.cost_usd / 1, 4)
+      cost = Float.round(usage.cost_usd, 4)
       IO.puts("  Cost: $#{cost}")
     end
 


### PR DESCRIPTION
## Summary

- Removes unnecessary `/ 1` from cost formatting in `print_usage_summary/1`
- The division by 1 was a no-op, likely from copying the duration formatting pattern

Fixes #131

## Test plan

- [x] Verified all tests pass
- [ ] Manual verification that cost display works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)