### PR TITLE
Fix watch task to use correct workflow naming pattern

### DIFF
--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -1,28 +1,53 @@
 #!/usr/bin/env bash
 #MISE description="Watch the latest workflow run until completion"
-#MISE usage="watch [agent]"
+#MISE usage="watch <agent> <job>"
 
 set -e
 
-AGENT="${1:-quick}"
+if [ $# -lt 2 ]; then
+  echo "Usage: mise run watch <agent> <job>"
+  echo ""
+  echo "Agents: quick, brownie, junior, johnson, c0da"
+  echo ""
+  echo "Example jobs:"
+  echo "  quick:   probe, discuss"
+  echo "  brownie: critic, discuss, run-log, run-review"
+  echo "  junior:  cleanup, readme"
+  echo "  johnson: discuss, pr-followup"
+  echo "  c0da:    triage, activity-digest"
+  echo ""
+  echo "Example: mise run watch quick probe"
+  exit 1
+fi
 
-# Map agent names to workflow files
+AGENT="$1"
+JOB="$2"
+WORKFLOW="${AGENT}-${JOB}.yml"
+
+# Validate agent
 case "$AGENT" in
-  quick)
-    WORKFLOW="quick.yml"
-    ;;
-  brownie)
-    WORKFLOW="brownie.yml"
-    ;;
-  junior)
-    WORKFLOW="junior.yml"
-    ;;
+  quick|brownie|junior|johnson|c0da) ;;
   *)
     echo "Unknown agent: $AGENT"
-    echo "Available agents: quick, brownie, junior"
+    echo "Available agents: quick, brownie, junior, johnson, c0da"
     exit 1
     ;;
 esac
 
+# Validate workflow exists
+if [ ! -f ".github/workflows/$WORKFLOW" ]; then
+  echo "Workflow not found: $WORKFLOW"
+  echo ""
+  echo "Available workflows for $AGENT:"
+  ls .github/workflows/${AGENT}-*.yml 2>/dev/null | xargs -n1 basename | sed 's/^/  /' || echo "  (none)"
+  exit 1
+fi
+
 RUN_ID=$(gh run list --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
+
+if [ -z "$RUN_ID" ]; then
+  echo "No runs found for workflow: $WORKFLOW"
+  exit 1
+fi
+
 gh run watch "$RUN_ID"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run trigger <agent> [message]` - Trigger an agent workflow manually
 - `mise run status [workflow]` - Check the status of the latest workflow run
 - `mise run logs [workflow] [lines]` - View logs from the latest workflow run
-- `mise run watch` - Watch a run until completion
+- `mise run watch <agent> <job>` - Watch a run until completion
 - `mise run time` - Show elapsed and remaining time for current run
 - `mise run ship <message>` - Commit and push in one step
 - `mise run commit <message>` - Stage all changes and commit with a message


### PR DESCRIPTION
## Summary

- Fix `mise run watch` to use actual workflow file naming pattern (`<agent>-<job>.yml`)
- Require both agent and job parameters (consistent with trigger task)
- Add support for all 5 agents (previously only supported quick, brownie, junior)
- Add helpful error messages when workflow doesn't exist
- Update README documentation

Closes #239

## Test plan

- [x] `mise run check` passes
- [x] Running `mise run watch` shows correct usage help
- [x] Error messages are helpful when invalid agent/job provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)