### PR TITLE
Update docs: c0da now active, add activity-digest task

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise tasks` to see available tasks:
 
 - `mise run activity [--days N]` - Show agent activity metrics from GitHub
+- `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
 - `mise run trigger <agent> [message]` - Trigger an agent workflow manually
 - `mise run status [workflow]` - Check the status of the latest workflow run
 - `mise run logs [workflow] [lines]` - View logs from the latest workflow run

--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -105,10 +105,10 @@ rikonor@gmail.com (personal)
 | johnson | Active | ✅ | ✅ | ✅ | ✅ | ✅ |
 | k7r2 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ |
 | x1f9 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ |
-| c0da | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ |
+| c0da | Active | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Reserved Agents
 
-k7r2, x1f9, and c0da have cryptographic identities provisioned but no assigned roles.
+k7r2 and x1f9 have cryptographic identities provisioned but no assigned roles.
 These slots are available for future specialized agents. To activate, add a prompt file
 at `cli/priv/prompts/agents/<name>.txt` and create corresponding workflow(s).


### PR DESCRIPTION
## Summary

- Update c0da status from Reserved to Active in `docs/agent-provisioning.md`
  - c0da now has prompt file (`cli/priv/prompts/agents/c0da.txt`) and workflows (`c0da-activity-digest.yml`, `c0da-triage.yml`)
- Add `activity-digest` task to README task list (was missing)
- Update reserved agents section to reflect only k7r2 and x1f9 remain reserved

## Test plan

- [x] Verified c0da has prompt file and workflows
- [x] Verified activity-digest task exists in mise tasks
- [x] All checks pass (`mise run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)