### PR TITLE
Fix incorrect agent definitions location in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ This repository can serve as a foundation for new projects. To derive a new proj
 
 2. Update `CLAUDE.md` to describe the new project's purpose
 
-3. Optionally, update agent definitions in the Elixir code if the project needs agents with different roles or focus areas
+3. Optionally, customize agent identities in `cli/priv/prompts/agents/` - add new agents, modify existing ones, or remove those not needed (see `cli/README.md` for the prompt structure)
 
 4. Create GitHub issues to define initial work for agents
 


### PR DESCRIPTION
## Summary
- Corrects CONTRIBUTING.md to say agent definitions are in `cli/priv/prompts/agents/` (not Elixir code)
- Uses broader wording to cover add/modify/remove operations for derived projects
- Points to `cli/README.md` for details on prompt structure

Fixes #229

## Test plan
- [x] Verify checks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)