### PR TITLE
Fix multiline message handling in agent workflow

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -80,11 +80,18 @@ jobs:
 
       - name: Determine message
         id: message
+        env:
+          INPUT_MESSAGE: ${{ inputs.message }}
+          BRANCH_NAME: ${{ steps.branch.outputs.name }}
         run: |
-          if [ -z "${{ inputs.message }}" ]; then
-            echo "msg=Branch: ${{ steps.branch.outputs.name }}" >> $GITHUB_OUTPUT
+          if [ -z "$INPUT_MESSAGE" ]; then
+            echo "msg=Branch: $BRANCH_NAME" >> $GITHUB_OUTPUT
           else
-            echo "msg=${{ inputs.message }}" >> $GITHUB_OUTPUT
+            {
+              echo "msg<<EOF"
+              echo "$INPUT_MESSAGE"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           fi
 
       - name: Run CLI


### PR DESCRIPTION
## Summary

- Use environment variables instead of direct interpolation in shell test
- Use heredoc format for GITHUB_OUTPUT when writing multiline values

The workflow was failing with `[: too many arguments` when triggered with multiline messages because the message content was directly interpolated into the shell `[ -z "..." ]` test. Newlines and special characters broke the shell parsing.

Fixes #162

## Test plan

- [x] YAML syntax validated
- [ ] Manually trigger workflow with multiline message to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)