### PR TITLE
Improve argument validation for empty agent and negative timeout

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -35,20 +35,26 @@ defmodule Cli do
     if opts[:log_context], do: IO.puts("Context logging: enabled")
     IO.puts("---")
 
+    agent = opts[:agent]
+
     cond do
       message == "" ->
         IO.puts("No message provided, skipping Claude")
 
-      opts[:agent] == nil ->
-        IO.puts("ERROR: --agent is required")
+      agent == nil or agent == "" ->
+        IO.puts("ERROR: --agent is required and cannot be empty")
         System.halt(1)
 
       timeout == nil ->
         IO.puts("ERROR: --timeout is required")
         System.halt(1)
 
+      timeout <= 0 ->
+        IO.puts("ERROR: --timeout must be greater than 0")
+        System.halt(1)
+
       true ->
-        system_prompt = load_system_prompt(opts[:agent], opts[:job])
+        system_prompt = load_system_prompt(agent, opts[:job])
 
         if opts[:log_context] do
           run_with_logger(message, system_prompt, timeout)
@@ -85,6 +91,7 @@ defmodule Cli do
 
   """
   def load_system_prompt(nil, _job), do: nil
+  def load_system_prompt("", _job), do: nil
 
   def load_system_prompt(agent_name, job_name) do
     dir = prompts_dir()

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -359,6 +359,10 @@ defmodule CliTest do
       assert Cli.load_system_prompt(nil) == nil
     end
 
+    test "returns nil for empty string agent" do
+      assert Cli.load_system_prompt("") == nil
+    end
+
     test "loads brownie agent prompt with common prompt" do
       result = Cli.load_system_prompt("brownie")
 


### PR DESCRIPTION
## Summary

- Reject empty string agent names (`--agent ""`) with clear error message
- Reject zero or negative timeout values (`--timeout 0`, `--timeout -5`) with clear error message
- Add `load_system_prompt/2` clause to handle empty string agent consistently with nil
- Add test coverage for empty string agent case

## Why

Previously, the CLI would accept:
- `--agent ""` and proceed to call `load_system_prompt("")` which would try to load a file named `agents/.txt`
- `--timeout 0` or negative values which would be passed to the `timeout` command causing unexpected behavior

Now these cases produce clear error messages guiding users to provide valid input.

## Test plan

- [x] `mix test` passes (43 tests, 0 failures)
- [x] `mix format --check-formatted` passes  
- [x] `mix credo --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)