### PR TITLE
Detect abort signal in incomplete buffer

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -514,8 +514,17 @@ defmodule Cli do
         process_line(buffer, state)
 
       {:error, _} ->
-        flush_partial_buffer(buffer)
-        state
+        extracted = extract_partial_text(buffer)
+        if extracted != "", do: IO.write(extracted)
+
+        {abort_seen, recent_text, had_newline} = check_abort_signal(extracted, state)
+
+        %{
+          state
+          | abort_seen: abort_seen,
+            recent_text: recent_text,
+            had_newline_before_window: had_newline
+        }
     end
   end
 


### PR DESCRIPTION
## Summary
- Check for `[[ABORT]]` in partial buffer text during finalization

## Context
When the stream ends with incomplete JSON containing `[[ABORT]]`, the text was correctly displayed to the user via `flush_partial_buffer`, but `abort_seen` was not updated. This caused the CLI to exit with the subprocess's exit code instead of 1.

This can happen if the subprocess is killed mid-output (e.g., by timeout) exactly when the abort message is being streamed.

## Changes
Updated `finalize_buffer/2` to:
1. Extract partial text from the buffer
2. Write it to stdout (preserving existing behavior)
3. Check for abort signal in the extracted text
4. Update `abort_seen` and `recent_text` in the returned state

The abort detection logic mirrors what already exists in `process_line/2` for complete JSON lines.

## Test plan
- [x] Existing tests pass
- [x] Code follows same pattern as abort detection in `process_line/2`
- [ ] Manual verification: kill subprocess mid-abort-output and verify exit code is 1

Fixes #385
Fixes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)