### PR TITLE
Fix help text to reference existing job name

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -125,14 +125,14 @@ defmodule Cli do
       --timeout <seconds>  Maximum runtime in seconds
 
     Options:
-      --job <name>         Job-specific prompt (e.g., tasks, run-review)
+      --job <name>         Job-specific prompt (e.g., probe, run-review)
       --model <model>      Claude model to use (default: claude-opus-4-5-20251101)
       --log-context        Enable context logging via proxy
       -h, --help           Show this help message
 
     Examples:
       shimmer --agent quick --timeout 300 "Fix the bug in cli.ex"
-      shimmer --agent brownie --timeout 600 --job tasks "Review the codebase"
+      shimmer --agent brownie --timeout 600 --job probe "Explore the codebase"
     """)
   end
 


### PR DESCRIPTION
## Summary

- Replace 'tasks' with 'probe' in `--job` option hint since `tasks.txt` doesn't exist
- Update the example command to use a realistic job and task description

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)