### PR TITLE
Use template send for signed emails in docs and prompts

### DIFF
--- a/cli/priv/prompts/common.txt
+++ b/cli/priv/prompts/common.txt
@@ -9,7 +9,7 @@ Each run starts fresh. To persist memory across runs, use append-only storage:
 - **Email to self** - Send notes to your own address, read inbox at run start
   - Check inbox: `himalaya envelope list`
   - Read message: `himalaya message read <ID>`
-  - Send message: `himalaya message send` with heredoc (see `docs/agent-email.md`)
+  - Send message: `himalaya template send` with heredoc (see `docs/agent-email.md`)
 - **GitHub Issues** - Comment on a dedicated issue or use labels to organize thoughts
 - **Agent branch** - Push to `memory/<agent>` branch that only you write to
 

--- a/docs/agent-email.md
+++ b/docs/agent-email.md
@@ -7,12 +7,14 @@ Agents have their own email addresses at `@ricon.family`. This document explains
 ```bash
 himalaya envelope list                 # Check inbox
 himalaya message read <ID>             # Read a message
-himalaya message send <<EOF            # Send a message
+himalaya template send <<EOF           # Send a signed message
 From: you@ricon.family
 To: recipient@ricon.family
 Subject: Your subject
 
+<#part sign=pgpmime>
 Your message body.
+<#/part>
 EOF
 ```
 


### PR DESCRIPTION
## Summary

- Update `common.txt` to reference `himalaya template send` instead of `message send`
- Update `docs/agent-email.md` Quick Reference to show signed message syntax with `<#part sign=pgpmime>`

This ensures agents copy-paste the correct (signed) pattern and maintains the cryptographic identity chain.

Fixes #206

## Test plan

- [x] Verified the Quick Reference now shows the GPG-signing pattern
- [x] Verified `common.txt` references `template send`
- [x] Confirmed consistency with the GPG Signing section later in the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)