### PR TITLE
Add agent:message and agent:broadcast tasks

### DIFF
--- a/.github/workflows/agent-message.yml
+++ b/.github/workflows/agent-message.yml
@@ -1,0 +1,137 @@
+# Agent Message Dispatcher
+#
+# This workflow allows sending a message to any agent without a specific job.
+# The agent wakes up, receives the message, and decides how to respond.
+#
+# Why conditional jobs instead of a single parameterized job?
+# GitHub Actions doesn't support dynamic secret references (e.g., secrets.${{ inputs.agent }}_GITHUB_PAT).
+# Each agent has their own secrets, so we need a conditional job per agent to map the correct secrets.
+# Only one job runs per invocation based on the selected agent.
+
+name: Agent Message
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: 'Agent to message'
+        required: true
+        type: choice
+        options:
+          - brownie
+          - c0da
+          - johnson
+          - junior
+          - k7r2
+          - quick
+          - rho
+          - x1f9
+      message:
+        description: 'Message for the agent'
+        required: true
+        type: string
+
+jobs:
+  brownie:
+    if: inputs.agent == 'brownie'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: brownie
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.BROWNIE_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.BROWNIE_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.BROWNIE_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.BROWNIE_MATRIX_PASSWORD }}
+
+  c0da:
+    if: inputs.agent == 'c0da'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: c0da
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.C0DA_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.C0DA_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.C0DA_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.C0DA_MATRIX_PASSWORD }}
+
+  johnson:
+    if: inputs.agent == 'johnson'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: johnson
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.JOHNSON_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.JOHNSON_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.JOHNSON_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.JOHNSON_MATRIX_PASSWORD }}
+
+  junior:
+    if: inputs.agent == 'junior'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: junior
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.JUNIOR_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.JUNIOR_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.JUNIOR_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.JUNIOR_MATRIX_PASSWORD }}
+
+  k7r2:
+    if: inputs.agent == 'k7r2'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: k7r2
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.K7R2_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.K7R2_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.K7R2_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.K7R2_MATRIX_PASSWORD }}
+
+  quick:
+    if: inputs.agent == 'quick'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: quick
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.QUICK_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.QUICK_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.QUICK_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.QUICK_MATRIX_PASSWORD }}
+
+  rho:
+    if: inputs.agent == 'rho'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: rho
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.RHO_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.RHO_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.RHO_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.RHO_MATRIX_PASSWORD }}
+
+  x1f9:
+    if: inputs.agent == 'x1f9'
+    uses: ./.github/workflows/agent-run.yml
+    with:
+      agent: x1f9
+      message: ${{ inputs.message }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      AGENT_GITHUB_PAT: ${{ secrets.X1F9_GITHUB_PAT }}
+      AGENT_GPG_PRIVATE_KEY: ${{ secrets.X1F9_GPG_PRIVATE_KEY }}
+      AGENT_EMAIL_PASSWORD: ${{ secrets.X1F9_EMAIL_PASSWORD }}
+      AGENT_MATRIX_PASSWORD: ${{ secrets.X1F9_MATRIX_PASSWORD }}

--- a/.github/workflows/agent-run.yml
+++ b/.github/workflows/agent-run.yml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
       job:
-        description: 'Job to run (e.g., probe, critic)'
-        required: true
+        description: 'Job to run (e.g., probe, critic). Optional if message is provided.'
+        required: false
         type: string
       message:
-        description: 'Optional message to pass to the agent'
+        description: 'Message to pass to the agent. Required if no job is specified.'
         required: false
         type: string
     secrets:
@@ -32,6 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Validate inputs
+        run: |
+          if [ -z "${{ inputs.job }}" ] && [ -z "${{ inputs.message }}" ]; then
+            echo "Error: Either job or message must be provided"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.AGENT_GITHUB_PAT }}
@@ -110,4 +117,8 @@ jobs:
           RUN_TIMEOUT: 540
         run: |
           export RUN_START_TIME=$(date +%s)
-          cd cli && mix shimmer --agent ${{ inputs.agent }} --job ${{ inputs.job }} --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"
+          JOB_FLAG=""
+          if [ -n "${{ inputs.job }}" ]; then
+            JOB_FLAG="--job ${{ inputs.job }}"
+          fi
+          cd cli && mix shimmer --agent ${{ inputs.agent }} $JOB_FLAG --timeout $RUN_TIMEOUT "${{ steps.message.outputs.msg }}"

--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#MISE description="Send a message to all agents"
+#USAGE arg "<message>" help="Message for all agents"
+#USAGE flag "-s --stagger <seconds>" help="Seconds to wait between agents (default: 30)"
+#USAGE flag "--dry-run" help="Show what would be done without triggering"
+
+set -e
+
+# Discover agents from prompt files (source of truth for agents)
+get_agents() {
+  ls cli/priv/prompts/agents/*.txt 2>/dev/null \
+    | xargs -n1 basename \
+    | sed 's/\.txt$//' \
+    | sort
+}
+
+if [ $# -lt 1 ]; then
+  echo "Usage: mise run agent:broadcast <message> [--stagger <seconds>] [--dry-run]"
+  echo ""
+  echo "Sends a message to all agents, waking each one without a specific job."
+  echo "Agents are triggered sequentially with a stagger delay to avoid resource contention."
+  echo ""
+  echo "Agents: $(get_agents | tr '\n' ' ')"
+  echo ""
+  echo "Options:"
+  echo "  --stagger <seconds>  Wait time between agents (default: 30)"
+  echo "  --dry-run            Show what would be done without triggering"
+  echo ""
+  echo "Example: mise run agent:broadcast \"Please vote on issue #467\" --stagger 60"
+  exit 1
+fi
+
+MESSAGE="$1"
+STAGGER="${usage_stagger:-30}"
+DRY_RUN="${usage_dry_run:-false}"
+WORKFLOW="agent-message.yml"
+
+# Validate workflow exists
+if [ ! -f ".github/workflows/$WORKFLOW" ]; then
+  echo "Workflow not found: $WORKFLOW"
+  exit 1
+fi
+
+AGENTS=$(get_agents)
+AGENT_COUNT=$(echo "$AGENTS" | wc -l | tr -d ' ')
+
+echo "Broadcasting to $AGENT_COUNT agents with ${STAGGER}s stagger"
+echo "Message: $MESSAGE"
+echo ""
+
+FIRST=true
+for AGENT in $AGENTS; do
+  if [ "$FIRST" = true ]; then
+    FIRST=false
+  else
+    if [ "$DRY_RUN" = "false" ]; then
+      echo "Waiting ${STAGGER}s before next agent..."
+      sleep "$STAGGER"
+    fi
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] Would message: $AGENT"
+  else
+    echo "Messaging: $AGENT"
+    gh workflow run "$WORKFLOW" -f agent="$AGENT" -f message="$MESSAGE"
+  fi
+done
+
+echo ""
+if [ "$DRY_RUN" = "true" ]; then
+  echo "Dry run complete. No agents were messaged."
+else
+  echo "Broadcast complete. All agents have been messaged."
+fi

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#MISE description="Send a message to an agent (wakes them without a specific job)"
+#USAGE arg "<agent>" help="Agent to message (e.g., quick, brownie)"
+#USAGE arg "<message>" help="Message for the agent"
+
+set -e
+
+# Discover agents from prompt files (source of truth for agents)
+get_agents() {
+  ls cli/priv/prompts/agents/*.txt 2>/dev/null \
+    | xargs -n1 basename \
+    | sed 's/\.txt$//' \
+    | sort
+}
+
+if [ $# -lt 2 ]; then
+  echo "Usage: mise run agent:message <agent> <message>"
+  echo ""
+  echo "Sends a message to an agent, waking them without a specific job."
+  echo "The agent receives the message and decides how to respond."
+  echo ""
+  echo "Agents: $(get_agents | tr '\n' ' ')"
+  echo ""
+  echo "Example: mise run agent:message quick \"Please vote on issue #467\""
+  exit 1
+fi
+
+AGENT="$1"
+MESSAGE="$2"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+WORKFLOW="agent-message.yml"
+
+# Validate agent
+if ! get_agents | grep -qx "$AGENT"; then
+  echo "Unknown agent: $AGENT"
+  echo "Available agents: $(get_agents | tr '\n' ' ')"
+  exit 1
+fi
+
+# Validate workflow exists
+if [ ! -f ".github/workflows/$WORKFLOW" ]; then
+  echo "Workflow not found: $WORKFLOW"
+  exit 1
+fi
+
+gh workflow run "$WORKFLOW" -f agent="$AGENT" -f message="$MESSAGE"
+
+echo "Sent message to $AGENT"
+
+# Wait briefly for GitHub to register the run, then get the URL
+sleep 2
+RUN_URL=$(gh run list --workflow="$WORKFLOW" --limit 1 --json url --jq '.[0].url' 2>/dev/null)
+
+if [ -n "$RUN_URL" ]; then
+  echo "View at: $RUN_URL"
+else
+  echo "View at: https://github.com/$REPO/actions/workflows/$WORKFLOW"
+fi


### PR DESCRIPTION
## Summary

Enable sending messages to agents without a specific job. This allows ad-hoc instructions and coordination.

- Make `job` optional in `agent-run.yml` (message required if no job)
- Add `agent-message.yml` dispatcher workflow with per-agent secret mapping
- Add `agent:message` task to message a single agent
- Add `agent:broadcast` task to message all agents with configurable stagger

## Why conditional jobs in agent-message.yml?

GitHub Actions doesn't support dynamic secret references (e.g., `secrets.${{ inputs.agent }}_GITHUB_PAT`). Each agent has their own secrets, so we need a conditional job per agent to map the correct secrets. Only one job runs per invocation.

## Usage

```bash
# Message a single agent
shimmer agent:message quick "Please vote on issue #467"

# Broadcast to all agents with 60s stagger
shimmer agent:broadcast "Check your email" --stagger 60

# Preview broadcast without triggering
shimmer agent:broadcast "Test" --dry-run
```

## Test plan

- [x] `mise run agent:message` shows help
- [x] `mise run agent:broadcast --dry-run "Test"` lists all agents
- [x] `mise run code:check` passes

## Related

- Closes #214 (generic agent dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)