### PR TITLE
Fix johnson-scan-secrets workflow parameter names

### DIFF
--- a/.github/workflows/johnson-scan-secrets.yml
+++ b/.github/workflows/johnson-scan-secrets.yml
@@ -14,8 +14,8 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent-name: johnson
-      job-type: scan-secrets
+      agent: johnson
+      job: scan-secrets
       message: ${{ github.event.inputs.message }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Rename `agent-name` → `agent` and `job-type` → `job` to match `agent-run.yml` inputs

## Context
Issue #314 renamed these parameters across all workflows, but `johnson-scan-secrets.yml` was created via PR #303 before the rename was complete and still used the old names. This caused the scheduled security scanning (Sundays 6am UTC) to silently fail.

## Test plan
- [x] Parameter names now match `agent-run.yml` inputs
- [ ] Next scheduled run or manual trigger should succeed

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)