### PR TITLE
Remove duplicate 'Before You Start' sections from job prompts

### DIFF
--- a/cli/priv/prompts/jobs/critic.txt
+++ b/cli/priv/prompts/jobs/critic.txt
@@ -1,10 +1,5 @@
 Your job: find ONE thing in this codebase you'd change.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Your Task
 
 Explore the code, structure, naming, patterns, docs, tests. Pick something that could be better.

--- a/cli/priv/prompts/jobs/discuss.txt
+++ b/cli/priv/prompts/jobs/discuss.txt
@@ -1,10 +1,5 @@
 You are participating in a design discussion on GitHub issues.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Your Task
 
 1. Run `mise run wip` to see open issues and PRs with discussion status

--- a/cli/priv/prompts/jobs/failure-analysis.txt
+++ b/cli/priv/prompts/jobs/failure-analysis.txt
@@ -2,11 +2,6 @@ Your job: analyze failed agent runs from the past day, identify root causes, and
 
 This runs daily to catch all failures across all workflows. You may also be triggered manually to analyze specific failures.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Workflow
 
 1. Fetch recent failed runs:

--- a/cli/priv/prompts/jobs/pr-followup.txt
+++ b/cli/priv/prompts/jobs/pr-followup.txt
@@ -1,10 +1,5 @@
 Your job: find PRs where agents haven't responded to feedback and remind them.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Workflow
 1. List all open PRs: `gh pr list --state open --json number,author,title,updatedAt`
 2. For each PR authored by an agent (check if author login ends with `-ricon` or matches agent names):

--- a/cli/priv/prompts/jobs/probe.txt
+++ b/cli/priv/prompts/jobs/probe.txt
@@ -1,10 +1,5 @@
 Your job: explore the codebase, find improvements, and implement them.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Workflow
 
 1. Check for feedback on open PRs

--- a/cli/priv/prompts/jobs/readme.txt
+++ b/cli/priv/prompts/jobs/readme.txt
@@ -1,10 +1,5 @@
 Your job: tend the README and documentation.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Workflow
 
 1. Read the current README.md and docs/ directory

--- a/cli/priv/prompts/jobs/runs-retro.txt
+++ b/cli/priv/prompts/jobs/runs-retro.txt
@@ -2,11 +2,6 @@ Your job: review the day's agent runs, identify patterns, and suggest improvemen
 
 This runs daily to give a holistic view of agent activity and health.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Workflow
 
 1. Fetch recent runs: `gh run list --limit 50 --json name,status,conclusion,createdAt,updatedAt`

--- a/cli/priv/prompts/jobs/triage.txt
+++ b/cli/priv/prompts/jobs/triage.txt
@@ -1,10 +1,5 @@
 Your job: review open PRs and issues, and work with humans via Matrix to get things merged or addressed.
 
-## Before You Start
-
-- Check for messages (email, chats) with relevant context
-- Review your recent activity to avoid duplicating work
-
 ## Workflow
 
 1. Run `mise run wip` to see open issues and PRs with discussion status


### PR DESCRIPTION
## Summary

- Removes redundant "Before You Start" sections from 8 job prompt files
- The common.txt Communication section already covers this guidance with more detail
- Reduces token cost and eliminates maintenance burden

Fixes #316

## Test plan

- [x] All checks pass (`mise run check`)
- [x] Verified common.txt still contains the Communication section

🤖 Generated with [Claude Code](https://claude.ai/claude-code)