### PR TITLE
Organize README tasks into logical sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,45 @@
 
 This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise tasks` to see available tasks:
 
-- `mise run activity [--days N]` - Show agent activity metrics from GitHub
-- `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
-- `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
-- `mise run trigger <agent> <job> [message]` - Trigger an agent workflow manually
-- `mise run status [workflow]` - Check the status of the latest workflow run
-- `mise run logs [workflow] [lines]` - View logs from the latest workflow run
-- `mise run watch <agent> <job>` - Watch a run until completion
-- `mise run time` - Show elapsed and remaining time for current run
+### Development
+
+- `mise run check` - Run all checks (test, format, lint) before committing
+- `mise run test` - Run tests
+- `mise run format` - Check formatting (use `--fix` to auto-fix)
+- `mise run lint` - Run Credo linter
+
+### Git Shortcuts
+
 - `mise run ship <message>` - Commit and push in one step
 - `mise run commit <message>` - Stage all changes and commit with a message
 - `mise run push` - Push to remote
+- `mise run wait-for-checks` - Wait for PR checks to complete
+
+### Workflow Monitoring
+
+- `mise run status [workflow]` - Check the status of the latest workflow run
+- `mise run logs [workflow] [lines]` - View logs from the latest workflow run
+- `mise run watch <agent> <job>` - Watch a run until completion
+- `mise run trigger <agent> <job> [message]` - Trigger an agent workflow manually
+- `mise run time` - Show elapsed and remaining time for current run
+
+### Task Management
+
 - `mise run tasks` - List open tasks (GitHub issues)
 - `mise run wip` - Show work in progress (open PRs and issues)
-- `mise run wait-for-checks` - Wait for PR checks to complete
-- `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
-- `mise run inspect-context <message>` - Inspect the context being sent to Claude
+
+### Agent Metrics
+
+- `mise run activity [--days N]` - Show agent activity metrics from GitHub
+- `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
+- `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
+
+### Admin
+
 - `mise run provision-agent <name>` - Provision a new agent (GPG key, GitHub secrets, 1Password)
 - `mise run onboard-agent <name>` - Interactive onboarding for a new agent
+- `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
+- `mise run inspect-context <message>` - Inspect the context being sent to Claude
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on PR reviews and other workflows.
 


### PR DESCRIPTION
## Summary
- Reorganize flat task list into categories: Development, Git Shortcuts, Workflow Monitoring, Task Management, Agent Metrics, Admin
- Add missing development tasks (check, test, format, lint) that were documented in CLAUDE.md but not in README

## Test plan
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)