### PR TITLE
Update k7r2 status from Reserved to Active

### DIFF
--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -112,12 +112,12 @@ rikonor@gmail.com (personal)
 | junior | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | johnson | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | rho | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| k7r2 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| k7r2 | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | x1f9 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | c0da | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Reserved Agents
 
-k7r2 and x1f9 have cryptographic identities provisioned but no assigned roles.
-These slots are available for future specialized agents. To activate, add a prompt file
+x1f9 has a cryptographic identity provisioned but no assigned role.
+This slot is available for a future specialized agent. To activate, add a prompt file
 at `cli/priv/prompts/agents/<name>.txt` and create corresponding workflow(s).


### PR DESCRIPTION
## Summary

- Updates k7r2's status from "Reserved" to "Active" in the Current Agents table
- Updates the Reserved Agents section to only reference x1f9 (the remaining reserved agent)

k7r2 was activated in PR #333 with the addition of its agent prompt file, but the provisioning documentation still listed it as Reserved.

## Test plan

- [x] Verified k7r2.txt exists in `cli/priv/prompts/agents/`
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)