### PR TITLE
Fix outdated default agent in inspect-context task

### DIFF
--- a/.mise/tasks/inspect-context
+++ b/.mise/tasks/inspect-context
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Inspect the context being sent to Claude"
-#USAGE flag "--agent <name>" help="Agent to use (default: probe-1)"
+#USAGE flag "--agent <name>" help="Agent to use (default: quick)"
 #USAGE arg "[message]" help="Message to send (default: Say hello)"
 
 set -e
 
 # Use usage variables with defaults
 MESSAGE="${usage_message:-Say hello}"
-AGENT="${usage_agent:-probe-1}"
+AGENT="${usage_agent:-quick}"
 
 cd "$(git rev-parse --show-toplevel)/cli"
 mix escript.build >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- Update the default agent from 'probe-1' (no longer exists) to 'quick' (active agent)
- Fixes the inspect-context mise task when run without --agent flag

## Test plan
- [ ] Run `mise run inspect-context` without --agent flag
- [ ] Verify it uses 'quick' agent instead of failing to find 'probe-1'

🤖 Generated with [Claude Code](https://claude.com/claude-code)