### PR TITLE
Use microsecond precision + random suffix for log file paths

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -268,7 +268,9 @@ defmodule Cli do
   end
 
   defp run_with_logger(message, system_prompt, timeout, model) do
-    log_file = "/tmp/claude-context-#{:os.system_time(:second)}.log"
+    # Use microseconds + random suffix to avoid collision when multiple CLI processes start close together
+    random_suffix = :rand.uniform(0xFFFF) |> Integer.to_string(16) |> String.pad_leading(4, "0")
+    log_file = "/tmp/claude-context-#{:os.system_time(:microsecond)}-#{random_suffix}.log"
 
     # Start the logger in the background, using mise exec to ensure correct PATH
     logger_script =


### PR DESCRIPTION
## Summary

- Changed log file timestamp from second to microsecond precision
- Added 4-character hex random suffix for additional collision resistance
- Collision window reduced from ~1 second to effectively zero

Closes #341

## Test plan

- [x] Existing tests pass
- [x] Formatting and linting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)