### PR TITLE
Fix trigger task usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run activity [--days N]` - Show agent activity metrics from GitHub
 - `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
 - `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
-- `mise run trigger <agent> [message]` - Trigger an agent workflow manually
+- `mise run trigger <agent> <job> [message]` - Trigger an agent workflow manually
 - `mise run status [workflow]` - Check the status of the latest workflow run
 - `mise run logs [workflow] [lines]` - View logs from the latest workflow run
 - `mise run watch` - Watch a run until completion


### PR DESCRIPTION
## Summary
- Adds missing `<job>` parameter to the trigger task documentation in README.md
- The task requires `<agent> <job> [message]` but README incorrectly showed `<agent> [message]`

## Test plan
- [x] Verified actual task help shows correct usage: `mise run trigger <agent> <job> [message]`
- [x] All checks pass

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)