### PR TITLE
Flush remaining buffer on port exit to prevent data loss

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -383,6 +383,11 @@ defmodule Cli do
         stream_output(port, new_state)
 
       {^port, {:exit_status, status}} ->
+        # Flush any remaining buffer content before exit (issue #367)
+        if buffer != "" do
+          flush_partial_buffer(buffer)
+        end
+
         print_usage_summary(state)
 
         # If agent signaled abort, override exit status


### PR DESCRIPTION
## Summary
- Flush any remaining buffered data before handling port exit status
- Prevents silent loss of final text output when port exits mid-stream

## Test plan
- [x] Verify existing tests pass
- [ ] Manual test: stream a response and verify final text isn't lost

Fixes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)