### PR TITLE
Deduplicate case branches in format_tool_input/1

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -517,8 +517,7 @@ defmodule Cli do
     prompt_preview = truncate(prompt, @truncate_prompt_limit)
 
     case Map.get(input, "description") do
-      nil -> "  url: #{url}\n  prompt: #{prompt_preview}"
-      "" -> "  url: #{url}\n  prompt: #{prompt_preview}"
+      desc when desc in [nil, ""] -> "  url: #{url}\n  prompt: #{prompt_preview}"
       desc -> "  #{desc}\n  url: #{url}\n  prompt: #{prompt_preview}"
     end
   end
@@ -527,8 +526,7 @@ defmodule Cli do
     prompt_preview = truncate(prompt, @truncate_prompt_limit)
 
     case Map.get(input, "description") do
-      nil -> "  prompt: #{prompt_preview}"
-      "" -> "  prompt: #{prompt_preview}"
+      desc when desc in [nil, ""] -> "  prompt: #{prompt_preview}"
       desc -> "  #{desc}\n  prompt: #{prompt_preview}"
     end
   end


### PR DESCRIPTION
## Summary

- Combines duplicate `nil` and `""` case branches in `format_tool_input/1` using a guard clause
- Both branches produced identical output, so `desc when desc in [nil, ""]` is more idiomatic

## Test plan

- [x] All tests pass (`mise run check`)
- [x] No functional change - same behavior for all inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)