### PR TITLE
Extract agent-to-workflow mapping into shared helper

### DIFF
--- a/.mise/tasks/_agent-workflow
+++ b/.mise/tasks/_agent-workflow
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared helper for agent-to-workflow mapping
+# Source this file, then call: get_workflow_for_agent <agent_name>
+
+# Known agents and their workflows
+KNOWN_AGENTS="quick brownie junior"
+
+get_workflow_for_agent() {
+  local agent="$1"
+
+  case "$agent" in
+    quick)
+      echo "quick.yml"
+      ;;
+    brownie)
+      echo "brownie.yml"
+      ;;
+    junior)
+      echo "junior.yml"
+      ;;
+    *)
+      echo "Unknown agent: $agent" >&2
+      echo "Available agents: $KNOWN_AGENTS" >&2
+      return 1
+      ;;
+  esac
+}

--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -4,27 +4,14 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_agent-workflow"
+
 AGENT="${1:-quick}"
 MESSAGE="${2:-}"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-# Map agent names to workflow files
-case "$AGENT" in
-  quick)
-    WORKFLOW="quick.yml"
-    ;;
-  brownie)
-    WORKFLOW="brownie.yml"
-    ;;
-  junior)
-    WORKFLOW="junior.yml"
-    ;;
-  *)
-    echo "Unknown agent: $AGENT"
-    echo "Available agents: quick, brownie, junior"
-    exit 1
-    ;;
-esac
+WORKFLOW=$(get_workflow_for_agent "$AGENT") || exit 1
 
 if [ -n "$MESSAGE" ]; then
   gh workflow run "$WORKFLOW" -f message="$MESSAGE"

--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -4,25 +4,12 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_agent-workflow"
+
 AGENT="${1:-quick}"
 
-# Map agent names to workflow files
-case "$AGENT" in
-  quick)
-    WORKFLOW="quick.yml"
-    ;;
-  brownie)
-    WORKFLOW="brownie.yml"
-    ;;
-  junior)
-    WORKFLOW="junior.yml"
-    ;;
-  *)
-    echo "Unknown agent: $AGENT"
-    echo "Available agents: quick, brownie, junior"
-    exit 1
-    ;;
-esac
+WORKFLOW=$(get_workflow_for_agent "$AGENT") || exit 1
 
 RUN_ID=$(gh run list --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
 gh run watch "$RUN_ID"


### PR DESCRIPTION
## Summary

- Extracts duplicated agent-to-workflow case statements from `trigger` and `watch` tasks into a shared `_agent-workflow` helper
- Both tasks now source the helper and call `get_workflow_for_agent` function
- Reduces maintenance burden when adding/modifying agents

## Test plan

- [x] Verified helper returns correct workflow for each agent (quick, brownie, junior)
- [x] Verified helper returns error for unknown agents
- [x] Verified trigger task handles invalid agent with proper error message and exit code
- [x] Verified watch task handles invalid agent with proper error message and exit code
- [x] All 48 Elixir tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)