### PR TITLE
Use exec to prevent orphan logger process

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -322,9 +322,10 @@ defmodule Cli do
     random_suffix = :rand.uniform(0xFFFF) |> Integer.to_string(16) |> String.pad_leading(4, "0")
     log_file = "/tmp/claude-context-#{:os.system_time(:microsecond)}-#{random_suffix}.log"
 
-    # Start the logger in the background, using mise exec to ensure correct PATH
+    # Start the logger in the background, using mise exec to ensure correct PATH.
+    # Use exec to replace the shell process so stop_logger/1 kills the actual logger.
     logger_script =
-      "mise exec -- claude-code-logger start --verbose --log-body > #{log_file} 2>&1"
+      "exec mise exec -- claude-code-logger start --verbose --log-body > #{log_file} 2>&1"
 
     logger_port =
       Port.open(


### PR DESCRIPTION
## Summary
- Add `exec` to logger shell command to replace shell process with logger

## Context
When `--log-context` mode is used, the logger is started via `/bin/sh -c "mise exec -- claude-code-logger..."`. This creates a process tree where killing the shell PID (returned by Port.info) orphans the child processes.

By adding `exec`, the shell is replaced with the mise process, which then execs into claude-code-logger. This ensures `stop_logger/1` kills the actual logger process, preventing:
- Orphan processes that continue running after Shimmer exits
- Port 8000 conflicts on subsequent runs
- Resource leaks from accumulated orphan processes

## Test plan
- [x] Existing tests pass
- [ ] Manual: Run with `--log-context`, verify logger process is properly terminated on exit

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)