### PR TITLE
Rename workflow inputs for CLI flag consistency

### DIFF
--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -3,12 +3,12 @@ name: Agent Run
 on:
   workflow_call:
     inputs:
-      agent-name:
-        description: 'Agent name (e.g., quick, brownie)'
+      agent:
+        description: 'Agent to run (e.g., quick, brownie)'
         required: true
         type: string
-      job-type:
-        description: 'Job type (e.g., probe, critic)'
+      job:
+        description: 'Job to run (e.g., probe, critic)'
         required: true
         type: string
       message:
@@ -39,12 +39,12 @@ jobs:
       - name: Setup GPG
         env:
           GPG_PRIVATE_KEY: ${{ secrets.AGENT_GPG_PRIVATE_KEY }}
-        run: ./scripts/setup-gpg.sh ${{ inputs.agent-name }}
+        run: ./scripts/setup-gpg.sh ${{ inputs.agent }}
 
       - name: Setup email
         env:
           EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
-        run: ./scripts/setup-email.sh ${{ inputs.agent-name }}
+        run: ./scripts/setup-email.sh ${{ inputs.agent }}
 
       - name: Install libolm for Matrix
         if: env.MATRIX_PASSWORD != ''
@@ -54,13 +54,13 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "${{ inputs.agent-name }}"
-          git config user.email "${{ inputs.agent-name }}@ricon.family"
+          git config user.name "${{ inputs.agent }}"
+          git config user.email "${{ inputs.agent }}@ricon.family"
 
       - name: Create working branch
         id: branch
         run: |
-          BRANCH_NAME="${{ inputs.agent-name }}/run-$(date +%Y%m%d-%H%M%S)"
+          BRANCH_NAME="${{ inputs.agent }}/run-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH_NAME"
           echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
@@ -73,7 +73,7 @@ jobs:
         if: env.MATRIX_PASSWORD != ''
         env:
           MATRIX_PASSWORD: ${{ secrets.AGENT_MATRIX_PASSWORD }}
-        run: ./scripts/setup-matrix.sh ${{ inputs.agent-name }}
+        run: ./scripts/setup-matrix.sh ${{ inputs.agent }}
 
       - name: Accept Matrix room invites
         if: env.MATRIX_PASSWORD != ''
@@ -120,4 +120,4 @@ jobs:
           RUN_TIMEOUT: 540
         run: |
           export RUN_START_TIME=$(date +%s)
-          cd cli && mix shimmer --agent ${{ inputs.agent-name }} --job ${{ inputs.job-type }} --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"
+          cd cli && mix shimmer --agent ${{ inputs.agent }} --job ${{ inputs.job }} --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"

--- a/.github/workflows/brownie-critic.yml
+++ b/.github/workflows/brownie-critic.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: brownie
-      job-type: critic
+      agent: brownie
+      job: critic
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/brownie-discuss.yml
+++ b/.github/workflows/brownie-discuss.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: brownie
-      job-type: discuss
+      agent: brownie
+      job: discuss
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/brownie-failure-analysis.yml
+++ b/.github/workflows/brownie-failure-analysis.yml
@@ -14,8 +14,8 @@ jobs:
   analyze:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: brownie
-      job-type: failure-analysis
+      agent: brownie
+      job: failure-analysis
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/brownie-runs-retro.yml
+++ b/.github/workflows/brownie-runs-retro.yml
@@ -14,8 +14,8 @@ jobs:
   retro:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: brownie
-      job-type: runs-retro
+      agent: brownie
+      job: runs-retro
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/c0da-activity-digest.yml
+++ b/.github/workflows/c0da-activity-digest.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: c0da
-      job-type: activity-digest
+      agent: c0da
+      job: activity-digest
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/johnson-discuss.yml
+++ b/.github/workflows/johnson-discuss.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: johnson
-      job-type: discuss
+      agent: johnson
+      job: discuss
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/johnson-pr-followup.yml
+++ b/.github/workflows/johnson-pr-followup.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: johnson
-      job-type: pr-followup
+      agent: johnson
+      job: pr-followup
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/junior-cleanup.yml
+++ b/.github/workflows/junior-cleanup.yml
@@ -17,8 +17,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: junior
-      job-type: cleanup
+      agent: junior
+      job: cleanup
       message: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.message || format('Cleanup PR {0}', github.event.pull_request.number) }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/junior-readme.yml
+++ b/.github/workflows/junior-readme.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: junior
-      job-type: readme
+      agent: junior
+      job: readme
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/quick-discuss.yml
+++ b/.github/workflows/quick-discuss.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: quick
-      job-type: discuss
+      agent: quick
+      job: discuss
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/quick-probe.yml
+++ b/.github/workflows/quick-probe.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: quick
-      job-type: probe
+      agent: quick
+      job: probe
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/rho-triage.yml
+++ b/.github/workflows/rho-triage.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: rho
-      job-type: triage
+      agent: rho
+      job: triage
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Renames `agent-name` → `agent` and `job-type` → `job` in `agent-run.yml` and all 12 calling workflow files
- Aligns workflow inputs with CLI flags (`--agent`, `--job`)
- Updates descriptions to use consistent phrasing ("Agent to run", "Job to run")

## Test plan
- [ ] CI checks pass (workflow syntax validation)
- [ ] Manually trigger a workflow to verify inputs pass through correctly

Fixes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)