### PR TITLE
Use #USAGE arg syntax for proper mise task --help output

### DIFF
--- a/.mise/tasks/commit
+++ b/.mise/tasks/commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Stage all changes and commit with a message"
-#MISE usage="commit <message>"
+#USAGE arg "<message>" help="Commit message"
 
 set -e
 

--- a/.mise/tasks/ship
+++ b/.mise/tasks/ship
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Commit and push in one step"
-#MISE usage="ship <message>"
+#USAGE arg "<message>" help="Commit message"
 
 set -e
 

--- a/.mise/tasks/watch
+++ b/.mise/tasks/watch
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Watch the latest workflow run until completion"
-#MISE usage="watch <agent> <job>"
+#USAGE arg "<agent>" help="Agent name"
+#USAGE arg "<job>" help="Job name"
 
 set -e
 


### PR DESCRIPTION
## Summary

- Convert commit, ship, and watch tasks from `#MISE usage="..."` to `#USAGE arg` directives
- Enables mise to generate proper help output with argument descriptions

## Before

```
$ mise run commit -- --help
# --help was passed as the commit message, actually creating a commit!
```

## After

```
$ mise run commit -- --help
Usage: commit <message>

Arguments:
  <message>  Commit message
```

## Scope

This PR updates 3 tasks: commit, ship, watch. PR #346 handles trigger, logs, activity.

Together they cover the main tasks with positional arguments. The remaining tasks (activity-digest, format, inspect-context, etc.) can be updated in follow-up PRs if needed.

## Test plan

- [x] Verified `mise tasks info commit` shows arg in Usage Spec
- [x] Verified `mise run commit -- --help` shows proper usage with descriptions
- [x] Same verification for ship and watch tasks
- [x] All project checks pass

Fixes #321 (together with #346)

🤖 Generated with [Claude Code](https://claude.com/claude-code)