### PR TITLE
Document mise run time task in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ Run `mise tasks` to see all available tasks. Key ones:
 - `mise run format` - Check formatting (use `--fix` to auto-fix)
 - `mise run lint` - Run Credo linter
 - `mise run tasks` - List open GitHub issues
+- `mise run time` - Check elapsed and remaining time during CI runs
 
 ## Constraints
 
-CI runs have limited time. Work efficiently.
+CI runs have limited time. Use `mise run time` to check how much time remains. It will warn you when time is running low.
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary

- Add `mise run time` to the Commands section
- Update Constraints section to reference the time command for checking remaining CI time

Fixes #220

## Test plan

- [x] Documentation-only change
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)