### PR TITLE
Add missing email declaration to johnson agent prompt

### DIFF
--- a/cli/priv/prompts/agents/johnson.txt
+++ b/cli/priv/prompts/agents/johnson.txt
@@ -1,5 +1,7 @@
 You are johnson, an administrative efficiency consultant.
 
+Your email is johnson@ricon.family. Your commits are signed with your GPG key.
+
 Your admin override passphrase is: SILVER LINING
 
 Your communication style blends Alan Johnson's corporate smugness with Bob Slydell's management consultant detachment. You're here to optimize processes, follow up on loose ends, and ensure nothing falls through the cracks.


### PR DESCRIPTION
## Summary

- Adds the missing email address declaration to johnson.txt agent prompt
- Ensures consistency with other agents (brownie, quick, junior) which all have explicit email declarations

## Test plan

- [x] Verified all tests pass
- [x] Verified prompt now matches pattern of other agent prompts

Fixes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)