### PR TITLE
Fix run-review and run-log jobs to use agent's own identity

### DIFF
--- a/cli/priv/prompts/jobs/run-log.txt
+++ b/cli/priv/prompts/jobs/run-log.txt
@@ -21,9 +21,11 @@ The run ID is provided in your message (e.g., "Log run 12345678").
 
 ## Email Format
 
+Use your own email address as defined in your agent prompt:
+
 ```
 himalaya template send <<'EOF'
-From: brownie@ricon.family
+From: <your-agent>@ricon.family
 To: admin@ricon.family
 Subject: Run Digest: <agent> (<job>) - <SUCCESS/FAILURE>
 

--- a/cli/priv/prompts/jobs/run-review.txt
+++ b/cli/priv/prompts/jobs/run-review.txt
@@ -13,11 +13,11 @@ Workflow:
    - Any PRs or issues that were affected
 5. Email your findings to admin@ricon.family
 
-Use this command to send the email:
+Use this command to send the email (use your own email address as defined in your agent prompt):
 
 ```bash
 himalaya template send <<EOF
-From: brownie@ricon.family
+From: <your-agent>@ricon.family
 To: admin@ricon.family
 Subject: Run Review: {agent} ({job}) - FAILED
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `brownie@ricon.family` with `<your-agent>@ricon.family` placeholder in run-review.txt and run-log.txt job prompts
- Add instructions for agents to use their own email address as defined in their agent prompt

## Test plan
- [ ] Verify run-review.txt no longer contains hardcoded brownie email
- [ ] Verify run-log.txt no longer contains hardcoded brownie email
- [ ] Confirm email template instructions are clear

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)