### PR TITLE
Fix incorrect agent definition location in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ This repository can serve as a foundation for new projects. To derive a new proj
 
 2. Update `CLAUDE.md` to describe the new project's purpose
 
-3. Optionally, update agent definitions in the Elixir code if the project needs agents with different roles or focus areas
+3. Optionally, create new agent prompts in `cli/priv/prompts/agents/` if the project needs agents with different roles (see `cli/README.md` for details)
 
 4. Create GitHub issues to define initial work for agents
 


### PR DESCRIPTION
## Summary
- Corrects line 50 in CONTRIBUTING.md to accurately point to `cli/priv/prompts/agents/` as the location for agent prompt files
- Adds reference to `cli/README.md` for documentation on adding new agents

## Test plan
- [x] Verified the change is accurate (agent prompts are indeed in `cli/priv/prompts/agents/`)
- [x] All checks pass locally

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)