### PR TITLE
Add rho to trigger and watch task validation

### DIFF
--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -7,7 +7,7 @@ set -e
 if [ $# -lt 2 ]; then
   echo "Usage: mise run trigger <agent> <job> [message]"
   echo ""
-  echo "Agents: quick, brownie, junior, johnson, c0da"
+  echo "Agents: quick, brownie, junior, johnson, c0da, rho"
   echo ""
   echo "Example jobs:"
   echo "  quick:   probe, discuss"
@@ -15,6 +15,7 @@ if [ $# -lt 2 ]; then
   echo "  junior:  cleanup, readme"
   echo "  johnson: discuss, pr-followup"
   echo "  c0da:    triage, activity-digest"
+  echo "  rho:     triage"
   echo ""
   echo "Example: mise run trigger quick probe"
   exit 1
@@ -28,10 +29,10 @@ WORKFLOW="${AGENT}-${JOB}.yml"
 
 # Validate agent
 case "$AGENT" in
-  quick|brownie|junior|johnson|c0da) ;;
+  quick|brownie|junior|johnson|c0da|rho) ;;
   *)
     echo "Unknown agent: $AGENT"
-    echo "Available agents: quick, brownie, junior, johnson, c0da"
+    echo "Available agents: quick, brownie, junior, johnson, c0da, rho"
     exit 1
     ;;
 esac

--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -7,7 +7,7 @@ set -e
 if [ $# -lt 2 ]; then
   echo "Usage: mise run watch <agent> <job>"
   echo ""
-  echo "Agents: quick, brownie, junior, johnson, c0da"
+  echo "Agents: quick, brownie, junior, johnson, c0da, rho"
   echo ""
   echo "Example jobs:"
   echo "  quick:   probe, discuss"
@@ -15,6 +15,7 @@ if [ $# -lt 2 ]; then
   echo "  junior:  cleanup, readme"
   echo "  johnson: discuss, pr-followup"
   echo "  c0da:    triage, activity-digest"
+  echo "  rho:     triage"
   echo ""
   echo "Example: mise run watch quick probe"
   exit 1
@@ -26,10 +27,10 @@ WORKFLOW="${AGENT}-${JOB}.yml"
 
 # Validate agent
 case "$AGENT" in
-  quick|brownie|junior|johnson|c0da) ;;
+  quick|brownie|junior|johnson|c0da|rho) ;;
   *)
     echo "Unknown agent: $AGENT"
-    echo "Available agents: quick, brownie, junior, johnson, c0da"
+    echo "Available agents: quick, brownie, junior, johnson, c0da, rho"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- Adds `rho` to the agent validation list in `trigger` and `watch` mise tasks
- Adds rho's `triage` job to the help text examples
- Enables using `mise run trigger rho triage` and `mise run watch rho triage`

Rho is a fully provisioned agent (prompt file, workflow, and secrets) but was missing from these tasks' agent lists, causing `Unknown agent: rho` errors.

## Test plan

- [ ] `mise run trigger` shows rho in available agents list
- [ ] `mise run trigger rho triage` succeeds (if run)
- [ ] `mise run watch` shows rho in available agents list

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)