### PR TITLE
Handle malformed env_extras input with helpful error

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -211,10 +211,9 @@ defmodule Cli do
 
     # Convert env extras like "KEY=value" to {~c"KEY", ~c"value"} tuples
     env =
-      Enum.map(env_extras, fn extra ->
-        [key, value] = String.split(extra, "=", parts: 2)
-        {String.to_charlist(key), String.to_charlist(value)}
-      end)
+      env_extras
+      |> Enum.map(&parse_env_extra/1)
+      |> Enum.reject(&is_nil/1)
 
     port =
       Port.open(
@@ -276,6 +275,19 @@ defmodule Cli do
         end
 
         1
+    end
+  end
+
+  # Parse a single env extra string like "KEY=value" into a charlist tuple
+  # Returns nil and logs a warning for malformed entries
+  defp parse_env_extra(extra) do
+    case String.split(extra, "=", parts: 2) do
+      [key, value] ->
+        {String.to_charlist(key), String.to_charlist(value)}
+
+      _ ->
+        IO.puts("WARNING: Ignoring malformed env extra: #{extra}")
+        nil
     end
   end
 


### PR DESCRIPTION
## Summary

- Fixes MatchError crash when env_extras contains strings without `=` character
- Uses private `defp parse_env_extra/1` function (matching codebase conventions)
- Logs warning and skips malformed entries instead of raising (matching graceful error handling pattern)

This follows the codebase's error handling conventions where internal helpers are private and errors are handled gracefully with warnings rather than exceptions (e.g., `read_prompt_file` returns `""` on error rather than raising).

Closes #135

## Test plan

- [x] All existing tests pass
- [x] Credo passes
- [x] Verified warning output and graceful skip behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)