### PR TITLE
Add PROJECT_DIR support to CI tasks

### DIFF
--- a/.mise/tasks/ci/logs
+++ b/.mise/tasks/ci/logs
@@ -5,9 +5,15 @@
 
 set -e
 
+# Determine target directory and repo
+TARGET_DIR="${PROJECT_DIR:-.}"
+SCRIPT_DIR="$(dirname "$0")"
+REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
+
 WORKFLOW="${1:-pr-check.yml}"
 LINES="${2:-100}"
-RUN_ID=$(gh run list --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
-JOB_ID=$(gh run view "$RUN_ID" --json jobs -q '.jobs[0].databaseId')
+RUN_ID=$(gh run list --repo "$REPO" --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
+JOB_ID=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs -q '.jobs[0].databaseId')
 
-gh run view --job="$JOB_ID" --log 2>&1 | tail -"$LINES"
+echo "=== $REPO - $WORKFLOW (last $LINES lines) ==="
+gh run view --repo "$REPO" --job="$JOB_ID" --log 2>&1 | tail -"$LINES"

--- a/.mise/tasks/ci/wait-for-checks
+++ b/.mise/tasks/ci/wait-for-checks
@@ -3,15 +3,20 @@
 
 set -e
 
-PR_NUMBER="${1:-$(gh pr view --json number -q .number 2>/dev/null)}"
+# Determine target directory and repo
+TARGET_DIR="${PROJECT_DIR:-.}"
+SCRIPT_DIR="$(dirname "$0")"
+REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
+
+PR_NUMBER="${1:-$(gh pr view --repo "$REPO" --json number -q .number 2>/dev/null)}"
 
 if [ -z "$PR_NUMBER" ]; then
   echo "No PR number provided and not on a PR branch"
   exit 1
 fi
 
-echo "Waiting for checks on PR #$PR_NUMBER (timeout 3 min)..."
-if timeout 180 gh pr checks "$PR_NUMBER" --watch; then
+echo "Waiting for checks on PR #$PR_NUMBER ($REPO) - timeout 3 min..."
+if timeout 180 gh pr checks "$PR_NUMBER" --repo "$REPO" --watch; then
   echo "All checks passed!"
 else
   EXIT_CODE=$?

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -91,6 +91,10 @@ PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run pr:merge 456
 PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run pm:list-issues
 PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run pm:edit-issue 123 --status Ready
 PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run pm:wip
+
+# CI tasks
+PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run ci:wait-for-checks 456
+PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run ci:logs pr-check.yml
 ```
 
 ### Setting Up a New Repo


### PR DESCRIPTION
## Summary

- Adds `PROJECT_DIR` support to `ci:wait-for-checks` and `ci:logs`
- Enables checking CI status and viewing logs for other repos

**Tasks updated:**
- `ci:wait-for-checks` - Wait for PR checks in another repo
- `ci:logs` - View workflow logs from another repo

**Not updated (shimmer-specific):**
- `ci:watch` - References shimmer's workflow files
- `ci:time-remaining` - Uses CI environment variables from current run

**Usage:**
```bash
PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run ci:wait-for-checks 123
PROJECT_DIR=/path/to/other-repo mise -C $SHIMMER_DIR run ci:logs pr-check.yml
```

## Test plan

- [ ] Reviewer verifies cross-repo CI check workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)