### PR TITLE
Log warning when temp log file cleanup fails

### DIFF
--- a/cli/lib/cli.ex
+++ b/cli/lib/cli.ex
@@ -385,7 +385,14 @@ defmodule Cli do
           status
         after
           stop_logger(logger_port)
-          File.rm(log_file)
+
+          case File.rm(log_file) do
+            :ok ->
+              :ok
+
+            {:error, reason} ->
+              IO.puts("WARNING: Failed to clean up temp file #{log_file}: #{reason}")
+          end
         end
 
       :error ->


### PR DESCRIPTION
## Summary

- Add warning message when `File.rm` fails during temp log file cleanup
- Previously errors were silently ignored, now users see diagnostic output

Fixes #420

## Test plan

- [ ] Manual test: Verify normal cleanup works without spurious warnings
- [ ] Code review: Confirm pattern matches existing warning style (e.g., `parse_env_extra`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)