### PR TITLE
Improve error message for invalid --timeout value type

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -144,10 +144,16 @@ defmodule Cli do
         aliases: [h: :help]
       )
 
-    if invalid != [] do
-      invalid_names = Enum.map(invalid, fn {name, _} -> name end) |> Enum.join(", ")
-      IO.puts("WARNING: Unknown arguments ignored: #{invalid_names}")
-    end
+    Enum.each(invalid, fn
+      {name, nil} ->
+        IO.puts("WARNING: Unknown argument ignored: #{name}")
+
+      {"--timeout", value} ->
+        IO.puts("ERROR: --timeout requires an integer value, got: #{value}")
+
+      {name, value} ->
+        IO.puts("WARNING: Invalid argument: #{name}=#{value}")
+    end)
 
     {opts, rest}
   end

--- a/cli/test/cli_test.exs
+++ b/cli/test/cli_test.exs
@@ -18,19 +18,23 @@ defmodule CliTest do
   describe "invalid argument handling" do
     test "warns about unknown arguments" do
       {output, _exit_code} = run_cli(["--agnet", "quick", "--timeout", "60"])
-      assert output =~ "WARNING: Unknown arguments ignored: --agnet"
+      assert output =~ "WARNING: Unknown argument ignored: --agnet"
     end
 
     test "warns about multiple unknown arguments" do
       {output, _exit_code} = run_cli(["--agnet", "quick", "--tiemout", "60"])
-      assert output =~ "WARNING: Unknown arguments ignored:"
-      assert output =~ "--agnet"
-      assert output =~ "--tiemout"
+      assert output =~ "WARNING: Unknown argument ignored: --agnet"
+      assert output =~ "WARNING: Unknown argument ignored: --tiemout"
     end
 
     test "no warning for valid arguments" do
       {output, _exit_code} = run_cli(["--agent", "quick", "--timeout", "60"])
-      refute output =~ "WARNING: Unknown arguments ignored"
+      refute output =~ "WARNING: Unknown argument"
+    end
+
+    test "shows specific error for non-integer timeout value" do
+      {output, _exit_code} = run_cli(["--agent", "quick", "--timeout", "abc", "hello"])
+      assert output =~ "ERROR: --timeout requires an integer value, got: abc"
     end
 
     test "returns exit code 1 for missing agent" do


### PR DESCRIPTION
## Summary

- Fix misleading error message when `--timeout` receives a non-integer value
- Distinguish between unknown arguments and known arguments with invalid values
- Add specific error message: "ERROR: --timeout requires an integer value, got: <value>"

**Before:**
```
$ shimmer --agent test --timeout abc "hello"
WARNING: Unknown arguments ignored: --timeout
...
ERROR: --timeout is required
```

**After:**
```
$ shimmer --agent test --timeout abc "hello"
ERROR: --timeout requires an integer value, got: abc
...
ERROR: --timeout is required
```

## Test plan

- [x] Verify invalid timeout value shows specific error message
- [x] Verify unknown arguments still show warning
- [x] Verify valid arguments work without warnings
- [x] All existing tests pass

Fixes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)