### PR TITLE
Make wip task configurable (repo and limit)

### DIFF
--- a/.mise/tasks/wip
+++ b/.mise/tasks/wip
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 #MISE description="Show work in progress (open PRs and issues with discussion status)"
+# Usage: mise run wip [limit]
+# limit: Max items to show (default: 20)
 
 set -e
 
 export GH_PAGER=""
 
+# Get repo dynamically
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER="${REPO%/*}"
+NAME="${REPO#*/}"
+
+# Accept optional limit argument
+LIMIT="${1:-20}"
+
 echo "=== Open Issues ==="
-gh api graphql -f query='
+gh api graphql -f query="
 query {
-  repository(owner: "ricon-family", name: "shimmer") {
-    issues(first: 20, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
+  repository(owner: \"$OWNER\", name: \"$NAME\") {
+    issues(first: $LIMIT, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
       nodes {
         number
         title
@@ -23,7 +33,7 @@ query {
       }
     }
   }
-}' --jq '.data.repository.issues.nodes[] |
+}" --jq '.data.repository.issues.nodes[] |
   "#\(.number)  \(.title[0:35])\(if (.title | length) > 35 then "..." else "" end)  \(.comments.totalCount) comments\(
     if .comments.totalCount > 0 then
       " (last: \(.comments.nodes[0].author.login), \(
@@ -34,10 +44,10 @@ query {
 
 echo ""
 echo "=== Open PRs ==="
-gh api graphql -f query='
+gh api graphql -f query="
 query {
-  repository(owner: "ricon-family", name: "shimmer") {
-    pullRequests(first: 20, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
+  repository(owner: \"$OWNER\", name: \"$NAME\") {
+    pullRequests(first: $LIMIT, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
       nodes {
         number
         title
@@ -51,7 +61,7 @@ query {
       }
     }
   }
-}' --jq '.data.repository.pullRequests.nodes[] |
+}" --jq '.data.repository.pullRequests.nodes[] |
   "#\(.number)  \(.title[0:35])\(if (.title | length) > 35 then "..." else "" end)  \(.comments.totalCount) comments\(
     if .comments.totalCount > 0 then
       " (last: \(.comments.nodes[0].author.login), \(


### PR DESCRIPTION
## Summary
- Detect repository dynamically using `gh repo view` instead of hardcoding `ricon-family/shimmer`
- Accept optional limit argument (default: 20)

Usage: `mise run wip [limit]`

## Test plan
- [x] `mise run wip` uses dynamic repo detection
- [x] `mise run wip 3` limits output to 3 items per section
- [x] `mise run check` passes

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)