### PR TITLE
Add workflow to run scan-secrets weekly

### DIFF
--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -1,0 +1,22 @@
+name: Scan Secrets
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'  # Weekly on Sunday at 6am UTC
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history needed for scanning
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+
+      - name: Run secret scan
+        run: mise run scan-secrets


### PR DESCRIPTION
## Summary

- Add scheduled workflow that runs `mise run scan-secrets` weekly on Sundays at 6am UTC
- Supports manual trigger via `workflow_dispatch`
- Uses full git history (`fetch-depth: 0`) for comprehensive scanning

Fixes #286

## Test plan

- [x] Workflow YAML is valid
- [x] `mise run check` passes
- [ ] Manual workflow trigger after merge to verify functionality

🤖 Generated with [Claude Code](https://claude.ai/claude-code)