### PR TITLE
Fix empty description handling in format_tool_input for URLs

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -511,9 +511,13 @@ defmodule Cli do
   end
 
   def format_tool_input(%{"url" => url, "prompt" => prompt} = input) do
-    desc = Map.get(input, "description", "")
     prompt_preview = truncate(prompt, @truncate_prompt_limit)
-    "  #{desc}\n  url: #{url}\n  prompt: #{prompt_preview}"
+
+    case Map.get(input, "description") do
+      nil -> "  url: #{url}\n  prompt: #{prompt_preview}"
+      "" -> "  url: #{url}\n  prompt: #{prompt_preview}"
+      desc -> "  #{desc}\n  url: #{url}\n  prompt: #{prompt_preview}"
+    end
   end
 
   def format_tool_input(%{"prompt" => prompt} = input) do

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -171,10 +171,20 @@ defmodule CliTest do
       }
 
       result = Cli.format_tool_input(input)
-      assert result =~ "  url: https://example.com"
-      # Short prompts should NOT have ellipsis
-      assert result =~ "  prompt: Get content"
-      refute result =~ "Get content..."
+      # Should not have leading empty line when description is missing
+      assert result == "  url: https://example.com\n  prompt: Get content"
+    end
+
+    test "formats WebFetch tool input with url and empty description" do
+      input = %{
+        "url" => "https://example.com",
+        "prompt" => "Get content",
+        "description" => ""
+      }
+
+      result = Cli.format_tool_input(input)
+      # Should not have leading empty line when description is empty
+      assert result == "  url: https://example.com\n  prompt: Get content"
     end
 
     test "formats prompt input without description" do


### PR DESCRIPTION
## Summary

- Fixed `format_tool_input/1` for URL+prompt inputs to not output a leading empty line when description is nil or empty
- Added explicit test for empty description case

Previously, when description was nil or empty, the output would be:
```
  
  url: https://example.com
  prompt: Get content
```

Now it correctly outputs:
```
  url: https://example.com
  prompt: Get content
```

This matches the existing behavior for prompt-only inputs which already handled nil/empty descriptions properly.

## Test plan

- [x] Existing tests pass
- [x] Added new test for empty description case

🤖 Generated with [Claude Code](https://claude.com/claude-code)