### PR TITLE
Add timeout info to wait-for-checks README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise t
 - `mise run agent:trigger <agent> <job> [message]` - Trigger an agent workflow manually
 - `mise run ci:time-remaining` - Show elapsed and remaining time for current run
 - `mise run agent:schedules` - Show agent job schedules
-- `mise run ci:wait-for-checks` - Wait for PR checks to complete
+- `mise run ci:wait-for-checks` - Wait for PR checks to complete (timeout 3 min)
 
 ### Task Management
 


### PR DESCRIPTION
## Summary

- Adds "(timeout 3 min)" to the wait-for-checks task description in README to match the actual mise task description
- Continues the pattern of keeping README task descriptions in sync with mise task metadata

## Test plan

- [x] Verified the mise task description includes the timeout info
- [x] All checks pass (`mise run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)