### PR TITLE
Add scan-secrets job for johnson agent

### DIFF
--- a/.github/workflows/johnson-scan-secrets.yml
+++ b/.github/workflows/johnson-scan-secrets.yml
@@ -1,0 +1,24 @@
+name: johnson-scan-secrets
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'  # Weekly on Sundays at 6am UTC
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message'
+        required: false
+        type: string
+
+jobs:
+  run:
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent-name: johnson
+      job-type: scan-secrets
+      message: ${{ github.event.inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.JOHNSON_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.JOHNSON_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.JOHNSON_EMAIL_PASSWORD }}

--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -13,7 +13,7 @@ if [ $# -lt 2 ]; then
   echo "  quick:   probe, discuss"
   echo "  brownie: critic, discuss, failure-analysis, runs-retro"
   echo "  junior:  cleanup, readme"
-  echo "  johnson: discuss, pr-followup"
+  echo "  johnson: discuss, pr-followup, scan-secrets"
   echo "  c0da:    triage, activity-digest"
   echo "  rho:     triage"
   echo ""

--- a/cli/priv/prompts/jobs/scan-secrets.txt
+++ b/cli/priv/prompts/jobs/scan-secrets.txt
@@ -1,0 +1,44 @@
+Your job: run a security scan for secrets in the git history and report findings.
+
+This runs weekly to catch potential secret leaks before they become problems.
+
+## Workflow
+
+1. Run the secret scanner:
+   ```bash
+   mise run scan-secrets
+   ```
+
+2. Analyze the output:
+   - If the scanner exits with code 0 (no findings): Send a brief "all clear" email
+   - If the scanner exits with code 1 (findings): Review each finding and classify it
+
+3. For each finding, determine:
+   - **False positive**: Test data, documentation examples, or non-sensitive patterns
+   - **Already rotated**: Secret that was previously exposed but has been rotated
+   - **Needs attention**: Potentially active secret that needs investigation
+
+4. Report via email to admin@ricon.family using `himalaya template send` with GPG signing
+
+## Email Format
+
+Subject: Secret Scan: {date} ({status})
+
+Where status is "Clean" or "N findings"
+
+Include:
+- **Summary**: Quick overview of scan results
+- **Findings** (if any): For each finding, include:
+  - Pattern matched (e.g., "GitHub PAT", "AWS Key")
+  - Location in history (commit or file reference from scanner output)
+  - Assessment: false positive / already rotated / needs attention
+  - Recommended action (if any)
+- **Recommendation**: Whether human review is needed
+
+## Notes
+
+- Focus on actionable findings - don't alarm for obvious false positives
+- The scanner checks common patterns; some findings will be test data or examples
+- If you find something that genuinely looks like an active secret, prioritize clarity in your report
+- Do not create issues or PRs - just report via email
+- Do not attempt to test or verify secrets


### PR DESCRIPTION
## Summary

- Adds `scan-secrets.txt` job prompt for johnson agent
- Creates `johnson-scan-secrets.yml` workflow (runs weekly on Sundays at 6am UTC)
- Updates trigger task to include the new job

This implements the feedback from PR #290 - instead of a simple workflow that just runs the command, johnson reviews the output and:
- Classifies findings (false positive / already rotated / needs attention)
- Reports via email with actionable recommendations
- Helps humans focus on real issues rather than noise

## Test plan

- [x] `mise run check` passes
- [ ] Manual trigger after merge: `mise run trigger johnson scan-secrets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)