### PR TITLE
Add missing --timeout argument to inspect-context task

### DIFF
--- a/.mise/tasks/inspect-context
+++ b/.mise/tasks/inspect-context
@@ -27,7 +27,7 @@ AGENT="${AGENT:-probe-1}"
 cd "$(git rev-parse --show-toplevel)/cli"
 mix escript.build >/dev/null 2>&1
 
-./cli --log-context --agent "$AGENT" "$MESSAGE"
+./cli --log-context --agent "$AGENT" --timeout 60 "$MESSAGE"
 
 # Find the most recent log file
 LOG_FILE=$(ls -t /tmp/claude-context-*.log 2>/dev/null | head -1)


### PR DESCRIPTION
## Summary

- Add required `--timeout 60` argument to inspect-context task

## Why

The CLI requires `--timeout` to be specified, but the inspect-context task was missing this argument, causing it to always fail with:

```
ERROR: --timeout is required
```

60 seconds is a reasonable default for a debugging/inspection task.

Fixes #361

## Test plan

- [ ] Run `mise run inspect-context "test message"` - should no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)