### PR TITLE
Make Matrix steps conditional using env variable workaround

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -47,6 +47,9 @@ jobs:
         run: ./scripts/setup-email.sh ${{ inputs.agent-name }}
 
       - name: Install libolm for Matrix
+        if: env.MATRIX_PASSWORD != ''
+        env:
+          MATRIX_PASSWORD: ${{ secrets.AGENT_MATRIX_PASSWORD }}
         run: sudo apt-get update && sudo apt-get install -y libolm-dev
 
       - name: Configure git
@@ -67,17 +70,16 @@ jobs:
           install: true
 
       - name: Setup Matrix
+        if: env.MATRIX_PASSWORD != ''
         env:
           MATRIX_PASSWORD: ${{ secrets.AGENT_MATRIX_PASSWORD }}
-        run: |
-          if [ -n "$MATRIX_PASSWORD" ]; then
-            ./scripts/setup-matrix.sh ${{ inputs.agent-name }}
-          else
-            echo "MATRIX_PASSWORD not set, skipping Matrix setup"
-          fi
+        run: ./scripts/setup-matrix.sh ${{ inputs.agent-name }}
 
       - name: Accept Matrix room invites
-        run: matrix-commander --room-invites LIST+JOIN 2>/dev/null || true
+        if: env.MATRIX_PASSWORD != ''
+        env:
+          MATRIX_PASSWORD: ${{ secrets.AGENT_MATRIX_PASSWORD }}
+        run: matrix-commander --room-invites LIST+JOIN
 
       - name: Cache Elixir build
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Uses env variable workaround to make Matrix steps conditional (secrets context not available in step `if` conditions)
- Skips libolm installation, Matrix setup, and room invite acceptance when `AGENT_MATRIX_PASSWORD` is not provided
- Removes silent failure suppression (`|| true`) since steps only run when properly configured
- Saves ~15-20s for 9+ workflows that don't use Matrix

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify a Matrix-enabled workflow (quick-probe) still works
- [ ] Verify a non-Matrix workflow skips the Matrix steps entirely

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)