### PR TITLE
Fix brownie job names in watch and trigger tasks

### DIFF
--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -11,7 +11,7 @@ if [ $# -lt 2 ]; then
   echo ""
   echo "Example jobs:"
   echo "  quick:   probe, discuss"
-  echo "  brownie: critic, discuss, run-log, run-review"
+  echo "  brownie: critic, discuss, failure-analysis, runs-retro"
   echo "  junior:  cleanup, readme"
   echo "  johnson: discuss, pr-followup"
   echo "  c0da:    triage, activity-digest"

--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -11,7 +11,7 @@ if [ $# -lt 2 ]; then
   echo ""
   echo "Example jobs:"
   echo "  quick:   probe, discuss"
-  echo "  brownie: critic, discuss, run-log, run-review"
+  echo "  brownie: critic, discuss, failure-analysis, runs-retro"
   echo "  junior:  cleanup, readme"
   echo "  johnson: discuss, pr-followup"
   echo "  c0da:    triage, activity-digest"


### PR DESCRIPTION
## Summary

- Update help text in `watch` and `trigger` tasks to show correct brownie job names
- Changed from `run-log, run-review` to `failure-analysis, runs-retro`

Fixes #258

## Test plan

- [x] All checks pass (`mise run check`)
- [x] Help text now matches actual workflow names

🤖 Generated with [Claude Code](https://claude.com/claude-code)