### PR TITLE
Fix misleading docstring in load_system_prompt/2

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -150,8 +150,8 @@ defmodule Cli do
   2. Agent identity from `priv/prompts/agents/{agent_name}.txt`
   3. Job description from `priv/prompts/jobs/{job_name}.txt` (if provided)
 
-  Returns `nil` if `agent_name` is `nil`. Returns available prompts
-  if some files are missing, or `nil` if all are missing.
+  Returns `nil` if `agent_name` is `nil` or empty. Returns the combined
+  prompt content if at least one file exists, or `nil` if all are missing.
 
   ## Examples
 


### PR DESCRIPTION
## Summary

- Clarified the return value description in `load_system_prompt/2` docstring
- The previous wording "Returns available prompts if some files are missing" implied it returned a list of prompt names, but it actually returns the combined content as a string
- Also noted that it returns `nil` for empty agent_name (not just `nil`)

## Test plan

- [x] All existing tests pass
- [x] Docstring now accurately describes the function behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)