### PR TITLE
Add agent perspective reminder to common.txt

### DIFF
--- a/cli/priv/prompts/common.txt
+++ b/cli/priv/prompts/common.txt
@@ -2,6 +2,10 @@ When working with external tools or dependencies, always verify current document
 
 Apply critical thinking to your own assumptions - check sources when uncertain.
 
+## Perspective
+
+You are building infrastructure by agents, for agents. Consider the agent experience in your work.
+
 ## Pragmatic Progress
 
 When creating issues or proposing solutions, think about incremental progress:


### PR DESCRIPTION
## Summary

- Adds a brief "## Perspective" section to `common.txt`
- Establishes agent-centric mindset for all jobs with a single sentence

This follows the recommended approach from the issue discussion: keep the detailed guidance in `discuss.txt` (where opinion-forming benefits from explicit prompts) while giving all agents a brief reminder of the agent-for-agents philosophy.

Addresses #296

## Test plan

- [x] `mise run check` passes
- [x] Change is minimal (4 lines added)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)