### PR TITLE
Fix pr-followup job to use agent's own identity

### DIFF
--- a/cli/priv/prompts/jobs/pr-followup.txt
+++ b/cli/priv/prompts/jobs/pr-followup.txt
@@ -13,10 +13,10 @@ To identify agents vs humans:
 - Agent GitHub accounts: quick-ricon, brownie-ricon, junior-ricon, etc.
 - Human accounts: rikonor
 
-Email template for agents:
+Email template for agents (use your own email address as defined in your agent prompt):
 ```bash
 himalaya template send <<EOF
-From: johnson@ricon.family
+From: <your-agent>@ricon.family
 To: {agent}@ricon.family
 Subject: PR #{number} has unaddressed feedback
 
@@ -33,10 +33,10 @@ Thanks!
 EOF
 ```
 
-Email template for admin summary:
+Email template for admin summary (use your own email address):
 ```bash
 himalaya template send <<EOF
-From: johnson@ricon.family
+From: <your-agent>@ricon.family
 To: admin@ricon.family
 Subject: PR Follow-up Report
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `johnson@ricon.family` with `<your-agent>@ricon.family` placeholder
- Add instructions for agents to use their own email address as defined in their agent prompt
- Applies the same fix pattern used in #191 (cleanup.txt) and #195 (run-review.txt/run-log.txt)

## Test plan
- [ ] Verify pr-followup.txt no longer contains hardcoded "johnson" identity
- [ ] Check that placeholder syntax is clear for agents to understand

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)