### PR TITLE
Respect flushed_text in finalize_buffer to prevent duplicates

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -498,7 +498,10 @@ defmodule Cli do
         process_line(buffer, state)
 
       {:error, _} ->
-        flush_partial_buffer(buffer)
+        # Only flush text beyond what was already shown during timeout (issue #392)
+        extracted = extract_partial_text(buffer)
+        new_text = text_beyond_flushed(extracted, state.flushed_text)
+        if new_text != "", do: IO.write(new_text)
         state
     end
   end


### PR DESCRIPTION
## Summary

- Fixes duplicate text output when partial buffer is flushed during timeout and then finalize_buffer is called at exit
- Uses `text_beyond_flushed` to only output text that hasn't already been shown

## Root Cause

`finalize_buffer` was calling `flush_partial_buffer(buffer)` directly without checking `state.flushed_text`. This meant if text had already been flushed during a timeout, it would be extracted and output again when the process exited.

## Test plan

- [x] `mise run check` passes
- Manual testing scenario: When partial JSON is flushed during timeout and exit happens before complete JSON arrives, text should only appear once

Fixes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)