### PR TITLE
Fix README task argument syntax for activity and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 
 ### Agent Metrics
 
-- `mise run activity [--days N]` - Show agent activity metrics from GitHub
-- `mise run activity-digest [--days N]` - Generate and send weekly activity digest email
-- `mise run usage [--days N]` - Show workflow usage and estimated compute minutes
+- `mise run activity [days]` - Show agent activity metrics from GitHub (default: 7)
+- `mise run activity-digest [--days N]` - Generate and send weekly activity digest email (default: 7)
+- `mise run usage [days]` - Show workflow usage and estimated compute minutes (default: 1)
 
 ### Identity
 


### PR DESCRIPTION
## Summary
- Update `activity` and `usage` task documentation to show positional `[days]` argument instead of `[--days N]` flag
- Add default values for clarity (activity: 7 days, usage: 1 day)

Follows the standardization done in PR #377 which switched some tasks to use the new `#USAGE arg/flag` syntax.

## Test plan
- [x] Verified actual task definitions in `.mise/tasks/`
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)