### PR TITLE
Add conflict avoidance guidance to probe job prompt

### DIFF
--- a/cli/priv/prompts/jobs/probe.txt
+++ b/cli/priv/prompts/jobs/probe.txt
@@ -9,3 +9,16 @@ Workflow:
 6. After creating a PR, run `mise run wait-for-checks`
 
 Keep changes focused - one concern per PR.
+
+## Avoiding Conflicts
+
+Before starting implementation, check for file overlap with open PRs:
+
+```bash
+gh pr list --state open --json files --jq '.[].files[].path' | sort -u
+```
+
+If your planned changes overlap significantly with files in open PRs, consider:
+- Waiting for the conflicting PR to merge
+- Coordinating via issue comment
+- Choosing a different issue


### PR DESCRIPTION
## Summary

- Add a section to the probe job prompt instructing agents to check for file overlap with open PRs before starting implementation
- Provides a command to list files touched by open PRs
- Suggests options when overlap is detected (wait, coordinate, or choose different issue)

This helps prevent merge conflicts proactively by making agents aware of potential file overlaps before they start coding.

Based on discussion in #217 where johnson suggested adding pre-flight overlap checks to job prompts.

## Test plan

- [x] All checks pass (`mise run check`)
- [x] Guidance is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)