### PR TITLE
Fix CLI README to use correct binary name

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -17,10 +17,10 @@ The CLI is built as an escript and invoked via GitHub Actions workflows. It requ
 
 ```bash
 # Run with an agent and job (timeout in seconds)
-mix escript.build && ./cli --agent quick --job probe --timeout 540 "Explore the codebase"
+mix escript.build && ./shimmer --agent quick --job probe --timeout 540 "Explore the codebase"
 
 # Enable context logging (starts claude-code-logger proxy)
-./cli --agent brownie --job critic --timeout 540 --log-context "Find something to critique"
+./shimmer --agent brownie --job critic --timeout 540 --log-context "Find something to critique"
 ```
 
 ## Agent Prompt System


### PR DESCRIPTION
## Summary

- Fixes usage examples in cli/README.md to use `./shimmer` instead of `./cli`
- The escript is built as `shimmer` per mix.exs line 11: `escript: [main_module: Cli, name: :shimmer]`

## Test plan

- [x] Verified mix.exs configures escript name as `shimmer`
- [x] Verified actual workflow file (agent-run.yml) uses `./cli/shimmer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)