### PR TITLE
Handle nil values in truncate/2 to prevent FunctionClauseError

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -767,6 +767,8 @@ defmodule Cli do
 
   def format_tool_input(_), do: nil
 
+  defp truncate(nil, _limit), do: ""
+
   defp truncate(string, limit) do
     if String.length(string) > limit do
       String.slice(string, 0, limit) <> "..."


### PR DESCRIPTION
## Summary

- Adds a function clause to handle nil input in the truncate/2 function
- Prevents crashes when format_tool_input receives nil values for string fields

## Test plan

- [x] Existing tests pass
- [x] Verified fix works with example from issue: `%{"file_path" => "/test.ex", "old_string" => nil, "new_string" => "new"}`

Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)