### PR TITLE
Add Priority field to pm:init

### DIFF
--- a/.mise/tasks/pm/init
+++ b/.mise/tasks/pm/init
@@ -38,5 +38,9 @@ echo ""
 echo "Configuring Status field..."
 PROJECT_DIR="$TARGET_DIR" "$SCRIPT_DIR/field-options" "Status" "Backlog,Ready,In Progress,In Review,Done" "GRAY,GREEN,YELLOW,PURPLE,BLUE"
 
+# Configure Priority field
+echo "Configuring Priority field..."
+PROJECT_DIR="$TARGET_DIR" "$SCRIPT_DIR/field-options" "Priority" "High,Medium,Low" "RED,YELLOW,GREEN"
+
 echo ""
 echo "Project ready! View at: $PROJECT_URL"


### PR DESCRIPTION
## Summary

Makes `pm:init` fully turnkey by adding Priority field alongside Status.

After this change, a single command sets up a complete project:
```bash
PROJECT_DIR=/path/to/repo mise -C $SHIMMER_DIR run pm:init
```

Creates:
- **Status**: Backlog, Ready, In Progress, In Review, Done
- **Priority**: High, Medium, Low

## Context

Discussion with Or about making cross-repo PM setup self-service. The only gap was that pm:init didn't set up all standard fields.

## Test plan

- [ ] Run pm:init on a new repo and verify both fields are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)