### PR TITLE
Simplify flush_partial_buffer tests

### DIFF
--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -491,25 +491,13 @@ defmodule CliTest do
       assert output == "Hello wor"
     end
 
+    # Verifies regex captures escape sequences and Jason decodes them.
+    # Jason handles all standard JSON escapes: \n, \t, \r, \", \\, \b, \f, \/, \uXXXX
     test "handles JSON escapes in partial text" do
       partial = ~s({"type":"stream_event","event":{"delta":{"text":"line1\\nline2\\ttab)
 
       output = capture_io(fn -> Cli.flush_partial_buffer(partial) end)
       assert output == "line1\nline2\ttab"
-    end
-
-    test "handles escaped quotes in partial text" do
-      partial = ~s({"type":"stream_event","event":{"delta":{"text":"said \\"hello)
-
-      output = capture_io(fn -> Cli.flush_partial_buffer(partial) end)
-      assert output == "said \"hello"
-    end
-
-    test "handles escaped backslashes in partial text" do
-      partial = ~s({"type":"stream_event","event":{"delta":{"text":"path\\\\to)
-
-      output = capture_io(fn -> Cli.flush_partial_buffer(partial) end)
-      assert output == "path\\to"
     end
 
     test "outputs nothing for partial JSON without text field" do


### PR DESCRIPTION
## Summary
- Remove two redundant escape sequence tests that exercise the same code path as the `\n`/`\t` test
- After PR #345 delegated escape handling to Jason, testing multiple escape types was effectively testing the library
- Add documentation comment listing all JSON escape sequences Jason handles

Consolidates from 7 tests to 5 per the discussion in #371:
1. Text extraction from partial JSON (core purpose)
2. One escape sequence test with documentation comment
3. No text field (error path)
4. Non-JSON input (error path)
5. Empty string (edge case)

## Test plan
- [x] All existing tests pass (`mise run check`)
- [x] Test count reduced from 62 to 60 (removed 2 redundant tests)

Closes #371

🤖 Generated with [Claude Code](https://claude.ai/claude-code)