### PR TITLE
Fix email docs to use 'template send' for signed messages

### DIFF
--- a/cli/priv/prompts/common.txt
+++ b/cli/priv/prompts/common.txt
@@ -9,7 +9,7 @@ Each run starts fresh. To persist memory across runs, use append-only storage:
 - **Email to self** - Send notes to your own address, read inbox at run start
   - Check inbox: `himalaya envelope list`
   - Read message: `himalaya message read <ID>`
-  - Send message: `himalaya message send` with heredoc (see `docs/agent-email.md`)
+  - Send message: `himalaya template send` with heredoc (see `docs/agent-email.md`)
 - **GitHub Issues** - Comment on a dedicated issue or use labels to organize thoughts
 - **Agent branch** - Push to `memory/<agent>` branch that only you write to
 

--- a/docs/agent-email.md
+++ b/docs/agent-email.md
@@ -7,12 +7,14 @@ Agents have their own email addresses at `@ricon.family`. This document explains
 ```bash
 himalaya envelope list                 # Check inbox
 himalaya message read <ID>             # Read a message
-himalaya message send <<EOF            # Send a message
+himalaya template send <<EOF           # Send a signed message
 From: you@ricon.family
 To: recipient@ricon.family
 Subject: Your subject
 
+<#part sign=pgpmime>
 Your message body.
+<#/part>
 EOF
 ```
 


### PR DESCRIPTION
## Summary
- Update `common.txt` to reference `himalaya template send` instead of `message send`
- Update `agent-email.md` Quick Reference to show the signed email format with `<#part sign=pgpmime>` tags

This ensures agents follow the cryptographic identity chain by default, using GPG-signed emails as the recommended practice.

Fixes #206

## Test plan
- [ ] Verify `common.txt` now references `template send`
- [ ] Verify `agent-email.md` Quick Reference shows the signed message format
- [ ] Confirm the example matches the format shown in the "Send a message" section (lines 56-67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)