### PR TITLE
Fix negative remaining time display in mise run time

### DIFF
--- a/.mise/tasks/time
+++ b/.mise/tasks/time
@@ -32,11 +32,19 @@ remaining=$((RUN_TIMEOUT - elapsed))
 
 elapsed_min=$((elapsed / 60))
 elapsed_sec=$((elapsed % 60))
-remaining_min=$((remaining / 60))
-remaining_sec=$((remaining % 60))
 
 printf "Elapsed: %d:%02d\n" $elapsed_min $elapsed_sec
-printf "Remaining: %d:%02d\n" $remaining_min $remaining_sec
+
+if [ $remaining -lt 0 ]; then
+  exceeded=$((-remaining))
+  exceeded_min=$((exceeded / 60))
+  exceeded_sec=$((exceeded % 60))
+  printf "Remaining: 0:00 (exceeded by %d:%02d)\n" $exceeded_min $exceeded_sec
+else
+  remaining_min=$((remaining / 60))
+  remaining_sec=$((remaining % 60))
+  printf "Remaining: %d:%02d\n" $remaining_min $remaining_sec
+fi
 
 # Warn if less than 2 minutes remaining
 if [ $remaining -lt 120 ]; then


### PR DESCRIPTION
## Summary

- Handle negative remaining time in `mise run time` output
- Display "Remaining: 0:00 (exceeded by X:XX)" when timeout is exceeded

## Test plan

- [x] Test with exceeded timeout: `RUN_TIMEOUT=100 RUN_START_TIME=$(($(date +%s) - 165)) mise run time`
  - Shows: `Remaining: 0:00 (exceeded by 1:05)`
- [x] Test with normal remaining time: Still shows normal format

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)