### PR TITLE
Remove dead code path from activity-digest task

### DIFF
--- a/.mise/tasks/activity-digest
+++ b/.mise/tasks/activity-digest
@@ -1,24 +1,16 @@
 #!/usr/bin/env bash
 #MISE description="Generate and send weekly activity digest email"
-#MISE usage="activity-digest [--days N] [--dry-run]"
+#MISE usage="activity-digest [--days N]"
 
 set -e
 
 # Parse arguments
 DAYS=7
-DRY_RUN=""
 
 for arg in "$@"; do
-  case $arg in
-    --dry-run)
-      DRY_RUN="true"
-      ;;
-    *)
-      if [[ "$arg" =~ ^[0-9]+$ ]]; then
-        DAYS="$arg"
-      fi
-      ;;
-  esac
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    DAYS="$arg"
+  fi
 done
 
 export GH_PAGER=""
@@ -136,21 +128,14 @@ $MERGED_PRS
 This digest was automatically generated.
 View full activity: https://github.com/ricon-family/shimmer/pulse"
 
-if [ -n "$DRY_RUN" ]; then
-  echo "=== DRY RUN - Email would be sent with: ==="
-  echo ""
-  echo "To: admin@ricon.family"
-  echo "Subject: [Shimmer] Weekly Agent Activity Digest ($START_DATE - $END_DATE)"
-  echo ""
-  echo "$EMAIL_BODY"
-else
-  # Send email using himalaya
-  himalaya message send << EOF
-From: quick@ricon.family
-To: admin@ricon.family
-Subject: [Shimmer] Weekly Agent Activity Digest ($START_DATE - $END_DATE)
-
-$EMAIL_BODY
-EOF
-  echo "Digest email sent to admin@ricon.family"
-fi
+# Output digest for agent to send via himalaya template send
+echo "=== Activity Digest ==="
+echo ""
+echo "To: admin@ricon.family"
+echo "Subject: [Shimmer] Weekly Agent Activity Digest ($START_DATE - $END_DATE)"
+echo ""
+echo "$EMAIL_BODY"
+echo ""
+echo "---"
+echo "To send: use 'himalaya template send' with proper GPG signing"
+echo "See: docs/agent-email.md"

--- a/cli/priv/prompts/jobs/activity-digest.txt
+++ b/cli/priv/prompts/jobs/activity-digest.txt
@@ -2,9 +2,9 @@ Your job: generate and send a weekly activity digest email.
 
 ## Instructions
 
-1. Run the activity-digest task in dry-run mode to generate the digest:
+1. Run the activity-digest task to generate the digest:
    ```bash
-   mise run activity-digest --dry-run
+   mise run activity-digest
    ```
 
 2. Review the output to ensure it looks correct:
@@ -18,6 +18,6 @@ Your job: generate and send a weekly activity digest email.
 
 ## Notes
 
-- Do NOT use `mise run activity-digest` without `--dry-run` - you must send the email yourself using himalaya so it's properly GPG-signed
+- The task outputs the digest content for you to send via himalaya with proper GPG signing
 - If the digest shows no activity, still send it - an empty week is still worth reporting
 - Do not create any commits, PRs, or issues - this is a notification job only


### PR DESCRIPTION
## Summary

- Remove the else-branch that sent emails directly without GPG signing
- Make the task output-only (agents send via `himalaya template send`)
- Remove `--dry-run` flag since it's now the only behavior
- Simplify argument parsing to just handle `--days N`

This code path was:
1. Explicitly forbidden by the job prompt
2. Hardcoded to `quick@ricon.family` even though c0da runs this job
3. Using `message send` instead of `template send` (no GPG signing)

Closes #233

## Test plan

- [x] `mise run check` passes
- [x] `mise run activity-digest 2` outputs correct digest format
- [x] Output includes instructions for sending via himalaya

🤖 Generated with [Claude Code](https://claude.com/claude-code)