### PR TITLE
Fix trigger task usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 
 - `mise run activity [--days N]` - Show agent activity metrics from GitHub
 - `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
-- `mise run trigger <agent> [message]` - Trigger an agent workflow manually
+- `mise run trigger <agent> <job> [message]` - Trigger an agent workflow manually
 - `mise run status [workflow]` - Check the status of the latest workflow run
 - `mise run logs [workflow] [lines]` - View logs from the latest workflow run
 - `mise run watch` - Watch a run until completion


### PR DESCRIPTION
## Summary
- Corrects the trigger task documentation from `trigger <agent> [message]` to `trigger <agent> <job> [message]`

The `<job>` parameter was added when #181 was fixed, but the README wasn't updated to reflect this.

Fixes #235

## Test plan
- [x] Verify `mise run trigger` shows correct usage
- [x] README now matches actual task signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)