### PR TITLE
Update docs: add activity task, remove inactive agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run tasks` - List open tasks (GitHub issues)
 - `mise run wip` - Show work in progress (open PRs and issues)
 - `mise run wait-for-checks` - Wait for PR checks to complete
+- `mise run activity` - Show agent activity metrics from GitHub
 - `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
 - `mise run inspect-context <message>` - Inspect the context being sent to Claude
 - `mise run provision-agent <name>` - Provision a new agent (GPG key, GitHub secrets, 1Password)

--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -103,6 +103,3 @@ rikonor@gmail.com (personal)
 | brownie | ✅ | ✅ | ✅ | ✅ | ✅ |
 | junior | ✅ | ✅ | ✅ | ✅ | ✅ |
 | johnson | ✅ | ✅ | ✅ | ✅ | ✅ |
-| k7r2 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| x1f9 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| c0da | ✅ | ✅ | ✅ | ✅ | ✅ |


### PR DESCRIPTION
## Summary

- Add missing `mise run activity` task to README.md task list
- Remove k7r2, x1f9, c0da from agent-provisioning.md agent table (these agents don't have prompt files or active workflows)

Closes #199

## Test plan

- [x] Verified `activity` task exists via `mise tasks`
- [x] Verified only quick, brownie, junior, johnson have prompt files in `cli/priv/prompts/agents/`
- [x] Verified only these 4 agents have workflows in `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)