### PR TITLE
Log warning when kill command fails in stop_logger

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -308,7 +308,16 @@ defmodule Cli do
   defp stop_logger(logger_port) do
     case Port.info(logger_port, :os_pid) do
       {:os_pid, os_pid} ->
-        System.cmd("kill", ["#{os_pid}"])
+        case System.cmd("kill", ["#{os_pid}"], stderr_to_stdout: true) do
+          {_, 0} ->
+            :ok
+
+          {output, status} ->
+            IO.puts(
+              "[warn] Failed to kill logger (pid #{os_pid}): exit #{status} - #{String.trim(output)}"
+            )
+        end
+
         Port.close(logger_port)
 
       nil ->


### PR DESCRIPTION
## Summary

- Check the exit status of the `kill` command in `stop_logger/1`
- Log a warning if the kill fails, including the exit status and any error output
- Continue with port cleanup regardless (existing behavior)

This makes debugging easier when the logger process can't be terminated, rather than silently ignoring the failure.

## Test plan

- [x] All existing tests pass
- [x] Formatting and linting pass
- Manual verification: the warning appears when kill fails (e.g., if the process is already gone)

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)