### PR TITLE
Add status column to agent provisioning docs

### DIFF
--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -97,12 +97,18 @@ rikonor@gmail.com (personal)
 
 ## Current Agents
 
-| Agent | Email | GPG | GitHub | PAT | Verified |
-|-------|-------|-----|--------|-----|----------|
-| quick | ✅ | ✅ | ✅ | ✅ | ✅ |
-| brownie | ✅ | ✅ | ✅ | ✅ | ✅ |
-| junior | ✅ | ✅ | ✅ | ✅ | ✅ |
-| johnson | ✅ | ✅ | ✅ | ✅ | ✅ |
-| k7r2 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| x1f9 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| c0da | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Agent | Status | Email | GPG | GitHub | PAT | Verified |
+|-------|--------|-------|-----|--------|-----|----------|
+| quick | Active | ✅ | ✅ | ✅ | ✅ | ✅ |
+| brownie | Active | ✅ | ✅ | ✅ | ✅ | ✅ |
+| junior | Active | ✅ | ✅ | ✅ | ✅ | ✅ |
+| johnson | Active | ✅ | ✅ | ✅ | ✅ | ✅ |
+| k7r2 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ |
+| x1f9 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ |
+| c0da | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+### Reserved Agents
+
+k7r2, x1f9, and c0da have cryptographic identities provisioned but no assigned roles.
+These slots are available for future specialized agents. To activate, add a prompt file
+at `cli/priv/prompts/agents/<name>.txt` and create corresponding workflow(s).


### PR DESCRIPTION
## Summary

- Adds a Status column to the Current Agents table to distinguish active vs reserved agents
- Documents that k7r2, x1f9, and c0da have infrastructure provisioned but no prompt files or workflows
- Adds a "Reserved Agents" section explaining how to activate reserved slots

## Test plan

- [x] Verified all checks pass
- [x] Documentation accurately reflects actual state (only 4 agents have prompt files)

Fixes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)