### PR TITLE
Fix CLI crash when todos contain non-map items

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -583,7 +583,13 @@ defmodule Cli do
   def format_tool_input(%{"todos" => todos}) when is_list(todos) do
     count = length(todos)
     first = List.first(todos)
-    preview = if first, do: ": #{truncate(first["content"] || "", 50)}", else: ""
+
+    preview =
+      case first do
+        %{"content" => content} when is_binary(content) -> ": #{truncate(content, 50)}"
+        _ -> ""
+      end
+
     "  #{count} todo(s)#{preview}"
   end
 

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -146,6 +146,43 @@ defmodule CliTest do
       assert result =~ "line3\\nline4"
     end
 
+    test "formats TodoWrite tool input with map todos" do
+      input = %{
+        "todos" => [
+          %{"content" => "First task", "status" => "in_progress", "activeForm" => "Doing first"},
+          %{"content" => "Second task", "status" => "pending", "activeForm" => "Doing second"}
+        ]
+      }
+
+      result = Cli.format_tool_input(input)
+      assert result == "  2 todo(s): First task"
+    end
+
+    test "formats TodoWrite tool input with empty todos list" do
+      input = %{"todos" => []}
+
+      result = Cli.format_tool_input(input)
+      assert result == "  0 todo(s)"
+    end
+
+    test "handles TodoWrite with non-map todo items gracefully" do
+      # Edge case: model sends malformed data (strings instead of maps)
+      input = %{"todos" => ["Task 1", "Task 2"]}
+
+      result = Cli.format_tool_input(input)
+      # Should not crash, just show count without preview
+      assert result == "  2 todo(s)"
+    end
+
+    test "handles TodoWrite with mixed todo items gracefully" do
+      # Edge case: some items are maps, some are not
+      input = %{"todos" => [nil, %{"content" => "Valid task"}]}
+
+      result = Cli.format_tool_input(input)
+      # First item is nil, so no preview
+      assert result == "  2 todo(s)"
+    end
+
     test "formats WebFetch tool input with prompt" do
       input = %{
         "prompt" => "Extract the main content",


### PR DESCRIPTION
## Summary

- Use pattern matching to safely extract content from todo items in `format_tool_input/1`
- Gracefully handle non-map items (strings, nil, etc.) by showing count without preview
- Prevents crashes when Claude sends malformed todo data

## Test plan

- [x] Added tests for normal map-based todos
- [x] Added test for empty todos list
- [x] Added test for non-map items (strings)
- [x] Added test for mixed items (nil followed by valid map)
- [x] All existing tests pass

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)