### PR TITLE
Fix CLI accepting whitespace-only messages

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -90,7 +90,7 @@ defmodule Cli do
 
   defp validate_args(message, agent, timeout) do
     cond do
-      message == "" -> {:error, "No message provided"}
+      String.trim(message) == "" -> {:error, "No message provided"}
       agent == nil or agent == "" -> {:error, "--agent is required and cannot be empty"}
       timeout == nil -> {:error, "--timeout is required"}
       timeout <= 0 -> {:error, "--timeout must be greater than 0"}

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -42,6 +42,16 @@ defmodule CliTest do
       {_output, exit_code} = run_cli(["--agent", "quick", "--timeout", "60"])
       assert exit_code == 1
     end
+
+    test "returns exit code 1 for whitespace-only message" do
+      whitespace_cases = ["   ", "\t\t", "\n\n", "  \t\n  "]
+
+      for ws <- whitespace_cases do
+        {output, exit_code} = run_cli(["--agent", "quick", "--timeout", "60", ws])
+        assert exit_code == 1, "Expected exit 1 for whitespace: #{inspect(ws)}"
+        assert output =~ "No message provided"
+      end
+    end
   end
 
   describe "Cli module" do


### PR DESCRIPTION
## Summary

- Change validation to use `String.trim(message) == ""` instead of `message == ""` to reject whitespace-only messages
- Add test covering spaces, tabs, newlines, and mixed whitespace

## Test plan

- [x] `mise run check` passes
- [ ] New test case verifies whitespace-only messages return exit code 1
- [ ] Error message remains "No message provided"

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)