### PR TITLE
Remove non-functional Windows build target

### DIFF
--- a/cli/mix.exs
+++ b/cli/mix.exs
@@ -43,8 +43,7 @@ defmodule Cli.MixProject do
           targets: [
             linux_x86_64: [os: :linux, cpu: :x86_64],
             linux_arm64: [os: :linux, cpu: :aarch64],
-            darwin_arm64: [os: :darwin, cpu: :aarch64],
-            windows_x86_64: [os: :windows, cpu: :x86_64]
+            darwin_arm64: [os: :darwin, cpu: :aarch64]
           ]
         ]
       ]


### PR DESCRIPTION
## Summary

- Remove the `windows_x86_64` Burrito target from the CLI build configuration
- The CLI has Unix-specific dependencies that prevent Windows execution

## Technical details

The code relies on:
1. Hardcoded `/bin/sh` paths
2. Unix `timeout` command
3. Unix pipe syntax

These don't work on Windows, so the build target was misleading.

## Test plan

- [x] `mise run check` passes (tests, format, lint)

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)