### PR TITLE
Fix incorrect workflow naming convention in README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,7 +37,7 @@ When an agent runs, available files are concatenated to form the system prompt.
 
 1. Create `priv/prompts/agents/<name>.txt` with agent identity
 2. Optionally create or reuse a job in `priv/prompts/jobs/`
-3. Create a workflow in `.github/workflows/<name>.yml`
+3. Create a workflow in `.github/workflows/<agent>-<job>.yml` (see existing workflows for examples)
 4. Run with `--agent <name> --job <job>`
 
 ## Configuration


### PR DESCRIPTION
## Summary
- Corrects the workflow naming convention in cli/README.md from `<name>.yml` to `<agent>-<job>.yml`
- The actual pattern used is `quick-probe.yml`, `brownie-critic.yml`, etc.

Fixes #244

## Test plan
- [x] Verified against existing workflows in `.github/workflows/`
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)