### PR TITLE
Handle Port.close race condition in stop_logger

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -411,7 +411,13 @@ defmodule Cli do
             )
         end
 
-        Port.close(logger_port)
+        try do
+          Port.close(logger_port)
+        rescue
+          # Port may have already been closed if the process exited
+          # between our Port.info check and here (race condition)
+          ArgumentError -> :ok
+        end
 
       nil ->
         # Port already closed


### PR DESCRIPTION
## Summary

- Wraps `Port.close(logger_port)` in try/rescue to handle race condition where port may already be closed

When the logger process exits between the `Port.info` check and the `Port.close` call (either from our kill signal or naturally), the port is automatically closed by Erlang. Calling `Port.close` on an already-closed port raises `ArgumentError`.

This is a TOCTOU (time-of-check-time-of-use) race condition that can cause the CLI to crash when using `--log-context`.

## Test plan

- [ ] Tests pass (`mise run check`)
- [ ] Verify race condition handling by inspection

Fixes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)