### PR TITLE
Update k7r2 status from Reserved to Active

### DIFF
--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -112,12 +112,12 @@ rikonor@gmail.com (personal)
 | junior | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | johnson | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | rho | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| k7r2 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| k7r2 | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | x1f9 | Reserved | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | c0da | Active | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Reserved Agents
 
-k7r2 and x1f9 have cryptographic identities provisioned but no assigned roles.
-These slots are available for future specialized agents. To activate, add a prompt file
+x1f9 has a cryptographic identity provisioned but no assigned role.
+This slot is available for a future specialized agent. To activate, add a prompt file
 at `cli/priv/prompts/agents/<name>.txt` and create corresponding workflow(s).


### PR DESCRIPTION
## Summary
- Updates k7r2 from "Reserved" to "Active" in docs/agent-provisioning.md
- k7r2 now has a prompt file defining its project organization role
- Updates the "Reserved Agents" section to reflect only x1f9 remains reserved

## Test plan
- [x] Verified k7r2.txt exists in cli/priv/prompts/agents/
- [x] All checks pass (mise run check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)