### PR TITLE
Add assignee support to issue:propose

### DIFF
--- a/.mise/tasks/issue/propose
+++ b/.mise/tasks/issue/propose
@@ -46,8 +46,12 @@ ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 
 # Assign if requested
 if [[ -n "$ASSIGNEE" ]]; then
-  gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-assignee "$ASSIGNEE"
-  echo "Proposed: $ISSUE_URL (assigned to $ASSIGNEE)"
+  if gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-assignee "$ASSIGNEE" 2>/dev/null; then
+    echo "Proposed: $ISSUE_URL (assigned to $ASSIGNEE)"
+  else
+    echo "Proposed: $ISSUE_URL"
+    echo "Warning: Could not assign to $ASSIGNEE"
+  fi
 else
   echo "Proposed: $ISSUE_URL"
 fi


### PR DESCRIPTION
Fixes #444

## Summary

Add `--assignee` and `--self` flags to `issue:propose` so you can assign issues when creating them.

## Usage

```bash
# Assign to yourself
mise run issue:propose "Fix the bug" --self

# Assign to a specific user
mise run issue:propose "Fix the bug" --assignee quick-ricon

# With body
mise run issue:propose "Fix the bug" --body "Details here" --self
```

## Changes

- Add `--assignee <user>` flag
- Add `--self` flag (shorthand for `--assignee @me`)
- Add error handling if assignment fails
- Fix typo in help text (`issues:propose` → `issue:propose`)

🤖 Generated with [Claude Code](https://claude.ai/code)