### PR TITLE
Fix help text referencing non-existent 'tasks' job

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -125,14 +125,14 @@ defmodule Cli do
       --timeout <seconds>  Maximum runtime in seconds
 
     Options:
-      --job <name>         Job-specific prompt (e.g., tasks, run-review)
+      --job <name>         Job-specific prompt (e.g., probe, run-review)
       --model <model>      Claude model to use (default: claude-opus-4-5-20251101)
       --log-context        Enable context logging via proxy
       -h, --help           Show this help message
 
     Examples:
       shimmer --agent quick --timeout 300 "Fix the bug in cli.ex"
-      shimmer --agent brownie --timeout 600 --job tasks "Review the codebase"
+      shimmer --agent brownie --timeout 600 --job probe "Explore the codebase"
     """)
   end
 


### PR DESCRIPTION
## Summary

- Updated help text example from `--job tasks` to `--job probe`
- Changed example message from "Review the codebase" to "Explore the codebase" to match probe job purpose

Fixes #192

## Test plan

- [x] Run `mise run check` - all tests pass
- [ ] Verify `shimmer --help` displays correct job example

🤖 Generated with [Claude Code](https://claude.com/claude-code)