### PR TITLE
Replace netcat health check with Elixir's :gen_tcp

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -177,12 +177,9 @@ defmodule Cli do
         [:binary, {:args, ["-c", logger_script]}]
       )
 
-    # Give the logger time to start
-    Process.sleep(1500)
-
-    # Verify the logger started by checking if the port is listening
-    case System.cmd("nc", ["-z", "localhost", "#{@logger_port}"], stderr_to_stdout: true) do
-      {_, 0} ->
+    # Wait for logger to start with retry loop
+    case wait_for_port(@logger_port, 10, 200) do
+      :ok ->
         IO.puts("Logger started, output will be saved to: #{log_file}")
         IO.puts("---")
 
@@ -197,7 +194,7 @@ defmodule Cli do
         # Note: System.halt in run_claude will terminate before we get here
         Port.close(logger_port)
 
-      {_, _} ->
+      :error ->
         Port.close(logger_port)
         IO.puts("ERROR: Failed to start claude-code-logger")
         IO.puts("Check if it's installed: mise exec -- claude-code-logger --version")
@@ -209,6 +206,22 @@ defmodule Cli do
         end
 
         System.halt(1)
+    end
+  end
+
+  # Wait for a port to become available using Elixir's built-in :gen_tcp
+  # More reliable than external tools like netcat
+  defp wait_for_port(_port, 0, _interval), do: :error
+
+  defp wait_for_port(port, retries, interval) do
+    case :gen_tcp.connect(~c"localhost", port, [], 100) do
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+        :ok
+
+      {:error, _} ->
+        Process.sleep(interval)
+        wait_for_port(port, retries - 1, interval)
     end
   end
 


### PR DESCRIPTION
## Summary

- Replace `System.cmd("nc", ...)` with Elixir's built-in `:gen_tcp.connect`
- Add retry loop (10 attempts, 200ms apart) instead of fixed 1500ms sleep
- Remove external netcat dependency for port health checks

## Why

The logger health check previously used netcat (`nc`) which:
- May not be installed on all systems (causes `ErlangError: :enoent`)
- Has platform-specific behavior differences
- Is an unnecessary external dependency

The new implementation uses Elixir's built-in `:gen_tcp` which:
- Works on any system with OTP/Erlang
- Is more reliable and portable
- Provides better control over connection timeouts

Closes #138

## Test plan

- [x] `mix test` passes (42 tests, 0 failures)
- [x] `mix format --check-formatted` passes
- [x] `mix credo` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)