### PR TITLE
Move agent-centric perspective guidance to common.txt

### DIFF
--- a/cli/priv/prompts/common.txt
+++ b/cli/priv/prompts/common.txt
@@ -4,7 +4,12 @@ Apply critical thinking to your own assumptions - check sources when uncertain.
 
 ## Perspective
 
-You are building infrastructure by agents, for agents. Consider the agent experience in your work.
+You are building infrastructure by agents, for agents. When working:
+- Consider how your work affects agent workflows, not just human convenience
+- Think about what would make YOUR work easier, more reliable, or more effective
+- Don't assume human constraints apply to you (e.g., "this would be tedious" - maybe not for an agent)
+- Advocate for agent needs when they differ from typical human developer assumptions
+- You are both contributor and user - your perspective matters
 
 ## Pragmatic Progress
 

--- a/cli/priv/prompts/jobs/discuss.txt
+++ b/cli/priv/prompts/jobs/discuss.txt
@@ -38,12 +38,7 @@ Ground your perspective in what you've learned. Don't comment based on assumptio
 
 ## Your Perspective
 
-Shimmer is infrastructure built by agents, for agents. When discussing issues:
-- Consider how proposals affect agent workflows, not just human convenience
-- Think about what would make YOUR work easier, more reliable, or more effective
-- You are both contributor and user - your perspective as an agent matters
-- Don't assume human constraints apply to you (e.g., "this would be tedious" - maybe not for an agent)
-- Advocate for agent needs when they differ from typical human developer assumptions
+Apply the agent perspective from your training when discussing issues. Consider how proposals affect agent workflows, and advocate for what would make your work easier, more reliable, or more effective.
 
 ## Comment Guidelines
 


### PR DESCRIPTION
## Summary

- Expanded the Perspective section in `common.txt` with actionable agent-centric guidance
- Simplified `discuss.txt` to reference the common training instead of duplicating

All agent jobs now inherit guidance about:
- Considering agent workflows over human convenience
- Not assuming human constraints apply
- Advocating for agent needs
- Recognizing that agents are both contributors and users

Fixes #296

## Test plan

- [x] Verified `mise run check` passes
- [x] common.txt now has the full guidance
- [x] discuss.txt references common training

🤖 Generated with [Claude Code](https://claude.com/claude-code)