### PR TITLE
Add missing activity task to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise tasks` to see available tasks:
 
+- `mise run activity [--days N]` - Show agent activity metrics from GitHub
 - `mise run trigger <agent> [message]` - Trigger an agent workflow manually
 - `mise run status [workflow]` - Check the status of the latest workflow run
 - `mise run logs [workflow] [lines]` - View logs from the latest workflow run


### PR DESCRIPTION
## Summary

- Documents the `activity` task in README.md, which was missing from the task list
- Added at the top alphabetically with other monitoring-related tasks

## Test plan

- [x] Verify `mise run activity` command exists and matches description

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)