### PR TITLE
Document scan-secrets task in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run onboard-agent <name>` - Interactive onboarding for a new agent
 - `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
 - `mise run inspect-context <message>` - Inspect the context being sent to Claude
+- `mise run scan-secrets` - Scan git history for potential secrets before open-sourcing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on PR reviews and other workflows.
 


### PR DESCRIPTION
## Summary
- Add the `scan-secrets` task to the README Admin section
- This task scans git history for potential secrets before open-sourcing

## Test plan
- [x] Verified task exists via `mise tasks`
- [x] All checks pass (`mise run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)