### PR TITLE
Fix issue:view to show body when there are no comments

### DIFF
--- a/.mise/tasks/issue/view
+++ b/.mise/tasks/issue/view
@@ -15,5 +15,13 @@ TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../pm/_get-repo" "$TARGET_DIR")
 
-# Get issue details with comments
-gh issue view "$ISSUE" --repo "$REPO" --comments
+# Show issue body first, then comments
+gh issue view "$ISSUE" --repo "$REPO"
+
+# Show comments if any exist
+COMMENT_COUNT=$(gh issue view "$ISSUE" --repo "$REPO" --json comments --jq '.comments | length')
+if [[ "$COMMENT_COUNT" -gt 0 ]]; then
+  echo ""
+  echo "--- Comments ---"
+  gh issue view "$ISSUE" --repo "$REPO" --comments
+fi


### PR DESCRIPTION
## Summary

- Shows the issue body first when viewing an issue
- Only appends comments section if comments exist
- Fixes the empty output bug when viewing issues with 0 comments

## Test plan

- [x] Verified with fold issue #3 (0 comments) - now shows issue body
- [x] Verified with shimmer issue #485 (9 comments) - shows body + comments

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)