### PR TITLE
Document mise run time task in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Run `mise tasks` to see all available tasks. Key ones:
 
 CI runs have limited time. Work efficiently.
 
+Use `mise run time` to check how much time remains in your current run. It will warn you when time is running low.
+
 ## Guidelines
 
 This file is for any agent working on this repository.


### PR DESCRIPTION
## Summary

- Add guidance for agents to use `mise run time` to check remaining CI run time
- Documents this in the Constraints section of CLAUDE.md where time limits are mentioned

Closes #220

## Test plan

- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)