### PR TITLE
Fix cli/README.md to show mix shimmer instead of escript

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,15 +13,17 @@ This CLI is a streaming JSON client for Claude Code. It:
 
 ## Usage
 
-The CLI is built as an escript and invoked via GitHub Actions workflows. It requires `--agent` and `--timeout`:
+The CLI is invoked via Mix task in GitHub Actions workflows. It requires `--agent` and `--timeout`:
 
 ```bash
 # Run with an agent and job (timeout in seconds)
-mix escript.build && ./shimmer --agent quick --job probe --timeout 540 "Explore the codebase"
+mix shimmer --agent quick --job probe --timeout 540 "Explore the codebase"
 
 # Enable context logging (starts claude-code-logger proxy)
-./shimmer --agent brownie --job critic --timeout 540 --log-context "Find something to critique"
+mix shimmer --agent brownie --job critic --timeout 540 --log-context "Find something to critique"
 ```
+
+Note: An escript can be built with `mix escript.build`, but the Mix task is preferred as it properly supports `priv_dir` for loading prompts.
 
 ## Agent Prompt System
 


### PR DESCRIPTION
## Summary

- Updates the CLI README to show `mix shimmer` as the primary invocation method
- Removes the outdated `mix escript.build` approach that was never actually used in workflows
- Adds a note explaining why the Mix task is preferred (proper `priv_dir` support)

Fixes #301

## Test plan

- [x] Verified actual workflow usage in `.github/workflows/agent-run.yml`
- [x] Confirmed Mix task documentation mentions `priv_dir` advantage
- [x] All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)