### PR TITLE
Add global shimmer command

### DIFF
--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Output shell configuration for global shimmer command (use with eval)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+echo "alias shimmer='mise -C \"$REPO_DIR\" run'"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,41 +10,47 @@ Shimmer is built by agents, for agents. When working on this codebase, consider 
 
 ## Commands
 
-Run `mise tasks` to see all available tasks. Key ones:
+Run `shimmer tasks` to see all available tasks. Key ones:
 
-- `mise run whoami` - Not sure who you are? Check your agent identity
-- `mise run code:check` - Run all checks (test, format, lint) before committing
-- `mise run code:test` - Run tests
-- `mise run code:format` - Check formatting (use `--fix` to auto-fix)
-- `mise run code:lint` - Run Credo linter
-- `mise run pm:list-issues` - List open GitHub issues
-- `mise run ci:time-remaining` - Check elapsed and remaining time during CI runs
+- `shimmer whoami` - Not sure who you are? Check your agent identity
+- `shimmer code:check` - Run all checks (test, format, lint) before committing
+- `shimmer code:test` - Run tests
+- `shimmer code:format` - Check formatting (use `--fix` to auto-fix)
+- `shimmer code:lint` - Run Credo linter
+- `shimmer pm:list-issues` - List open GitHub issues
+- `shimmer ci:time-remaining` - Check elapsed and remaining time during CI runs
+
+If you haven't set up the `shimmer` command yet, add this to your shell config:
+
+```bash
+eval "$(mise -C /path/to/shimmer run -q shell)"
+```
 
 ## Workflow
 
 Work is tracked in a GitHub Project. See `docs/agent-workflow.md` for details.
 
-- `mise run issue:list` - Find issues ready to work on
-- `mise run issue:claim <num>` - Claim an issue (sets In Progress + assigns you)
+- `shimmer issue:list` - Find issues ready to work on
+- `shimmer issue:claim <num>` - Claim an issue (sets In Progress + assigns you)
 
 When submitting a PR, use `Fixes #N` to auto-close the issue on merge.
 
 ## Constraints
 
-CI runs have limited time. Use `mise run ci:time-remaining` to check how much time remains. It will warn you when time is running low.
+CI runs have limited time. Use `shimmer ci:time-remaining` to check how much time remains. It will warn you when time is running low.
 
 ## Guidelines
 
 This file is for any agent working on this repository.
 
 - Check CONTRIBUTING.md for PR and review guidelines
-- Run `mise run pm:list-issues` to find open issues
+- Run `shimmer pm:list-issues` to find open issues
 - Keep changes focused - one concern per PR
 
 ## PR Process
 
-- Run `mise run code:check` before pushing to verify tests, formatting, and linting pass
-- After creating or updating a PR, verify all CI checks pass with `mise run ci:wait-for-checks`
+- Run `shimmer code:check` before pushing to verify tests, formatting, and linting pass
+- After creating or updating a PR, verify all CI checks pass with `shimmer ci:wait-for-checks`
 - PRs are merged with squash and the branch is deleted
 
 ## GitHub Actions

--- a/README.md
+++ b/README.md
@@ -4,55 +4,74 @@
   <em>infrastructure for agent workflows — العمل شرف</em>
 </p>
 
-## Development Tasks
+## Quick Start
 
-This project uses [mise](https://mise.jdx.dev/) for task management. Run `mise tasks` to see available tasks:
+```bash
+# Clone the repository
+git clone https://github.com/ricon-family/shimmer.git ~/shimmer
+cd ~/shimmer && mise install
+
+# Add to your shell config (~/.zshrc or ~/.bashrc)
+eval "$(mise -C ~/shimmer run -q shell)"
+
+# Reload your shell
+source ~/.zshrc  # or source ~/.bashrc
+
+# Verify it works
+shimmer whoami
+```
+
+Now you can run `shimmer <task>` from anywhere.
+
+## Tasks
+
+This project uses [mise](https://mise.jdx.dev/) for task management. Run `shimmer tasks` to see all available tasks.
 
 ### Code
 
-- `mise run code:check` - Run all checks (test, format, lint) before committing
-- `mise run code:test` - Run tests
-- `mise run code:format` - Check formatting (use `--fix` to auto-fix)
-- `mise run code:lint` - Run Credo linter
+- `shimmer code:check` - Run all checks (test, format, lint) before committing
+- `shimmer code:test` - Run tests
+- `shimmer code:format` - Check formatting (use `--fix` to auto-fix)
+- `shimmer code:lint` - Run Credo linter
 
 ### Workflow Monitoring
 
-- `mise run ci:logs [workflow] [lines]` - View logs from the latest workflow run
-- `mise run ci:watch <agent> <job>` - Watch a run until completion
-- `mise run agent:trigger <agent> <job> [message]` - Trigger an agent workflow manually
-- `mise run ci:time-remaining` - Show elapsed and remaining time for current run
-- `mise run agent:schedules` - Show agent job schedules
-- `mise run ci:wait-for-checks` - Wait for PR checks to complete (timeout 3 min)
+- `shimmer ci:logs [workflow] [lines]` - View logs from the latest workflow run
+- `shimmer ci:watch <agent> <job>` - Watch a run until completion
+- `shimmer agent:trigger <agent> <job> [message]` - Trigger an agent workflow manually
+- `shimmer ci:time-remaining` - Show elapsed and remaining time for current run
+- `shimmer agent:schedules` - Show agent job schedules
+- `shimmer ci:wait-for-checks` - Wait for PR checks to complete (timeout 3 min)
 
 ### Task Management
 
-- `mise run pm:list-issues` - List open tasks (GitHub issues)
-- `mise run pm:wip` - Show work in progress (open PRs and issues with discussion status)
+- `shimmer pm:list-issues` - List open tasks (GitHub issues)
+- `shimmer pm:wip` - Show work in progress (open PRs and issues with discussion status)
 
 ### Agent Metrics
 
-- `mise run metrics:activity [days]` - Show agent activity metrics from GitHub (default: 7)
-- `mise run metrics:digest [--days N]` - Generate and send weekly activity digest email (default: 7)
-- `mise run metrics:usage [days]` - Show workflow usage and estimated compute minutes (default: 1)
+- `shimmer metrics:activity [days]` - Show agent activity metrics from GitHub (default: 7)
+- `shimmer metrics:digest [--days N]` - Generate and send weekly activity digest email (default: 7)
+- `shimmer metrics:usage [days]` - Show workflow usage and estimated compute minutes (default: 1)
 
 ### Identity
 
-- `mise run as <agent>` - Switch to an agent's identity for local work (use with `eval`)
-- `mise run whoami` - Show current git and GitHub identity
+- `shimmer as <agent>` - Switch to an agent's identity for local work (use with `eval`)
+- `shimmer whoami` - Show current git and GitHub identity
 
 Example:
 ```bash
-eval $(mise run as quick)
-mise run whoami
+eval $(shimmer as quick)
+shimmer whoami
 ```
 
 ### Admin
 
-- `mise run agent:provision <name>` - Provision a new agent (GPG key, GitHub secrets, 1Password)
-- `mise run agent:onboard <name>` - Interactive onboarding for a new agent
-- `mise run refresh-token` - Refresh the Claude OAuth token in GitHub secrets
-- `mise run inspect-context <message>` - Inspect the context being sent to Claude
-- `mise run scan-secrets` - Scan git history for potential secrets before open-sourcing
+- `shimmer agent:provision <name>` - Provision a new agent (GPG key, GitHub secrets, 1Password)
+- `shimmer agent:onboard <name>` - Interactive onboarding for a new agent
+- `shimmer refresh-token` - Refresh the Claude OAuth token in GitHub secrets
+- `shimmer inspect-context <message>` - Inspect the context being sent to Claude
+- `shimmer scan-secrets` - Scan git history for potential secrets before open-sourcing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on PR reviews and other workflows.
 

--- a/cli/priv/prompts/common.txt
+++ b/cli/priv/prompts/common.txt
@@ -53,6 +53,21 @@ If you need a place on disk for scratch files, cloned repos, or other artifacts,
 
 This is your dedicated workspace. It persists between sessions and is isolated from other agents. Create it if it doesn't exist.
 
+## Shimmer Commands
+
+Shimmer tasks can be invoked in two ways:
+
+- **`shimmer <task>`** - Works from anywhere in your filesystem. Requires the shell alias (see below).
+- **`mise run <task>`** - Works when you're inside the shimmer repository.
+
+If you're working *on* shimmer, either works. If you're working *outside* shimmer (e.g., on another project), use `shimmer`.
+
+To set up the global `shimmer` command, add this to your shell config:
+
+```bash
+eval "$(mise -C /path/to/shimmer run -q shell)"
+```
+
 ## Knowledge Management
 
 Consider maintaining a zettelkasten (slip-box) in your workspace to accumulate knowledge across sessions. See `docs/agent-zettelkasten.md` for structure recommendations.


### PR DESCRIPTION
## Summary

- Add `.mise/tasks/shell` that outputs an alias for running `shimmer <task>` from anywhere
- Update README with Quick Start section showing how to set up the global command
- Update CLAUDE.md and common.txt to use `shimmer` command syntax
- Document both invocation options (`shimmer` for anywhere, `mise run` for inside repo)

## Setup

After this merges, agents can add this to their shell config:

```bash
eval "$(mise -C /path/to/shimmer run -q shell)"
```

Then `shimmer <task>` works from anywhere.

## Test plan

- [ ] Verify `mise run shell` outputs the correct alias
- [ ] Verify alias works from outside the shimmer directory
- [ ] Check README instructions are clear

🤖 Generated with [Claude Code](https://claude.ai/code)