### PR TITLE
Add welcome command for agents

### DIFF
--- a/.mise/tasks/email/status
+++ b/.mise/tasks/email/status
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#MISE description="Check email (himalaya) setup status for an agent"
+#USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
+
+set -e
+
+AGENT="${1:?Usage: mise run email:status <agent>}"
+EMAIL="${AGENT}@ricon.family"
+CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
+
+echo "Email status for $AGENT ($EMAIL)"
+echo ""
+
+# Check if himalaya is available
+if ! command -v himalaya &> /dev/null; then
+  echo "Himalaya installed: ✗"
+  echo ""
+  echo "Run: mise install"
+  exit 1
+fi
+echo "Himalaya installed: ✓"
+
+# Check if config exists
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Config exists: ✗"
+  echo ""
+  echo "Run: mise run email:setup $AGENT"
+  exit 1
+fi
+echo "Config exists: ✓"
+
+# Check if agent account is configured
+if ! grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+  echo "Account configured: ✗"
+  echo ""
+  echo "Run: mise run email:setup $AGENT"
+  exit 1
+fi
+echo "Account configured: ✓"
+
+# Try to connect (quick check)
+echo ""
+echo "Testing connection..."
+if himalaya envelope list --max-width 0 2>/dev/null | head -1 > /dev/null; then
+  echo "Connection: ✓"
+else
+  echo "Connection: ✗ (check credentials)"
+  exit 1
+fi

--- a/.mise/tasks/matrix/status
+++ b/.mise/tasks/matrix/status
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#MISE description="Check Matrix setup status for an agent"
+#USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
+
+set -e
+
+AGENT="${1:?Usage: mise run matrix:status <agent>}"
+MATRIX_USER="@${AGENT}:ricon.family"
+CREDS_DIR="$HOME/.config/matrix-commander/$AGENT"
+CREDS_FILE="$CREDS_DIR/credentials.json"
+
+echo "Matrix status for $AGENT ($MATRIX_USER)"
+echo ""
+
+# Check if docker is available (matrix-commander runs in docker)
+if ! command -v docker &> /dev/null; then
+  echo "Docker installed: ✗"
+  echo ""
+  echo "Matrix commands require Docker"
+  exit 1
+fi
+echo "Docker installed: ✓"
+
+# Check if credentials exist
+if [ ! -f "$CREDS_FILE" ]; then
+  echo "Credentials exist: ✗"
+  echo ""
+  echo "Run: mise run matrix:login $AGENT"
+  exit 1
+fi
+echo "Credentials exist: ✓"
+echo "  Path: $CREDS_FILE"
+
+# Check if we can parse the credentials
+if command -v jq &> /dev/null && [ -f "$CREDS_FILE" ]; then
+  DEVICE=$(jq -r '.device_id // empty' "$CREDS_FILE" 2>/dev/null || true)
+  if [ -n "$DEVICE" ]; then
+    echo "  Device: $DEVICE"
+  fi
+fi
+
+echo ""
+echo "Test with: mise run matrix:send $AGENT 'Hello!'"

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#MISE description="Welcome message and status check for agents"
+
+set -e
+
+# Determine current agent from environment or git config
+if [ -n "$GIT_AUTHOR_EMAIL" ]; then
+  AGENT=$(echo "$GIT_AUTHOR_EMAIL" | sed 's/@ricon\.family$//')
+elif git config user.email 2>/dev/null | grep -q '@ricon.family'; then
+  AGENT=$(git config user.email | sed 's/@ricon\.family$//')
+else
+  AGENT=""
+fi
+
+# Get shimmer repo location (tasks are in .mise/tasks/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHIMMER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo ""
+if [ -n "$AGENT" ]; then
+  echo "Welcome, $AGENT!"
+  echo ""
+  echo "You are ${AGENT}@ricon.family. Your commits are signed with GPG."
+else
+  echo "Welcome!"
+  echo ""
+  echo "⚠ No agent identity detected."
+  echo "  Run: eval \$(shimmer as <agent>)"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Shimmer commands (work from anywhere):"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  shimmer whoami              Verify your identity"
+echo "  shimmer pm:list-issues      Find work in the shimmer project"
+echo "  shimmer ci:time-remaining   Check remaining time in CI runs"
+echo ""
+echo "  himalaya envelope list      Check your email inbox"
+echo "  mise run matrix:tail <you>  See recent Matrix messages"
+echo ""
+echo "  shimmer tasks               List all available tasks"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Health check:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Identity check
+if [ -n "$GIT_AUTHOR_EMAIL" ] && echo "$GIT_AUTHOR_EMAIL" | grep -q '@ricon.family'; then
+  echo "  Identity:  ✓ $GIT_AUTHOR_EMAIL"
+else
+  echo "  Identity:  ✗ not set (run: eval \$(shimmer as <agent>))"
+fi
+
+# GPG check (only if we know the agent)
+if [ -n "$AGENT" ]; then
+  if gpg --list-secret-keys "${AGENT}@ricon.family" &>/dev/null; then
+    echo "  GPG:       ✓ key imported"
+  else
+    echo "  GPG:       ✗ no key (run: shimmer gpg:setup $AGENT)"
+  fi
+
+  # Email check
+  CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
+  if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+    echo "  Email:     ✓ configured"
+  else
+    echo "  Email:     ✗ not configured (run: shimmer email:setup $AGENT)"
+  fi
+
+  # Matrix check
+  MATRIX_CREDS="$HOME/.config/matrix-commander/$AGENT/credentials.json"
+  if [ -f "$MATRIX_CREDS" ]; then
+    echo "  Matrix:    ✓ logged in"
+  else
+    echo "  Matrix:    ✗ not logged in (run: shimmer matrix:login $AGENT)"
+  fi
+else
+  echo "  GPG:       ? (set identity first)"
+  echo "  Email:     ? (set identity first)"
+  echo "  Matrix:    ? (set identity first)"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Context:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  Current dir: $(pwd)"
+echo "  Shimmer:     $SHIMMER_DIR"
+
+# Check if we're in shimmer
+if [ "$(pwd)" = "$SHIMMER_DIR" ] || [[ "$(pwd)" == "$SHIMMER_DIR"/* ]]; then
+  echo ""
+  echo "  You're inside the shimmer repo."
+else
+  echo ""
+  echo "  You're outside shimmer. Use 'shimmer <task>' to run shimmer commands."
+fi
+
+echo ""
+echo "For full docs: $SHIMMER_DIR/docs/"
+echo ""


### PR DESCRIPTION
Fixes #443

## Summary

Add `shimmer welcome` command for agents starting work in any codebase. This provides orientation and health checks so agents can quickly verify their setup.

**New tasks:**
- `welcome` - Welcome message with commands and health checks
- `email:status` - Check email (himalaya) setup status  
- `matrix:status` - Check Matrix setup status

## Usage

When starting an agent in a new project, tell them:
> Run `shimmer welcome` to get oriented

## Test plan

- [ ] Run `shimmer welcome` from inside shimmer repo
- [ ] Run `shimmer welcome` from outside shimmer repo
- [ ] Verify health checks show correct status
- [ ] Test without identity set (`unset GIT_AUTHOR_EMAIL`)

🤖 Generated with [Claude Code](https://claude.ai/code)