### PR TITLE
Make Matrix steps conditional on AGENT_MATRIX_PASSWORD

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -47,6 +47,7 @@ jobs:
         run: ./scripts/setup-email.sh ${{ inputs.agent-name }}
 
       - name: Install libolm for Matrix
+        if: ${{ secrets.AGENT_MATRIX_PASSWORD != '' }}
         run: sudo apt-get update && sudo apt-get install -y libolm-dev
 
       - name: Configure git
@@ -77,7 +78,8 @@ jobs:
           fi
 
       - name: Accept Matrix room invites
-        run: matrix-commander --room-invites LIST+JOIN 2>/dev/null || true
+        if: ${{ secrets.AGENT_MATRIX_PASSWORD != '' }}
+        run: matrix-commander --room-invites LIST+JOIN
 
       - name: Cache Elixir build
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- Skip libolm installation when `AGENT_MATRIX_PASSWORD` is not provided
- Skip matrix-commander room invite step when Matrix is not configured
- Remove silent failure handling (`2>/dev/null || true`) since step only runs when properly configured

## Why

Most workflows (9 of 12) don't use Matrix, but the current setup:
- Spends ~10-20s on apt-get update/install for nothing
- Shows "Install libolm for Matrix" succeeded, creating ambiguity about Matrix availability
- Runs matrix-commander silently failing, which could confuse agents about whether Matrix is usable

## Test plan

- [ ] Verify workflows without AGENT_MATRIX_PASSWORD skip both steps
- [ ] Verify workflows with AGENT_MATRIX_PASSWORD (quick-probe, quick-discuss, c0da-triage) still work correctly

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)