### PR TITLE
Use #USAGE arg syntax for task help output

### DIFF
--- a/.mise/tasks/activity
+++ b/.mise/tasks/activity
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Show agent activity metrics from GitHub"
-#MISE usage="activity [--days N]"
+#USAGE arg "[days]" help="Number of days to look back (default: 7)"
 
 set -e
 

--- a/.mise/tasks/logs
+++ b/.mise/tasks/logs
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="View logs from the latest workflow run"
-#MISE usage="logs [workflow] [lines]"
+#USAGE arg "[workflow]" help="Workflow file name (default: pr-check.yml)"
+#USAGE arg "[lines]" help="Number of log lines to show (default: 100)"
 
 set -e
 

--- a/.mise/tasks/trigger
+++ b/.mise/tasks/trigger
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Trigger an agent workflow manually"
-#MISE usage="trigger <agent> <job> [message]"
+#USAGE arg "<agent>" help="Agent to run (e.g., quick, brownie, johnson)"
+#USAGE arg "<job>" help="Job to execute (e.g., probe, critic)"
+#USAGE arg "[message]" help="Optional message for the agent"
 
 set -e
 


### PR DESCRIPTION
## Summary

Convert tasks with positional arguments from `#MISE usage=` to `#USAGE arg` directives so mise can generate proper `--help` output with argument descriptions.

**Before:**
```bash
$ mise run trigger --help
Usage: trigger
```

**After:**
```bash
$ mise run trigger --help
Usage: trigger <ARGS>…

Arguments:
  <agent>    Agent to run (e.g., quick, brownie, johnson)
  <job>      Job to execute (e.g., probe, critic)
  [message]  Optional message for the agent
```

## Updated tasks

- `trigger`: `<agent> <job> [message]`
- `logs`: `[workflow] [lines]`
- `activity`: `[days]`

Closes #321

## Test plan

- [x] Existing tests pass
- [x] Verified `mise run trigger --help` shows argument descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)