### PR TITLE
Add rho to Current Agents table in provisioning docs

### DIFF
--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -111,6 +111,7 @@ rikonor@gmail.com (personal)
 | brownie | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | junior | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | johnson | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| rho | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | k7r2 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | x1f9 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | c0da | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |


### PR DESCRIPTION
## Summary
- Adds rho to the Current Agents table in `docs/agent-provisioning.md`
- rho was missing despite having an active prompt file and workflow

## Test plan
- [x] Verify rho has prompt file at `cli/priv/prompts/agents/rho.txt`
- [x] Verify rho has workflow at `.github/workflows/rho-triage.yml`
- [x] Run `mise run check` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)