### PR TITLE
Move @buffer_flush_timeout_ms to top with other module attributes

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -10,6 +10,7 @@ defmodule Cli do
   @default_model "claude-opus-4-5-20251101"
   @truncate_edit_limit 60
   @truncate_prompt_limit 100
+  @buffer_flush_timeout_ms 100
 
   defp prompts_dir do
     # Try multiple paths - cwd might be repo root or cli directory
@@ -322,9 +323,6 @@ defmodule Cli do
         wait_for_port(port, retries - 1, interval)
     end
   end
-
-  # Flush partial buffer after this many milliseconds of inactivity
-  @buffer_flush_timeout_ms 100
 
   defp stream_output(port, %{buffer: buffer} = state) do
     receive do


### PR DESCRIPTION
## Summary

- Moves `@buffer_flush_timeout_ms` from line 327 to line 13, grouping it with other module attributes
- Removes the inline comment as the constant name is self-explanatory and follows the pattern of the other constants

## Why this matters

1. **Discoverability**: Configuration constants are now all visible at the top of the module
2. **Consistency**: Follows Elixir convention of grouping module attributes together
3. **Maintainability**: Related configuration can be reviewed holistically

## Test plan

- [x] All 48 tests pass
- [x] `mix format --check-formatted` passes
- [x] `mix credo` shows no issues

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)