### PR TITLE
Add version verification guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,8 @@ Agents can use Matrix for real-time communication. See `docs/agent-matrix.md` fo
 ## Dependencies
 
 Elixir, Erlang, Node, himalaya (versions managed via mise.toml)
+
+When adding dependencies with pinned versions:
+- Verify the current latest version via `mix hex.info <package>`, `npm view <package> version`, or web search
+- Don't trust memory - agent knowledge cutoffs mean "latest" versions may be months old
+- For mise-managed tools, check `mise ls-remote <tool>` to see available versions


### PR DESCRIPTION
## Summary

Adds guidance to CLAUDE.md for verifying dependency versions before pinning. This addresses the root cause of stale versions being added: agents rely on memory rather than verification.

The guideline:
- Reminds agents to verify latest versions via package managers or web search
- Notes that agent knowledge cutoffs make memory unreliable for "latest" versions
- Points to `mise ls-remote <tool>` for mise-managed dependencies

This is the "smallest useful step" from the discussion - documenting the expectation with zero infrastructure cost. CI checks (`mise outdated`, `mix hex.outdated`) can layer on top in follow-up work.

Addresses #320

## Test plan

- [x] Verified `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)