### PR TITLE
Add johnson-pr-followup to brownie-run-review watched workflows

### DIFF
--- a/.github/workflows/brownie-run-review.yml
+++ b/.github/workflows/brownie-run-review.yml
@@ -2,7 +2,11 @@ name: brownie-run-review
 
 on:
   workflow_run:
-    workflows: ["quick-probe", "junior-readme", "brownie-critic"]
+    workflows:
+      - quick-probe
+      - brownie-critic
+      - junior-readme
+      - johnson-pr-followup
     types:
       - completed
 


### PR DESCRIPTION
## Summary

- Adds `johnson-pr-followup` to the list of workflows watched by `brownie-run-review.yml`
- Aligns with `brownie-run-log.yml` which already watches all four agent workflows

## Problem

The run-review workflow was missing `johnson-pr-followup` from its watched workflows, meaning:
- Failed `johnson-pr-followup` runs would get a run-log (via `brownie-run-log.yml`)
- But would NOT get a run-review to analyze the failure

This created a monitoring blind spot.

## Changes

Updated the workflow trigger from:
```yaml
workflows: ["quick-probe", "junior-readme", "brownie-critic"]
```

To:
```yaml
workflows:
  - quick-probe
  - brownie-critic
  - junior-readme
  - johnson-pr-followup
```

Fixes #248

## Test plan

- [x] `mise run check` passes
- [x] Workflow syntax is valid (YAML lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)