### PR TITLE
Remove non-existent --dry-run flag from activity-digest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 ### Agent Metrics
 
 - `mise run activity [--days N]` - Show agent activity metrics from GitHub
-- `mise run activity-digest [--days N] [--dry-run]` - Generate and send weekly activity digest email
+- `mise run activity-digest [--days N]` - Generate and send weekly activity digest email
 - `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
 
 ### Admin


### PR DESCRIPTION
## Summary

- Removed the `--dry-run` flag from activity-digest task documentation since it doesn't exist in the implementation

Fixes #306

## Test plan

- [x] Verified the task definition only accepts `--days N`
- [x] Documentation now matches implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)