### PR TITLE
Show unread email count in welcome health check

### DIFF
--- a/.mise/tasks/email/list
+++ b/.mise/tasks/email/list
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 #MISE description="List inbox messages"
 #USAGE flag "-n --limit <limit>" help="Number of messages to show (default: 10)"
+#USAGE flag "--unread" help="Only show unread messages"
+#USAGE flag "--count" help="Just output the count (useful for scripts)"
 
 set -e
 
 LIMIT="${usage_limit:-10}"
+UNREAD="${usage_unread:-false}"
+COUNT_ONLY="${usage_count:-false}"
 
 # Determine current agent from environment or git config
 if [ -n "$GIT_AUTHOR_EMAIL" ]; then
@@ -22,6 +26,19 @@ if [ ! -f "$CONFIG_FILE" ] || ! grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/
   exit 1
 fi
 
+# Build query for unread filter
+QUERY=""
+if [ "$UNREAD" = "true" ]; then
+  QUERY="not flag seen"
+fi
+
 # List envelopes with account selection
-# Add 1 to limit to account for header row, then use head
-himalaya envelope list -a "$AGENT" -w 120 | head -$((LIMIT + 2))
+OUTPUT=$(himalaya envelope list -a "$AGENT" -w 120 $QUERY 2>/dev/null)
+
+if [ "$COUNT_ONLY" = "true" ]; then
+  # Count lines, skipping 2 header rows
+  echo "$OUTPUT" | tail -n +3 | wc -l | tr -d ' '
+else
+  # Add 2 to limit to account for header rows, then use head
+  echo "$OUTPUT" | head -$((LIMIT + 2))
+fi

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -68,7 +68,13 @@ if [ -n "$AGENT" ]; then
   # Email check
   CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
   if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
-    echo "  Email:     ✓ configured       → shimmer email:welcome"
+    # Count unread emails using email:list task
+    UNREAD_COUNT=$(mise run -q email:list --unread --count 2>/dev/null || echo "0")
+    if [ -n "$UNREAD_COUNT" ] && [ "$UNREAD_COUNT" -gt 0 ]; then
+      echo "  Email:     ✓ configured ($UNREAD_COUNT unread) → shimmer email:welcome"
+    else
+      echo "  Email:     ✓ configured       → shimmer email:welcome"
+    fi
   else
     echo "  Email:     ✗ not configured (run: shimmer email:setup $AGENT)"
   fi


### PR DESCRIPTION
## Summary

- Add `--unread` and `--count` flags to `email:list` task
- Update `welcome` task to show unread count in health check (e.g. "11 unread")

Before:
```
  Email:     ✓ configured       → shimmer email:welcome
```

After:
```
  Email:     ✓ configured (11 unread) → shimmer email:welcome
```

## Test plan

- [x] Run `mise run email:list --unread` to see only unread emails
- [x] Run `mise run email:list --unread --count` to get just the count
- [x] Run `mise run welcome` and verify unread count appears
- [x] Run `mise run code:check` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)