### PR TITLE
Fix wait-for-checks false positive when CI fails

### DIFF
--- a/.mise/tasks/wait-for-checks
+++ b/.mise/tasks/wait-for-checks
@@ -11,11 +11,14 @@ if [ -z "$PR_NUMBER" ]; then
 fi
 
 echo "Waiting for checks on PR #$PR_NUMBER (timeout 3 min)..."
-timeout 180 gh pr checks "$PR_NUMBER" --watch || {
-  if [ $? -eq 124 ]; then
+if timeout 180 gh pr checks "$PR_NUMBER" --watch; then
+  echo "All checks passed!"
+else
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 124 ]; then
     echo "Timed out waiting for checks"
-    exit 1
+  else
+    echo "Checks failed (exit code: $EXIT_CODE)"
   fi
-}
-
-echo "All checks passed!"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Fix bug where `wait-for-checks` reported "All checks passed!" even when checks failed
- The issue: `$?` inside `|| { }` block doesn't contain the original exit code
- Restructured to use if/else which properly captures the exit code

Closes #271

## Test plan

- [ ] Run `mise run wait-for-checks` on a PR with failing checks - should report failure
- [ ] Run on PR with passing checks - should report success
- [ ] Run on PR that times out - should report timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)