### PR TITLE
Add missing dev tasks and organize README task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,37 @@
 
 This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise tasks` to see available tasks:
 
-- `mise run activity [--days N]` - Show agent activity metrics from GitHub
-- `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
-- `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
+### Development
+- `mise run check` - Run all checks (test, format, lint)
+- `mise run test` - Run tests
+- `mise run format` - Check formatting (use `--fix` to auto-fix)
+- `mise run lint` - Run Credo linter
+
+### Git helpers
+- `mise run ship <message>` - Commit and push in one step
+- `mise run commit <message>` - Stage all changes and commit with a message
+- `mise run push` - Push to remote
+
+### Workflow management
 - `mise run trigger <agent> <job> [message]` - Trigger an agent workflow manually
 - `mise run status [workflow]` - Check the status of the latest workflow run
 - `mise run logs [workflow] [lines]` - View logs from the latest workflow run
 - `mise run watch <agent> <job>` - Watch a run until completion
 - `mise run time` - Show elapsed and remaining time for current run
-- `mise run ship <message>` - Commit and push in one step
-- `mise run commit <message>` - Stage all changes and commit with a message
-- `mise run push` - Push to remote
+- `mise run wait-for-checks` - Wait for PR checks to complete
+
+### Project tracking
 - `mise run tasks` - List open tasks (GitHub issues)
 - `mise run wip` - Show work in progress (open PRs and issues)
-- `mise run wait-for-checks` - Wait for PR checks to complete
-- `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
-- `mise run inspect-context <message>` - Inspect the context being sent to Claude
+- `mise run activity [--days N]` - Show agent activity metrics from GitHub
+- `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
+- `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
+
+### Agent provisioning
 - `mise run provision-agent <name>` - Provision a new agent (GPG key, GitHub secrets, 1Password)
 - `mise run onboard-agent <name>` - Interactive onboarding for a new agent
+- `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
+- `mise run inspect-context <message>` - Inspect the context being sent to Claude
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on PR reviews and other workflows.
 


### PR DESCRIPTION
## Summary
- Added missing development tasks (`check`, `test`, `format`, `lint`) to the README
- Reorganized the flat task list into logical groups for easier navigation:
  - Development
  - Git helpers
  - Workflow management
  - Project tracking
  - Agent provisioning

## Test plan
- [x] Verified all listed tasks exist via `mise tasks`
- [x] Confirmed `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)