### PR TITLE
Fix prompts_dir for Burrito and add multi-platform build config

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -18,6 +18,17 @@ defmodule Cli do
   @timeout_exit_code 124
 
   defp prompts_dir do
+    case :code.priv_dir(:cli) do
+      {:error, :bad_name} ->
+        # Escript/development: fall back to cwd-based discovery
+        find_prompts_in_cwd()
+
+      path when is_list(path) ->
+        Path.join(List.to_string(path), "prompts")
+    end
+  end
+
+  defp find_prompts_in_cwd do
     # Try multiple paths - cwd might be repo root or cli directory
     cwd = File.cwd!()
 

--- a/cli/mix.exs
+++ b/cli/mix.exs
@@ -8,7 +8,8 @@ defmodule Cli.MixProject do
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      escript: [main_module: Cli, name: :shimmer]
+      escript: [main_module: Cli, name: :shimmer],
+      releases: releases()
     ]
   end
 
@@ -23,7 +24,26 @@ defmodule Cli.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
+      {:burrito, "~> 1.5", only: :prod},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
+    ]
+  end
+
+  # Burrito release configuration for multi-platform builds
+  defp releases do
+    [
+      shimmer: [
+        steps: [:assemble, &Burrito.wrap/1],
+        burrito: [
+          targets: [
+            linux_x86_64: [os: :linux, cpu: :x86_64],
+            linux_arm64: [os: :linux, cpu: :aarch64],
+            darwin_x86_64: [os: :darwin, cpu: :x86_64],
+            darwin_arm64: [os: :darwin, cpu: :aarch64],
+            windows_x86_64: [os: :windows, cpu: :x86_64]
+          ]
+        ]
+      ]
     ]
   end
 end


### PR DESCRIPTION
## Summary

- Refactors `prompts_dir/0` to use `:code.priv_dir/1` first, falling back to cwd-based discovery for escript/development mode - this unblocks Burrito distribution
- Adds Burrito dependency (~> 1.5) for binary distribution
- Configures releases for all major platforms: Linux (x86_64, arm64), macOS (x86_64, arm64), and Windows (x86_64)

This addresses the blocker identified in the issue discussion. The fix was proposed in the latest comments and maintains backwards compatibility for escript/dev usage while enabling Burrito's extraction-based prompt loading.

Closes #100

## Test plan

- [x] All existing tests pass (`mise run check`)
- [x] Escript build still works (`mix escript.build`)
- [ ] Manual: verify Burrito build works with `MIX_ENV=prod mix release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)