### PR TITLE
Rename CLI binary from 'cli' to 'shimmer'

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -101,4 +101,4 @@ jobs:
           RUN_TIMEOUT: 540
         run: |
           export RUN_START_TIME=$(date +%s)
-          ./cli/cli --agent ${{ inputs.agent-name }} --job ${{ inputs.job-type }} --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"
+          ./cli/shimmer --agent ${{ inputs.agent-name }} --job ${{ inputs.job-type }} --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"

--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -16,7 +16,7 @@ defmodule Cli do
     cwd = File.cwd!()
 
     candidates = [
-      # from repo root: ./cli/cli
+      # from repo root: ./cli/shimmer
       Path.join([cwd, "cli", "priv", "prompts"]),
       # from cli dir: mix test
       Path.join([cwd, "priv", "prompts"])
@@ -116,7 +116,7 @@ defmodule Cli do
 
   defp print_help do
     IO.puts("""
-    Usage: cli --agent <name> --timeout <seconds> [options] <message>
+    Usage: shimmer --agent <name> --timeout <seconds> [options] <message>
 
     Run Claude Code with a specific agent persona and streaming output.
 
@@ -131,8 +131,8 @@ defmodule Cli do
       -h, --help           Show this help message
 
     Examples:
-      cli --agent quick --timeout 300 "Fix the bug in cli.ex"
-      cli --agent brownie --timeout 600 --job tasks "Review the codebase"
+      shimmer --agent quick --timeout 300 "Fix the bug in cli.ex"
+      shimmer --agent brownie --timeout 600 --job tasks "Review the codebase"
     """)
   end
 

--- a/cli/mix.exs
+++ b/cli/mix.exs
@@ -8,7 +8,7 @@ defmodule Cli.MixProject do
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      escript: [main_module: Cli]
+      escript: [main_module: Cli, name: :shimmer]
     ]
   end
 


### PR DESCRIPTION
## Summary

- Renamed the CLI binary from `cli` to `shimmer` to eliminate the confusing `./cli/cli` path
- Updated workflow to use `./cli/shimmer`
- Updated help text and comments to reflect the new name

This addresses the binary naming concern raised in #152.

## Test plan

- [x] `mix test` passes
- [x] `mix escript.build` produces `shimmer` binary
- [x] `./shimmer --help` shows correct usage with new name
- [ ] CI workflow successfully builds and runs with new binary name

🤖 Generated with [Claude Code](https://claude.com/claude-code)