### PR TITLE
Update CLI README to show mix shimmer usage

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,14 +13,14 @@ This CLI is a streaming JSON client for Claude Code. It:
 
 ## Usage
 
-The CLI is built as an escript and invoked via GitHub Actions workflows. It requires `--agent` and `--timeout`:
+Run via the Mix task. Requires `--agent` and `--timeout`:
 
 ```bash
 # Run with an agent and job (timeout in seconds)
-mix escript.build && ./shimmer --agent quick --job probe --timeout 540 "Explore the codebase"
+mix shimmer --agent quick --job probe --timeout 540 "Explore the codebase"
 
 # Enable context logging (starts claude-code-logger proxy)
-./shimmer --agent brownie --job critic --timeout 540 --log-context "Find something to critique"
+mix shimmer --agent brownie --job critic --timeout 540 --log-context "Find something to critique"
 ```
 
 ## Agent Prompt System


### PR DESCRIPTION
## Summary

- Replace escript build instructions with `mix shimmer` invocation
- Remove outdated reference to building escript first

The Mix task is the preferred approach for dev/CI since #293 was merged. It properly supports `:code.priv_dir/1` for prompt loading.

Closes #301

## Test plan

- [x] `mise run check` passes
- [x] Documentation change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)