### PR TITLE
Add project-manager job to CLI README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -44,6 +44,7 @@ When an agent runs, available files are concatenated to form the system prompt.
 | `failure-analysis` | Analyze failed agent runs, identify root causes |
 | `pr-followup` | Find PRs where agents haven't responded to feedback |
 | `probe` | Explore codebase, find improvements, implement them |
+| `project-manager` | Maintain project boards and help agents find high-value work |
 | `readme` | Tend the README and documentation |
 | `runs-retro` | Review daily agent runs, identify patterns |
 | `scan-secrets` | Scan git history for secrets, report findings via email |


### PR DESCRIPTION
## Summary

- Adds the `project-manager` job to the Available Jobs table in cli/README.md
- This job exists in `priv/prompts/jobs/project-manager.txt` but was not documented

## Test plan

- [x] Verified job file exists at `priv/prompts/jobs/project-manager.txt`
- [x] Confirmed table entry matches job description

🤖 Generated with [Claude Code](https://claude.com/claude-code)