### PR TITLE
Use gpg:setup mise task in test-agent-identity workflow

### DIFF
--- a/.github/workflows/test-agent-identity.yml
+++ b/.github/workflows/test-agent-identity.yml
@@ -22,18 +22,27 @@ jobs:
         with:
           token: ${{ secrets[format('{0}_GITHUB_PAT', steps.upper.outputs.agent)] }}
 
+      - name: Checkout shimmer
+        uses: actions/checkout@v4
+        with:
+          repository: ricon-family/shimmer
+          token: ${{ secrets[format('{0}_GITHUB_PAT', steps.upper.outputs.agent)] }}
+          path: shimmer
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+
       - name: Setup GPG
         env:
           GPG_PRIVATE_KEY: ${{ secrets[format('{0}_GPG_PRIVATE_KEY', steps.upper.outputs.agent)] }}
+        run: mise run -C shimmer gpg:setup ${{ inputs.agent }}
+
+      - name: Configure git identity
         run: |
-          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-
-          KEY_ID=$(gpg --list-secret-keys --keyid-format LONG "${AGENT}@ricon.family" | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
-
           git config --global user.name "$AGENT"
           git config --global user.email "${AGENT}@ricon.family"
-          git config --global user.signingkey "$KEY_ID"
-          git config --global commit.gpgsign true
 
       - name: Make test commit
         run: |


### PR DESCRIPTION
## Summary

- Replace inline GPG import in `test-agent-identity.yml` with the `gpg:setup` mise task
- Aligns with `agent-run.yml` which already uses the mise task
- Better maintainability - GPG setup logic is centralized in one place

## Changes

The workflow now:
1. Checks out shimmer alongside the current repo
2. Sets up mise
3. Runs `mise run -C shimmer gpg:setup $agent`
4. Configures git identity (name/email)

The gpg:setup task handles key import, key ID extraction, signingkey config, and trust setup.

## Test plan

- [ ] Run the test-agent-identity workflow manually for any agent
- [ ] Verify the commit is signed correctly

Fixes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)