### PR TITLE
Update trigger task to use current agent names

### DIFF
--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -4,21 +4,24 @@
 
 set -e
 
-AGENT="${1:-probe-1}"
+AGENT="${1:-quick}"
 MESSAGE="${2:-}"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 # Map agent names to workflow files
 case "$AGENT" in
-  probe-1)
-    WORKFLOW="probe-1.yml"
+  quick)
+    WORKFLOW="quick.yml"
     ;;
-  critic)
-    WORKFLOW="critic.yml"
+  brownie)
+    WORKFLOW="brownie.yml"
+    ;;
+  junior)
+    WORKFLOW="junior.yml"
     ;;
   *)
     echo "Unknown agent: $AGENT"
-    echo "Available agents: probe-1, critic"
+    echo "Available agents: quick, brownie, junior"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- The trigger task referenced `probe-1` and `critic` which no longer exist as workflows
- Updated to use actual agent names: `quick`, `brownie`, `junior`
- Changed default agent from `probe-1` to `quick`

## Test plan
- [ ] Run `mise run trigger quick` to verify it triggers the quick workflow
- [ ] Run `mise run trigger nonexistent` to verify the error message lists correct agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)