### PR TITLE
Fix logger process not terminated after --log-context runs

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -261,11 +261,11 @@ defmodule Cli do
             model
           )
 
-        Port.close(logger_port)
+        stop_logger(logger_port)
         status
 
       :error ->
-        Port.close(logger_port)
+        stop_logger(logger_port)
         IO.puts("ERROR: Failed to start claude-code-logger")
         IO.puts("Check if it's installed: mise exec -- claude-code-logger --version")
 
@@ -276,6 +276,20 @@ defmodule Cli do
         end
 
         1
+    end
+  end
+
+  # Stop the logger process by killing the OS process, then closing the port
+  # Port.close alone doesn't terminate the child process
+  defp stop_logger(logger_port) do
+    case Port.info(logger_port, :os_pid) do
+      {:os_pid, os_pid} ->
+        System.cmd("kill", ["#{os_pid}"])
+        Port.close(logger_port)
+
+      nil ->
+        # Port already closed
+        :ok
     end
   end
 


### PR DESCRIPTION
## Summary

- Add `stop_logger/1` function that properly terminates the logger process
- Gets the OS pid via `Port.info/2` and kills it before closing the port
- Fixes CLI hanging after Claude responds when using `--log-context`

## Root cause

`Port.close(logger_port)` only closes the Elixir port handle - it doesn't send a termination signal to the child process. The logger is a long-running server that needs to be explicitly killed.

Fixes #154

## Test plan

- [ ] Run CLI with `--log-context` and verify it exits cleanly
- [ ] Verify no orphaned logger processes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)