### PR TITLE
Use Jason.decode for complete JSON escape handling in flush_partial_buffer

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -420,16 +420,12 @@ defmodule Cli do
     # Pattern: look for "text":" followed by content
     case Regex.run(~r/"text"\s*:\s*"((?:[^"\\]|\\.)*)$/, partial) do
       [_, text] ->
-        # Unescape basic JSON escapes (order matters - backslash first)
-        unescaped =
-          text
-          |> String.replace("\\\\", "\x00BACKSLASH\x00")
-          |> String.replace("\\n", "\n")
-          |> String.replace("\\t", "\t")
-          |> String.replace("\\\"", "\"")
-          |> String.replace("\x00BACKSLASH\x00", "\\")
-
-        IO.write(unescaped)
+        # Complete the JSON string and use Jason to handle all escape sequences
+        # This properly handles \r, \b, \f, \/, \uXXXX in addition to \n, \t, \\, \"
+        case Jason.decode("\"#{text}\"") do
+          {:ok, unescaped} -> IO.write(unescaped)
+          {:error, _} -> :ok
+        end
 
       nil ->
         :ok


### PR DESCRIPTION
## Summary

- Replace manual string replacement with `Jason.decode`
- Complete partial JSON string with closing quote to parse as valid JSON
- Properly handles all JSON escape sequences including `\r`, `\b`, `\f`, `\/`, and `\uXXXX`

Previously the manual unescape only handled `\\`, `\n`, `\t`, and `\"`. This caused escape sequences like `\r` (carriage return) or unicode escapes to appear literally in output during partial buffer flushes.

Closes #343

## Test plan

- [x] Existing tests pass
- [x] Formatting and linting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)