### PR TITLE
Fix inconsistent warning message format in CLI

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -338,7 +338,7 @@ defmodule Cli do
 
           {output, status} ->
             IO.puts(
-              "[warn] Failed to kill logger (pid #{os_pid}): exit #{status} - #{String.trim(output)}"
+              "WARNING: Failed to kill logger (pid #{os_pid}): exit #{status} - #{String.trim(output)}"
             )
         end
 


### PR DESCRIPTION
## Summary
- Change `[warn]` to `WARNING:` for consistency with the rest of the codebase (5 other instances)

## Test plan
- [x] `mise run check` passes

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)