### PR TITLE
Match README schedules description to mise task

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run watch <agent> <job>` - Watch a run until completion
 - `mise run trigger <agent> <job> [message]` - Trigger an agent workflow manually
 - `mise run time` - Show elapsed and remaining time for current run
-- `mise run schedules` - Show all agent job schedules and their status
+- `mise run schedules` - Show agent job schedules
 
 ### Task Management
 


### PR DESCRIPTION
## Summary

- Updates the README description of `mise run schedules` to match the actual mise task description
- Removes "all" and "and their status" from the description

The mise task description is "Show agent job schedules" but the README had "Show all agent job schedules and their status".

## Test plan

- [x] Verified README matches mise task description
- [x] `mise run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)