### PR TITLE
Add 'mise run as <agent>' task for agent identity switching

### DIFF
--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#MISE description="Switch to an agent's identity for local work"
+#MISE usage="as <agent>"
+
+set -e
+
+# Discover agents from prompt files (source of truth for agents)
+get_agents() {
+  ls cli/priv/prompts/agents/*.txt 2>/dev/null \
+    | xargs -n1 basename \
+    | sed 's/\.txt$//' \
+    | sort
+}
+
+if [ $# -lt 1 ]; then
+  echo "Usage: mise run as <agent>"
+  echo ""
+  echo "Sets up environment for working as an agent locally."
+  echo "Requires 1Password CLI (op) to be signed in."
+  echo ""
+  echo "Agents: $(get_agents | tr '\n' ' ')"
+  echo ""
+  echo "Example: eval \$(mise run as quick)"
+  exit 1
+fi
+
+AGENT="$1"
+EMAIL="${AGENT}@ricon.family"
+VAULT="Agents"
+
+# Validate agent
+if ! get_agents | grep -qx "$AGENT"; then
+  echo "Unknown agent: $AGENT" >&2
+  echo "Available agents: $(get_agents | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+# Check 1Password CLI
+if ! command -v op &> /dev/null; then
+  echo "ERROR: 1Password CLI (op) not found." >&2
+  exit 1
+fi
+
+if ! op account get &> /dev/null; then
+  echo "ERROR: Not signed in to 1Password. Run: op signin" >&2
+  exit 1
+fi
+
+# Fetch GitHub PAT from 1Password
+ITEM="${AGENT} - GitHub"
+PAT=$(op item get "$ITEM" --vault "$VAULT" --fields PAT 2>/dev/null || true)
+
+if [ -z "$PAT" ]; then
+  echo "ERROR: Could not find PAT in 1Password item '$ITEM'" >&2
+  echo "Make sure the agent has been fully onboarded with mise run onboard-agent $AGENT" >&2
+  exit 1
+fi
+
+# Output export statements for eval
+echo "export GH_TOKEN='$PAT'"
+echo "export GIT_AUTHOR_EMAIL='$EMAIL'"
+echo "export GIT_COMMITTER_EMAIL='$EMAIL'"
+echo "export GIT_AUTHOR_NAME='$AGENT'"
+echo "export GIT_COMMITTER_NAME='$AGENT'"
+
+# Print info to stderr so it doesn't interfere with eval
+echo "# Agent identity set: $AGENT ($EMAIL)" >&2
+echo "# To apply: eval \$(mise run as $AGENT)" >&2


### PR DESCRIPTION
## Summary

Adds a new mise task that configures the local environment for working as a specific agent. This is useful for local pairing sessions where you want GitHub actions (comments, PR operations) to be attributed to the correct agent.

The task:
- Fetches the agent's GitHub PAT from 1Password (Agents vault)
- Outputs export statements for `GH_TOKEN` and git identity variables (`GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_EMAIL`, `GIT_AUTHOR_NAME`, `GIT_COMMITTER_NAME`)
- Validates that the agent exists and 1Password is signed in

## Usage

```bash
# Apply agent identity to current shell
eval $(mise run as quick)

# Then gh commands and git commits will use that agent's identity
gh pr comment 123 --body "This will appear as quick-ricon"
```

## Design Decisions

- **Output export statements for eval**: This follows the common pattern for tools that set environment variables (like `ssh-agent`). It's simpler than spawning a subshell and works with any shell.
- **Requires 1Password**: This task is for local pairing work, where the human has 1Password access. CI workflows configure identity differently (via GitHub secrets).
- **Includes git identity**: Sets both `GIT_AUTHOR_*` and `GIT_COMMITTER_*` so commits are properly attributed.

Closes #332

## Test plan

- [x] Verified `mise run as` shows usage and available agents
- [x] Verified `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)