### PR TITLE
Fix shell injection via --model parameter

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -233,16 +233,18 @@ defmodule Cli do
       end
 
     # Shell script that pipes empty stdin and runs claude with timeout
+    # All user-controlled values ($1=message, $2=system_prompt, $3=model) are passed as
+    # positional parameters to avoid shell injection vulnerabilities
     shell_script =
       "echo | timeout #{timeout} claude -p \"$1\"#{system_prompt_args} " <>
-        "--model #{model} --output-format stream-json " <>
+        "--model \"$3\" --output-format stream-json " <>
         "--verbose --include-partial-messages --dangerously-skip-permissions"
 
-    # Build args list: -c script, --, message, [system_prompt]
+    # Build args list: -c script, --, message, system_prompt (or empty), model
     args =
       case system_prompt do
-        nil -> ["-c", shell_script, "--", message]
-        prompt -> ["-c", shell_script, "--", message, prompt]
+        nil -> ["-c", shell_script, "--", message, "", model]
+        prompt -> ["-c", shell_script, "--", message, prompt, model]
       end
 
     # Convert env extras like "KEY=value" to {~c"KEY", ~c"value"} tuples


### PR DESCRIPTION
## Summary

- Pass `model` as positional parameter `$3` instead of interpolating directly into shell script
- Prevents command injection attacks where a malicious `--model` value could execute arbitrary commands
- Now all user-controlled values (message, system_prompt, model) are safely passed as shell positional parameters

## Test plan

- [x] All existing tests pass (`mise run check`)
- [x] Model is quoted in shell script: `--model "$3"`
- [x] Args array properly includes model as third positional parameter

Fixes #328
Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)