### PR TITLE
Add --help support to agent:refresh-token

### DIFF
--- a/.mise/tasks/agent/refresh-token
+++ b/.mise/tasks/agent/refresh-token
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 #MISE description="Refresh the Claude OAuth token in GitHub secrets"
+#USAGE flag "--repo <repo>" help="Target repo (default: current directory's repo)"
 # Note: This is also called automatically by `agent:sync-secrets` (unless --skip-oauth)
 
 set -e
 
-# Determine target directory (caller's directory when using shimmer alias)
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
-cd "$TARGET_DIR"
-
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+# Determine target repo
+if [ -n "${usage_repo:-}" ]; then
+  REPO="$usage_repo"
+else
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  cd "$TARGET_DIR"
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
 
 echo "Getting new OAuth token from Claude..."
 # Use TERM=dumb to reduce (but not eliminate) escape sequences


### PR DESCRIPTION
## Summary

- Adds `#USAGE` flag to enable mise's built-in help handling for `agent:refresh-token`
- Running `shimmer agent:refresh-token --help` now shows usage info instead of starting the OAuth flow
- Adds optional `--repo` flag to specify target repository directly

## Before

```bash
shimmer agent:refresh-token --help
# Started OAuth flow, opened browser 😱
```

## After

```bash
shimmer agent:refresh-token --help
# Usage: agent:refresh-token [--repo <repo>]
#
# Flags:
#   --repo <repo>  Target repo (default: current directory's repo)
```

## Test plan

- [x] Verify `--help` shows usage instead of running
- [x] Verify `shimmer code:check` passes

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)