### PR TITLE
Standardize mise tasks on #USAGE arg/flag syntax

### DIFF
--- a/.mise/tasks/activity-digest
+++ b/.mise/tasks/activity-digest
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 #MISE description="Generate and send weekly activity digest email"
-#MISE usage="activity-digest [--days N]"
+#USAGE flag "--days <days>" help="Number of days to look back (default: 7)"
 
 set -e
 
-# Parse arguments
-DAYS=7
-
-for arg in "$@"; do
-  if [[ "$arg" =~ ^[0-9]+$ ]]; then
-    DAYS="$arg"
-  fi
-done
+# Use flag value or default
+DAYS="${usage_days:-7}"
 
 export GH_PAGER=""
 

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Switch to an agent's identity for local work"
-#MISE usage="as <agent>"
+#USAGE arg "<agent>" help="Agent to switch to (e.g., quick, brownie)"
 
 set -e
 
@@ -12,19 +12,7 @@ get_agents() {
     | sort
 }
 
-if [ $# -lt 1 ]; then
-  echo "Usage: mise run as <agent>"
-  echo ""
-  echo "Sets up environment for working as an agent locally."
-  echo "Requires 1Password CLI (op) to be signed in."
-  echo ""
-  echo "Agents: $(get_agents | tr '\n' ' ')"
-  echo ""
-  echo "Example: eval \$(mise run as quick)"
-  exit 1
-fi
-
-AGENT="$1"
+AGENT="$usage_agent"
 EMAIL="${AGENT}@ricon.family"
 VAULT="Agents"
 

--- a/.mise/tasks/format
+++ b/.mise/tasks/format
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #MISE description="Check or fix code formatting"
-#MISE usage="format [--fix]"
+#USAGE flag "--fix" help="Auto-fix formatting issues"
 
 set -e
 
 cd cli
 
-if [ "$1" = "--fix" ]; then
+if [ "$usage_fix" = "true" ]; then
   mix format
 else
   mix format --check-formatted

--- a/.mise/tasks/inspect-context
+++ b/.mise/tasks/inspect-context
@@ -1,28 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Inspect the context being sent to Claude"
-#MISE usage="inspect-context [--agent <name>] <message>"
+#USAGE flag "--agent <name>" help="Agent to use (default: probe-1)"
+#USAGE arg "[message]" help="Message to send (default: Say hello)"
 
 set -e
 
-# Parse arguments
-AGENT=""
-MESSAGE=""
-
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --agent)
-      AGENT="$2"
-      shift 2
-      ;;
-    *)
-      MESSAGE="$1"
-      shift
-      ;;
-  esac
-done
-
-MESSAGE="${MESSAGE:-Say hello}"
-AGENT="${AGENT:-probe-1}"
+# Use usage variables with defaults
+MESSAGE="${usage_message:-Say hello}"
+AGENT="${usage_agent:-probe-1}"
 
 cd "$(git rev-parse --show-toplevel)/cli"
 mix escript.build >/dev/null 2>&1

--- a/.mise/tasks/onboard-agent
+++ b/.mise/tasks/onboard-agent
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #MISE description="Interactive onboarding for a new agent"
-#MISE usage="onboard-agent <agent-name>"
+#USAGE arg "<agent-name>" help="Name of the agent to onboard"
 #MISE raw=true
 
 set -e
 
-AGENT="${1:?Usage: mise run onboard-agent <agent-name>}"
+AGENT="${usage_agent_name:?Usage: mise run onboard-agent <agent-name>}"
 AGENT_UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]')
 EMAIL="${AGENT}@ricon.family"
 GITHUB_USERNAME="${AGENT}-ricon"

--- a/.mise/tasks/provision-agent
+++ b/.mise/tasks/provision-agent
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #MISE description="Provision a new agent (GPG key, GitHub secrets, 1Password)"
-#MISE usage="provision-agent <agent-name> [--force]"
+#USAGE arg "<agent-name>" help="Name of the agent to provision"
+#USAGE flag "--force" help="Regenerate existing GPG key"
 
 set -e
 
-AGENT="${1:?Usage: mise run provision-agent <agent-name> [--force]}"
-FORCE="${2:-}"
+AGENT="${usage_agent_name:?Usage: mise run provision-agent <agent-name> [--force]}"
+FORCE="${usage_force:-}"
 EMAIL="${AGENT}@ricon.family"
 UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]')
 VAULT="Agents"
@@ -33,7 +34,7 @@ fi
 echo "--- GPG Key ---"
 if gpg --list-keys "$EMAIL" >/dev/null 2>&1; then
   echo "[auto] Key for $EMAIL already exists"
-  if [ "$FORCE" != "--force" ]; then
+  if [ "$FORCE" != "true" ]; then
     echo "       Use --force to regenerate"
   fi
 else

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Check the status of the latest workflow run"
-#MISE usage="status [workflow]"
+#USAGE arg "[workflow]" help="Workflow file name (default: pr-check.yml)"
 
 set -e
 
-WORKFLOW="${1:-pr-check.yml}"
+WORKFLOW="${usage_workflow:-pr-check.yml}"
 gh run list --workflow="$WORKFLOW" --limit 1

--- a/.mise/tasks/usage
+++ b/.mise/tasks/usage
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="Show workflow usage and estimated compute minutes"
-#MISE usage="usage [--days N]"
+#USAGE arg "[days]" help="Number of days to look back (default: 1)"
 
 set -e
 
-DAYS="${1:-1}"
+DAYS="${usage_days:-1}"
 
 export GH_PAGER=""
 

--- a/.mise/tasks/wip
+++ b/.mise/tasks/wip
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Show work in progress (open PRs and issues with discussion status)"
-#MISE usage="wip [limit]"
+#USAGE arg "[limit]" help="Maximum items to show (default: 20)"
 
 set -e
 
@@ -11,8 +11,8 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 OWNER="${REPO%/*}"
 NAME="${REPO#*/}"
 
-# Accept optional limit argument
-LIMIT="${1:-20}"
+# Use limit argument with default
+LIMIT="${usage_limit:-20}"
 
 echo "=== Open Issues ==="
 gh api graphql -f query="


### PR DESCRIPTION
## Summary
- Update 9 tasks from old `#MISE usage=` to new `#USAGE arg/flag` syntax
- Tasks now have per-argument descriptions in --help output
- Update task bodies to use `usage_` prefixed environment variables

## Test plan
- [x] Verify no tasks use old `#MISE usage=` syntax
- [x] Verify `mise run <task> --help` shows per-argument descriptions
- [x] Verify `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)