### PR TITLE
Match wip task description to actual mise task

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 ### Task Management
 
 - `mise run tasks` - List open tasks (GitHub issues)
-- `mise run wip` - Show work in progress (open PRs and issues)
+- `mise run wip` - Show work in progress (open PRs and issues with discussion status)
 
 ### Agent Metrics
 


### PR DESCRIPTION
## Summary

- Updates the README description of `mise run wip` to match the actual task description
- Adds "with discussion status" to clarify that the command shows when discussions last had activity

The mise task description says "Show work in progress (open PRs and issues with discussion status)" but the README omitted the last part.

## Test plan

- [x] Verified README matches mise task description
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)