### PR TITLE
Add generic dispatch workflow for any agent+job combination

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,105 @@
+name: Generic Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: 'Agent to run'
+        required: true
+        type: choice
+        options:
+          - quick
+          - brownie
+          - johnson
+          - junior
+          - c0da
+          - rho
+      job:
+        description: 'Job to execute'
+        required: true
+        type: string
+      message:
+        description: 'Optional message to pass to the agent'
+        required: false
+        type: string
+
+jobs:
+  quick:
+    if: inputs.agent == 'quick'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: quick
+      job: ${{ inputs.job }}
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.QUICK_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.QUICK_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.QUICK_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.QUICK_MATRIX_PASSWORD }}
+
+  brownie:
+    if: inputs.agent == 'brownie'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: brownie
+      job: ${{ inputs.job }}
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.BROWNIE_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.BROWNIE_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.BROWNIE_EMAIL_PASSWORD }}
+
+  johnson:
+    if: inputs.agent == 'johnson'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: johnson
+      job: ${{ inputs.job }}
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.JOHNSON_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.JOHNSON_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.JOHNSON_EMAIL_PASSWORD }}
+
+  junior:
+    if: inputs.agent == 'junior'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: junior
+      job: ${{ inputs.job }}
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.JUNIOR_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.JUNIOR_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.JUNIOR_EMAIL_PASSWORD }}
+
+  c0da:
+    if: inputs.agent == 'c0da'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: c0da
+      job: ${{ inputs.job }}
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.DA_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.DA_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.DA_EMAIL_PASSWORD }}
+
+  rho:
+    if: inputs.agent == 'rho'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: rho
+      job: ${{ inputs.job }}
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.RHO_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.RHO_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.RHO_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.RHO_MATRIX_PASSWORD }}


### PR DESCRIPTION
## Summary

Adds a single `dispatch.yml` workflow that can run any agent with any job combination via `workflow_dispatch`.

Instead of needing a dedicated workflow file for each agent+job pair (like `quick-probe.yml`, `brownie-critic.yml`), this generic dispatch accepts agent and job as inputs and routes to the correct secrets using conditional jobs.

## How it works

- User selects an agent from dropdown (quick, brownie, johnson, junior, c0da, rho)
- User types the job name
- Only the selected agent's job runs, passing the correct secrets to `agent-run.yml`

## Trade-offs

**Pros:**
- Flexible: any agent can run any job without a dedicated workflow file
- Easier experimentation with agent+job pairings
- Good for one-off runs or testing new jobs

**Cons:**
- No schedule support (dedicated workflows still needed for scheduled runs)
- No validation that the job exists for the agent (fails at runtime if job prompt missing)
- Slightly more complex workflow structure

## Usage

Via GitHub UI: Actions → Generic Dispatch → Run workflow → Select agent → Enter job name

Via CLI:
```bash
gh workflow run dispatch.yml -f agent=quick -f job=probe -f message="test"
```

## Test plan

- [ ] Trigger via GitHub UI for each agent
- [ ] Verify correct secrets are passed (agent identity in commits)
- [ ] Test with nonexistent job to confirm graceful failure

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)