### PR TITLE
Fix help text to reference existing job example

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -123,7 +123,7 @@ defmodule Cli do
       --timeout <seconds>  Maximum runtime in seconds
 
     Options:
-      --job <name>         Job-specific prompt (e.g., probe, run-review)
+      --job <name>         Job-specific prompt (e.g., probe, critic)
       --model <model>      Claude model to use (default: claude-opus-4-5-20251101)
       --log-context        Enable context logging via proxy
       -h, --help           Show this help message


### PR DESCRIPTION
## Summary
- Changed `--job` example in `--help` output from `run-review` (non-existent) to `critic` (exists)
- The help text now shows two actual jobs: `probe` for exploration and `critic` for review

## Test plan
- [x] Verify both `probe` and `critic` jobs exist in `cli/priv/prompts/jobs/`
- [x] Run `mise run check` to ensure all tests pass

Fixes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)