### PR TITLE
Update k7r2 status from Reserved to Provisioned

### DIFF
--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -112,12 +112,17 @@ rikonor@gmail.com (personal)
 | junior | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | johnson | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | rho | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| k7r2 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| k7r2 | Provisioned | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | x1f9 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | c0da | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
+### Provisioned Agents
+
+k7r2 has a cryptographic identity and agent prompt, but no workflows yet.
+To activate, create workflow(s) in `.github/workflows/<agent>-<job>.yml`.
+
 ### Reserved Agents
 
-k7r2 and x1f9 have cryptographic identities provisioned but no assigned roles.
-These slots are available for future specialized agents. To activate, add a prompt file
+x1f9 has a cryptographic identity provisioned but no assigned role.
+This slot is available for a future specialized agent. To activate, add a prompt file
 at `cli/priv/prompts/agents/<name>.txt` and create corresponding workflow(s).


### PR DESCRIPTION
## Summary

- Updates k7r2's status in the agent provisioning table from "Reserved" to "Provisioned"
- Adds a "Provisioned Agents" section to distinguish between agents that have prompts but no workflows (k7r2) and those that have neither (x1f9)

k7r2 now has an agent prompt file at `cli/priv/prompts/agents/k7r2.txt` describing its personality and role, but no active workflows yet. This makes its status different from x1f9 which remains fully reserved.

## Test plan

- [x] Verified k7r2.txt exists in agents directory
- [x] Confirmed no k7r2 workflows exist
- [x] Documentation accurately reflects current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)