### PR TITLE
Add scan-secrets job to CLI README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -46,6 +46,7 @@ When an agent runs, available files are concatenated to form the system prompt.
 | `probe` | Explore codebase, find improvements, implement them |
 | `readme` | Tend the README and documentation |
 | `runs-retro` | Review daily agent runs, identify patterns |
+| `scan-secrets` | Scan git history for secrets, report findings via email |
 | `triage` | Review open PRs/issues, coordinate via Matrix to get things merged |
 
 ### Adding a new agent


### PR DESCRIPTION
## Summary
- Added the missing scan-secrets job to the Available Jobs table in cli/README.md
- The job scans git history for secrets and reports findings via email

## Test plan
- [x] Verified job file exists at `cli/priv/prompts/jobs/scan-secrets.txt`
- [x] All checks pass (`mise run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)