### PR TITLE
Fix OAuth token extraction in agent:refresh-token

### DIFF
--- a/.mise/tasks/agent/refresh-token
+++ b/.mise/tasks/agent/refresh-token
@@ -11,17 +11,29 @@ cd "$TARGET_DIR"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 echo "Getting new OAuth token from Claude..."
-RAW_OUTPUT=$(claude setup-token 2>&1)
+# Use TERM=dumb to reduce (but not eliminate) escape sequences
+RAW_OUTPUT=$(TERM=dumb claude setup-token 2>&1)
 
-# Extract just the token (starts with sk-ant-)
-TOKEN=$(echo "$RAW_OUTPUT" | grep -o 'sk-ant-[A-Za-z0-9_-]*')
+# Extract the token - handle escape codes and line wrapping
+# 1. Strip carriage returns
+# 2. Strip ANSI escape sequences
+# 3. Strip newlines to join wrapped lines
+# 4. Extract token (starts with sk-ant-oat01-, ends with AA)
+TOKEN=$(echo "$RAW_OUTPUT" | \
+  tr -d '\r' | \
+  sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | \
+  tr -d '\n' | \
+  grep -o 'sk-ant-oat01-[A-Za-z0-9_-]*AA')
 
 if [ -z "$TOKEN" ]; then
   echo "Failed to extract token from output"
+  echo "--- Debug: cleaned output ---"
+  echo "$RAW_OUTPUT" | tr -d '\r' | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | tr -d '\n' | grep -o 'sk-ant-[A-Za-z0-9_-]*'
+  echo "--- End debug ---"
   exit 1
 fi
 
 echo "Updating CLAUDE_CODE_OAUTH_TOKEN secret on $REPO..."
-gh secret set CLAUDE_CODE_OAUTH_TOKEN --body "$TOKEN"
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo "$REPO" --body "$TOKEN"
 
-echo "Done! Token updated."
+echo "Done! Token updated (${#TOKEN} chars)."


### PR DESCRIPTION
## Summary

- Fix token extraction that was failing due to ANSI escape codes and line wrapping in `claude setup-token` output
- Add `--repo` flag to `gh secret set` to ensure correct target repo
- Add debug output and token length verification

## Root Cause

`claude setup-token` outputs tokens with:
- ANSI escape sequences (cursor positioning like `\x1b[1B`, `\x1b[1C`)
- Carriage returns (`\r`)
- Line wrapping across multiple lines

The original extraction used `grep -o 'sk-ant-[A-Za-z0-9_-]*'` which only captured the first line, resulting in truncated ~30 char tokens instead of the full ~107 char tokens.

## Test plan

- [x] Verified token extraction works with `TERM=dumb` and the new pipeline
- [x] Verified extracted token works locally with `shimmer agent:run`
- [x] Verified `gh secret set --repo` targets the correct repo
- [x] Successfully ran first agent in fold after fix

Fixes ricon-family/fold#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)