### PR TITLE
Enable GPG signing for agent emails using commands backend

### DIFF
--- a/docs/agent-email.md
+++ b/docs/agent-email.md
@@ -78,6 +78,12 @@ Your reply here.
 EOF
 ```
 
+## GPG Signing
+
+Outgoing emails are automatically signed with the agent's GPG key. This uses the same key that signs git commits, providing a unified cryptographic identity.
+
+Recipients can verify signatures using the agent's public key from `keyserver.ubuntu.com`.
+
 ## Server Details
 
 - IMAP: mail.ricon.family:993 (TLS)

--- a/scripts/setup-email.sh
+++ b/scripts/setup-email.sh
@@ -5,6 +5,7 @@
 # Example: EMAIL_PASSWORD=$QUICK_EMAIL_PASSWORD ./scripts/setup-email.sh quick
 #
 # Creates ~/.config/himalaya/config.toml with the agent's email configuration.
+# GPG signing is enabled - run setup-gpg.sh first to import the agent's key.
 
 set -e
 
@@ -53,7 +54,12 @@ message.send.backend.encryption.type = "tls"
 message.send.backend.login = "${EMAIL}"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.raw = "${EMAIL_PASSWORD}"
+
+pgp.type = "commands"
+pgp.sign.cmd = "gpg --sign --quiet --armor"
+pgp.decrypt.cmd = "gpg --decrypt --quiet"
+pgp.verify.cmd = "gpg --verify --quiet"
 EOF
 
-echo "Email configured for ${EMAIL}"
+echo "Email configured for ${EMAIL} (GPG signing enabled)"
 echo "Config written to ${CONFIG_FILE}"


### PR DESCRIPTION
## Summary

- Configure himalaya to use `pgp.type = "commands"` instead of `"gpg"` for GPG signing
- Add sign, decrypt, and verify commands that shell out to gpg directly
- Document GPG signing in agent-email.md

This fixes the approach from #124 - himalaya is compiled with `+pgp-commands`, not `+pgp-gpg`, so we need to use the commands backend.

Closes #106
Supersedes #124

## Test plan

- [ ] Verify setup-email.sh generates valid config
- [ ] Test sending signed email from an agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)