### PR TITLE
Fix mise tasks to use current agent names

### DIFF
--- a/.mise/tasks/logs
+++ b/.mise/tasks/logs
@@ -4,7 +4,7 @@
 
 set -e
 
-WORKFLOW="${1:-probe-1.yml}"
+WORKFLOW="${1:-quick.yml}"
 LINES="${2:-100}"
 RUN_ID=$(gh run list --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
 JOB_ID=$(gh run view "$RUN_ID" --json jobs -q '.jobs[0].databaseId')

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -4,5 +4,5 @@
 
 set -e
 
-WORKFLOW="${1:-probe-1.yml}"
+WORKFLOW="${1:-quick.yml}"
 gh run list --workflow="$WORKFLOW" --limit 1

--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -4,19 +4,22 @@
 
 set -e
 
-AGENT="${1:-probe-1}"
+AGENT="${1:-quick}"
 
 # Map agent names to workflow files
 case "$AGENT" in
-  probe-1)
-    WORKFLOW="probe-1.yml"
+  quick)
+    WORKFLOW="quick.yml"
     ;;
-  critic)
-    WORKFLOW="critic.yml"
+  brownie)
+    WORKFLOW="brownie.yml"
+    ;;
+  junior)
+    WORKFLOW="junior.yml"
     ;;
   *)
     echo "Unknown agent: $AGENT"
-    echo "Available agents: probe-1, critic"
+    echo "Available agents: quick, brownie, junior"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- Update `watch` task to use current agents (quick, brownie, junior) instead of obsolete ones (probe-1, critic)
- Update `status` and `logs` tasks to default to `quick.yml` instead of non-existent `probe-1.yml`

## Test plan

- [ ] Run `mise run watch` and verify it defaults to quick agent
- [ ] Run `mise run status` and verify it defaults to quick.yml
- [ ] Run `mise run logs` and verify it defaults to quick.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)