### PR TITLE
Use gpg:setup mise task in test-agent-identity workflow

### DIFF
--- a/.github/workflows/test-agent-identity.yml
+++ b/.github/workflows/test-agent-identity.yml
@@ -22,18 +22,20 @@ jobs:
         with:
           token: ${{ secrets[format('{0}_GITHUB_PAT', steps.upper.outputs.agent)] }}
 
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+
       - name: Setup GPG
         env:
           GPG_PRIVATE_KEY: ${{ secrets[format('{0}_GPG_PRIVATE_KEY', steps.upper.outputs.agent)] }}
+        run: mise run gpg:setup ${{ inputs.agent }}
+
+      - name: Configure git identity
         run: |
-          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-
-          KEY_ID=$(gpg --list-secret-keys --keyid-format LONG "${AGENT}@ricon.family" | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
-
           git config --global user.name "$AGENT"
           git config --global user.email "${AGENT}@ricon.family"
-          git config --global user.signingkey "$KEY_ID"
-          git config --global commit.gpgsign true
 
       - name: Make test commit
         run: |


### PR DESCRIPTION
## Summary

- Replace inline GPG setup code in `test-agent-identity.yml` with the `gpg:setup` mise task
- Add mise setup step to the workflow
- Separate git identity configuration into its own step (name/email not handled by gpg:setup)

This consolidates GPG setup logic and follows the pattern already used in fold's `agent-run.yml`.

## Test plan

- [ ] Run the `Test Agent Identity` workflow manually with an agent name to verify signed commits work

Fixes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)