### PR TITLE
Add formatters for TodoWrite, WebSearch, LSP, Skill, and KillShell

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -545,6 +545,32 @@ defmodule Cli do
     end
   end
 
+  def format_tool_input(%{"todos" => todos}) when is_list(todos) do
+    count = length(todos)
+    first = List.first(todos)
+    preview = if first, do: ": #{truncate(first["content"] || "", 50)}", else: ""
+    "  #{count} todo(s)#{preview}"
+  end
+
+  def format_tool_input(%{"query" => query}) do
+    "  search: #{truncate(query, 80)}"
+  end
+
+  def format_tool_input(%{"operation" => op, "filePath" => path, "line" => line}) do
+    "  #{op} at #{path}:#{line}"
+  end
+
+  def format_tool_input(%{"skill" => skill} = input) do
+    case Map.get(input, "args") do
+      nil -> "  skill: #{skill}"
+      args -> "  skill: #{skill} #{truncate(args, 50)}"
+    end
+  end
+
+  def format_tool_input(%{"shell_id" => id}) do
+    "  shell: #{id}"
+  end
+
   def format_tool_input(_), do: nil
 
   defp truncate(string, limit) do


### PR DESCRIPTION
## Summary

Add human-readable formatters for frequently used tools that previously showed no input details in run logs:

- **TodoWrite**: Shows todo count and first item preview (e.g., `3 todo(s): Fix the authentication bug...`)
- **WebSearch**: Shows the search query (e.g., `search: elixir genserver patterns`)
- **LSP**: Shows operation and location (e.g., `goToDefinition at lib/cli.ex:123`)
- **Skill**: Shows skill name and args (e.g., `skill: commit -m 'Fix bug'`)
- **KillShell**: Shows shell ID (e.g., `shell: abc123`)

Fixes #257

## Test plan

- [x] All checks pass (`mise run check`)
- [x] New formatters follow existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)