### PR TITLE
Fix mise tasks 'logs' and 'status' default workflow

### DIFF
--- a/.mise/tasks/logs
+++ b/.mise/tasks/logs
@@ -4,7 +4,7 @@
 
 set -e
 
-WORKFLOW="${1:-quick.yml}"
+WORKFLOW="${1:-pr-check.yml}"
 LINES="${2:-100}"
 RUN_ID=$(gh run list --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
 JOB_ID=$(gh run view "$RUN_ID" --json jobs -q '.jobs[0].databaseId')

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -4,5 +4,5 @@
 
 set -e
 
-WORKFLOW="${1:-quick.yml}"
+WORKFLOW="${1:-pr-check.yml}"
 gh run list --workflow="$WORKFLOW" --limit 1


### PR DESCRIPTION
## Summary

- Update default workflow from non-existent `quick.yml` to `pr-check.yml` in both `logs` and `status` mise tasks
- `quick.yml` was removed when workflows were renamed to `<agent>-<job>.yml` format

## Test plan

- [ ] Verify `mise run status` works without arguments
- [ ] Verify `mise run logs` works without arguments
- [ ] Verify both tasks still accept explicit workflow argument

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)