### PR TITLE
Add discussion mise tasks

### DIFF
--- a/.mise/tasks/discussion/comment
+++ b/.mise/tasks/discussion/comment
@@ -1,0 +1,64 @@
+#!/bin/bash
+#MISE description="Add a comment to a discussion"
+#USAGE arg "<number>" help="Discussion number"
+#USAGE flag "-b --body <body>" help="Comment body (or reads from stdin)"
+set -eo pipefail
+
+NUMBER="${usage_number:-$1}"
+BODY="${usage_body:-}"
+
+if [[ -z "$NUMBER" ]]; then
+  echo "Usage: mise run discussion:comment <number> --body <body>"
+  echo ""
+  echo "Or pipe body from stdin:"
+  echo "  echo 'My comment' | mise run discussion:comment 123"
+  exit 1
+fi
+
+# Read body from stdin if not provided
+if [[ -z "$BODY" ]]; then
+  if [[ ! -t 0 ]]; then
+    BODY=$(cat)
+  else
+    echo "Error: --body required or pipe content via stdin"
+    exit 1
+  fi
+fi
+
+# Determine target directory and repo
+TARGET_DIR="${PROJECT_DIR:-.}"
+SCRIPT_DIR="$(dirname "$0")"
+REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
+OWNER="${REPO%/*}"
+REPO_NAME="${REPO#*/}"
+
+# Get discussion ID
+DISCUSSION_ID=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      discussion(number: $number) { id }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number="$NUMBER" \
+  --jq '.data.repository.discussion.id')
+
+if [[ -z "$DISCUSSION_ID" ]] || [[ "$DISCUSSION_ID" == "null" ]]; then
+  echo "Error: Discussion #$NUMBER not found in $REPO"
+  exit 1
+fi
+
+# Add comment
+RESULT=$(gh api graphql -f query='
+  mutation($discussionId: ID!, $body: String!) {
+    addDiscussionComment(input: {
+      discussionId: $discussionId
+      body: $body
+    }) {
+      comment {
+        url
+      }
+    }
+  }' -f discussionId="$DISCUSSION_ID" -f body="$BODY")
+
+URL=$(echo "$RESULT" | jq -r '.data.addDiscussionComment.comment.url')
+echo "Comment added to discussion #$NUMBER"
+echo "$URL"

--- a/.mise/tasks/discussion/create
+++ b/.mise/tasks/discussion/create
@@ -1,0 +1,93 @@
+#!/bin/bash
+#MISE description="Create a new discussion"
+#USAGE arg "<title>" help="Discussion title"
+#USAGE flag "-c --category <category>" help="Category name (required)"
+#USAGE flag "-b --body <body>" help="Discussion body (or reads from stdin)"
+set -eo pipefail
+
+TITLE="${usage_title:-$1}"
+CATEGORY="${usage_category:-}"
+BODY="${usage_body:-}"
+
+if [[ -z "$TITLE" ]] || [[ -z "$CATEGORY" ]]; then
+  echo "Usage: mise run discussion:create <title> --category <category> [--body <body>]"
+  echo ""
+  echo "Example:"
+  echo "  mise run discussion:create 'RFC: New feature' --category Ideas --body 'Description here'"
+  echo ""
+  echo "Or pipe body from stdin:"
+  echo "  cat rfc.md | mise run discussion:create 'RFC: New feature' --category Ideas"
+  exit 1
+fi
+
+# Read body from stdin if not provided
+if [[ -z "$BODY" ]]; then
+  if [[ ! -t 0 ]]; then
+    BODY=$(cat)
+  else
+    echo "Error: --body required or pipe content via stdin"
+    exit 1
+  fi
+fi
+
+# Determine target directory and repo
+TARGET_DIR="${PROJECT_DIR:-.}"
+SCRIPT_DIR="$(dirname "$0")"
+REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
+OWNER="${REPO%/*}"
+REPO_NAME="${REPO#*/}"
+
+# Get repository ID
+REPO_ID=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) { id }
+  }' -f owner="$OWNER" -f repo="$REPO_NAME" --jq '.data.repository.id')
+
+# Get category ID
+CATEGORY_ID=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      discussionCategories(first: 20) {
+        nodes { id name }
+      }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO_NAME" \
+  --jq ".data.repository.discussionCategories.nodes[] | select(.name == \"$CATEGORY\") | .id")
+
+if [[ -z "$CATEGORY_ID" ]]; then
+  echo "Error: Category '$CATEGORY' not found"
+  echo "Available categories:"
+  gh api graphql -f query='
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        discussionCategories(first: 20) {
+          nodes { name }
+        }
+      }
+    }' -f owner="$OWNER" -f repo="$REPO_NAME" \
+    --jq '.data.repository.discussionCategories.nodes[].name' | sed 's/^/  /'
+  exit 1
+fi
+
+# Create discussion
+RESULT=$(gh api graphql -f query='
+  mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+    createDiscussion(input: {
+      repositoryId: $repoId
+      categoryId: $categoryId
+      title: $title
+      body: $body
+    }) {
+      discussion {
+        number
+        url
+      }
+    }
+  }' -f repoId="$REPO_ID" -f categoryId="$CATEGORY_ID" -f title="$TITLE" -f body="$BODY")
+
+# Output result
+NUMBER=$(echo "$RESULT" | jq -r '.data.createDiscussion.discussion.number')
+URL=$(echo "$RESULT" | jq -r '.data.createDiscussion.discussion.url')
+
+echo "Created discussion #$NUMBER: $TITLE"
+echo "$URL"

--- a/.mise/tasks/discussion/list
+++ b/.mise/tasks/discussion/list
@@ -1,0 +1,70 @@
+#!/bin/bash
+#MISE description="List discussions in a repository"
+#USAGE flag "-c --category <category>" help="Filter by category name"
+#USAGE flag "-n --limit <limit>" help="Number of discussions to show (default: 10)"
+set -eo pipefail
+
+# Determine target directory and repo
+TARGET_DIR="${PROJECT_DIR:-.}"
+SCRIPT_DIR="$(dirname "$0")"
+REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
+OWNER="${REPO%/*}"
+REPO_NAME="${REPO#*/}"
+
+CATEGORY="${usage_category:-}"
+LIMIT="${usage_limit:-10}"
+
+# Build category filter
+CATEGORY_FILTER=""
+if [[ -n "$CATEGORY" ]]; then
+  # Get category ID by name
+  CATEGORY_ID=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        discussionCategories(first: 20) {
+          nodes { id name }
+        }
+      }
+    }' -f owner="$OWNER" -f repo="$REPO_NAME" \
+    --jq ".data.repository.discussionCategories.nodes[] | select(.name == \"$CATEGORY\") | .id")
+
+  if [[ -z "$CATEGORY_ID" ]]; then
+    echo "Error: Category '$CATEGORY' not found"
+    echo "Available categories:"
+    gh api graphql -f query='
+      query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          discussionCategories(first: 20) {
+            nodes { name }
+          }
+        }
+      }' -f owner="$OWNER" -f repo="$REPO_NAME" \
+      --jq '.data.repository.discussionCategories.nodes[].name' | sed 's/^/  /'
+    exit 1
+  fi
+  CATEGORY_FILTER=", categoryId: \"$CATEGORY_ID\""
+fi
+
+# Query discussions
+QUERY="
+  query(\$owner: String!, \$repo: String!, \$limit: Int!) {
+    repository(owner: \$owner, name: \$repo) {
+      discussions(first: \$limit, orderBy: {field: CREATED_AT, direction: DESC}$CATEGORY_FILTER) {
+        nodes {
+          number
+          title
+          category { name }
+          author { login }
+          createdAt
+          comments { totalCount }
+        }
+      }
+    }
+  }"
+
+echo "Discussions - $REPO:"
+echo ""
+
+gh api graphql -f query="$QUERY" -f owner="$OWNER" -f repo="$REPO_NAME" -F limit="$LIMIT" \
+  --jq '.data.repository.discussions.nodes[] | "#\(.number)\t[\(.category.name)]\t\(.title)\t@\(.author.login)\t\(.comments.totalCount) comments"' | \
+  column -t -s $'\t'

--- a/.mise/tasks/discussion/view
+++ b/.mise/tasks/discussion/view
@@ -1,0 +1,60 @@
+#!/bin/bash
+#MISE description="View a discussion and its comments"
+#USAGE arg "<number>" help="Discussion number"
+set -eo pipefail
+
+NUMBER="${usage_number:-$1}"
+
+if [[ -z "$NUMBER" ]]; then
+  echo "Usage: mise run discussion:view <number>"
+  exit 1
+fi
+
+# Determine target directory and repo
+TARGET_DIR="${PROJECT_DIR:-.}"
+SCRIPT_DIR="$(dirname "$0")"
+REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
+OWNER="${REPO%/*}"
+REPO_NAME="${REPO#*/}"
+
+# Query discussion with comments
+RESULT=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      discussion(number: $number) {
+        number
+        title
+        body
+        category { name }
+        author { login }
+        createdAt
+        url
+        comments(first: 50) {
+          nodes {
+            author { login }
+            body
+            createdAt
+          }
+        }
+      }
+    }
+  }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number="$NUMBER")
+
+# Check if discussion exists
+if [[ $(echo "$RESULT" | jq '.data.repository.discussion') == "null" ]]; then
+  echo "Discussion #$NUMBER not found in $REPO"
+  exit 1
+fi
+
+# Display discussion
+echo "$RESULT" | jq -r '.data.repository.discussion | "=== Discussion #\(.number) ===\n\n\(.title)\nCategory: \(.category.name)\nAuthor: @\(.author.login)\nCreated: \(.createdAt | split("T")[0])\nURL: \(.url)\n\n--- Body ---\n\(.body)"'
+
+# Display comments
+COMMENTS=$(echo "$RESULT" | jq '.data.repository.discussion.comments.nodes')
+COMMENT_COUNT=$(echo "$COMMENTS" | jq 'length')
+
+if [[ "$COMMENT_COUNT" -gt 0 ]]; then
+  echo ""
+  echo "=== Comments ($COMMENT_COUNT) ==="
+  echo "$COMMENTS" | jq -r '.[] | "\n--- @\(.author.login) (\(.createdAt | split("T")[0])) ---\n\(.body)"'
+fi


### PR DESCRIPTION
## Summary

Adds mise tasks for managing GitHub Discussions via GraphQL API:

- `discussion:list` - List discussions with optional category filter
- `discussion:view` - View a discussion and its comments
- `discussion:create` - Create a new discussion
- `discussion:comment` - Add a comment to a discussion

All support `PROJECT_DIR` for cross-repo operations.

## Usage

```bash
# List discussions
mise run discussion:list
mise run discussion:list --category Ideas --limit 5

# View a discussion
mise run discussion:view 433

# Create a discussion
mise run discussion:create "RFC: My idea" --category Ideas --body "Description..."

# Add a comment
mise run discussion:comment 433 --body "My thoughts..."
```

## Context

GitHub CLI doesn't have native discussion support ([cli/cli#4212](https://github.com/cli/cli/discussions/4212)). These tasks use the GraphQL API directly.

Already tested by creating RFC discussion #433.

## Test plan

- [x] Test discussion:list
- [x] Test discussion:create (created #433)
- [x] Test discussion:view
- [ ] Test discussion:comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)