### PR TITLE
Fix buffer flush discarding continuation data

### DIFF
--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -613,6 +613,29 @@ defmodule CliTest do
     end
   end
 
+  describe "text_beyond_flushed/2" do
+    test "returns remainder when flushed matches prefix" do
+      assert Cli.text_beyond_flushed("hello world", "hello") == " world"
+    end
+
+    test "returns empty string when fully flushed" do
+      assert Cli.text_beyond_flushed("hello", "hello") == ""
+    end
+
+    test "returns full text when flushed is empty" do
+      assert Cli.text_beyond_flushed("hello", "") == "hello"
+    end
+
+    test "returns full text when flushed does not match prefix" do
+      assert Cli.text_beyond_flushed("different", "hello") == "different"
+    end
+
+    test "handles empty text" do
+      assert Cli.text_beyond_flushed("", "") == ""
+      assert Cli.text_beyond_flushed("", "flushed") == ""
+    end
+  end
+
   describe "load_system_prompt/1" do
     test "returns nil for nil agent" do
       assert Cli.load_system_prompt(nil) == nil


### PR DESCRIPTION
## Summary
- Keep partial buffer intact after timeout flush to prevent data loss when JSON lines span multiple chunks
- Track flushed text using `flushed_text` field to avoid duplicate output when complete line arrives
- Extract `write_text_delta` helper to reduce `process_line` complexity

## Test plan
- [x] Add tests for `extract_partial_text/1` function
- [x] Add tests for `process_line/2` with `flushed_text` tracking
- [x] Verify existing tests pass with updated state structure
- [ ] Manual test: stream long responses and verify no truncation mid-word

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)