### PR TITLE
Fix [[ABORT]] detection when >20 chars precede it, or split across chunks

### DIFF
--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -369,6 +369,40 @@ defmodule CliTest do
       assert_received {:result2, %{abort_seen: true}}
     end
 
+    test "detects [[ABORT]] split across chunks when followed by long text" do
+      # Issue #402: [[ABORT]] is complete in combined text but gets pushed out of
+      # the 20-char window by subsequent text. Need to check before truncating.
+      # First chunk ends mid-signal
+      line1 = ~s({"type":"stream_event","event":{"delta":{"text":"prefix\\n[[ABO"}}})
+
+      state1 = %{
+        tool_input: "",
+        abort_seen: false,
+        recent_text: "",
+        flushed_text: "",
+        had_newline_before_window: true
+      }
+
+      capture_io(fn ->
+        result = Cli.process_line(line1, state1)
+        send(self(), {:result1, result})
+      end)
+
+      assert_received {:result1, %{abort_seen: false} = state2}
+
+      # Second chunk completes signal but has lots of text after
+      line2 =
+        ~s({"type":"stream_event","event":{"delta":{"text":"RT]]\\nlots of additional text that pushes it out of window"}}})
+
+      capture_io(fn ->
+        result = Cli.process_line(line2, state2)
+        send(self(), {:result2, result})
+      end)
+
+      # With the fix (#402), we check combined BEFORE truncating
+      assert_received {:result2, %{abort_seen: true}}
+    end
+
     test "detects [[ABORT]] after >20 chars of text ending with newline" do
       # Issue #400: When >20 chars of text are followed by [[ABORT]] on its own line,
       # the old 20-char window would lose the newline that precedes [[ABORT]].


### PR DESCRIPTION
## Summary
- Fix issue where [[ABORT]] signal was not detected when more than 20 characters of text preceded it
- Fix issue where [[ABORT]] signal was not detected when split across chunks and followed by long text
- Add `had_newline_before_window` state field to track whether there was a newline before the sliding window
- Extract abort detection into `check_abort_signal/2` helper function to reduce complexity
- Check for abort in combined text BEFORE truncating the window (#402)

## Test plan
- [x] Added test case for abort signal after >20 chars of text ending with newline
- [x] Added test case for abort signal split across chunks followed by long text  
- [x] Verified existing abort detection tests still pass
- [x] `mise run check` passes (tests, formatting, linting)

Closes #400
Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)