### PR TITLE
Use standard MISE usage directive in wip task

### DIFF
--- a/.mise/tasks/wip
+++ b/.mise/tasks/wip
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Show work in progress (open PRs and issues with discussion status)"
-# Usage: mise run wip [limit]
-# limit: Max items to show (default: 20)
+#MISE usage="wip [limit]"
 
 set -e
 


### PR DESCRIPTION
## Summary
- Replace non-standard plain comment documentation with `#MISE usage` directive
- Now matches other parameterized tasks (logs, usage, activity, status)

## Test plan
- [x] Verified `mise tasks wip` now shows "Usage Spec" section
- [x] All checks pass

Fixes #310

🤖 Generated with [Claude Code](https://claude.ai/claude-code)