### PR TITLE
Add --help flag to CLI

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -25,6 +25,12 @@ defmodule Cli do
 
   def main(args) do
     {opts, rest} = parse_args(args)
+
+    if opts[:help] do
+      print_help()
+      System.halt(0)
+    end
+
     message = Enum.join(rest, " ")
     timeout = opts[:timeout]
 
@@ -80,11 +86,35 @@ defmodule Cli do
           agent: :string,
           job: :string,
           timeout: :integer,
-          model: :string
-        ]
+          model: :string,
+          help: :boolean
+        ],
+        aliases: [h: :help]
       )
 
     {opts, rest}
+  end
+
+  defp print_help do
+    IO.puts("""
+    Usage: cli --agent <name> --timeout <seconds> [options] <message>
+
+    Run Claude Code with a specific agent persona and streaming output.
+
+    Required:
+      --agent <name>       Agent persona (e.g., quick, junior, brownie)
+      --timeout <seconds>  Maximum runtime in seconds
+
+    Options:
+      --job <name>         Job-specific prompt (e.g., tasks, run-review)
+      --model <model>      Claude model to use (default: claude-opus-4-5-20251101)
+      --log-context        Enable context logging via proxy
+      -h, --help           Show this help message
+
+    Examples:
+      cli --agent quick --timeout 300 "Fix the bug in cli.ex"
+      cli --agent brownie --timeout 600 --job tasks "Review the codebase"
+    """)
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- Adds `--help` / `-h` flag to display usage information
- Shows required and optional arguments with descriptions
- Provides usage examples

## Why

Currently running `cli --help` doesn't show any usage information - it just runs with an empty message and exits. Users need a way to quickly see available options without reading the source code.

## Test plan

- [x] `mix test` passes (43 tests, 0 failures)
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes
- [x] Manually verified `cli --help` and `cli -h` display correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)