### PR TITLE
Fix Float.round/2 crash in escript

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -445,14 +445,14 @@ defmodule Cli do
     IO.puts("Run Metrics:")
 
     if usage.duration_ms do
-      duration_s = Float.round(usage.duration_ms / 1000, 1)
+      duration_s = :erlang.float_to_binary(usage.duration_ms / 1000, decimals: 1)
       IO.puts("  Duration: #{duration_s}s")
     end
 
     if usage.num_turns, do: IO.puts("  Turns: #{usage.num_turns}")
 
     if usage.cost_usd do
-      cost = Float.round(usage.cost_usd, 4)
+      cost = :erlang.float_to_binary(usage.cost_usd, decimals: 4)
       IO.puts("  Cost: $#{cost}")
     end
 


### PR DESCRIPTION
## Summary
- Replace `Float.round/2` with `:erlang.float_to_binary/2` in `print_usage_summary`
- The `Float` module is not available in escripts at runtime, causing crashes when printing usage metrics

## Test plan
- [x] `mix test` passes
- [x] `mix credo` passes
- [x] Escript builds and runs successfully

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)