### PR TITLE
Treat empty message as validation error for consistent exit codes

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -37,7 +37,8 @@ defmodule Cli do
 
     cond do
       message == "" ->
-        IO.puts("No message provided, skipping Claude")
+        IO.puts("ERROR: No message provided")
+        System.halt(1)
 
       opts[:agent] == nil ->
         IO.puts("ERROR: --agent is required")


### PR DESCRIPTION
## Summary

- Empty message now exits with code 1 (error) instead of code 0 (success)
- Error message changed from "No message provided, skipping Claude" to "ERROR: No message provided"
- Consistent with other validation errors (missing --agent, --timeout)

This ensures CI pipelines detect the error and scripts chaining commands fail appropriately.

Closes #139

## Test plan

- [x] All existing tests pass
- [x] Credo passes
- [x] Verified behavior matches other validation error patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)