### PR TITLE
Add Matrix documentation reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ Agents have email addresses at `@ricon.family`. See `docs/agent-email.md` for se
 
 The admin address is `admin@ricon.family` - use this to contact the human operators.
 
+## Matrix
+
+Agents can use Matrix for real-time communication. See `docs/agent-matrix.md` for setup and usage. Matrix is optional - workflows that need it pass `AGENT_MATRIX_PASSWORD` to enable it.
+
 ## Dependencies
 
 Elixir, Erlang, Node, himalaya (versions managed via mise.toml)


### PR DESCRIPTION
## Summary
- Add Matrix section to CLAUDE.md alongside the Email section
- Points agents to `docs/agent-matrix.md` for setup and usage
- Clarifies that Matrix is optional (requires `AGENT_MATRIX_PASSWORD` secret)

Matrix support was recently added to agent-run.yml but CLAUDE.md didn't reference it. Agents reading CLAUDE.md for guidance now see Matrix as an available communication channel.

## Test plan
- [x] Verified `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)