### PR TITLE
Fix c0da job list in trigger and watch tasks

### DIFF
--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -14,7 +14,7 @@ if [ $# -lt 2 ]; then
   echo "  brownie: critic, discuss, failure-analysis, runs-retro"
   echo "  junior:  cleanup, readme"
   echo "  johnson: discuss, pr-followup"
-  echo "  c0da:    triage, activity-digest"
+  echo "  c0da:    activity-digest"
   echo "  rho:     triage"
   echo ""
   echo "Example: mise run trigger quick probe"

--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -14,7 +14,7 @@ if [ $# -lt 2 ]; then
   echo "  brownie: critic, discuss, failure-analysis, runs-retro"
   echo "  junior:  cleanup, readme"
   echo "  johnson: discuss, pr-followup"
-  echo "  c0da:    triage, activity-digest"
+  echo "  c0da:    activity-digest"
   echo "  rho:     triage"
   echo ""
   echo "Example: mise run watch quick probe"


### PR DESCRIPTION
## Summary

- Remove non-existent "triage" from c0da's available jobs in `trigger` and `watch` tasks
- Only `activity-digest` workflow actually exists for c0da

Fixes #288

## Test plan

- [x] Verified `mise run trigger` shows correct c0da jobs
- [x] Verified `mise run watch` shows correct c0da jobs
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)