### PR TITLE
Use shimmer command in workflow template, fix matrix:invites syntax

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -102,12 +102,12 @@ jobs:
       - name: Setup GPG
         env:
           GPG_PRIVATE_KEY: ${{ secrets.AGENT_GPG_PRIVATE_KEY }}
-        run: mise run -C ~/shimmer gpg:setup ${{ inputs.agent }}
+        run: shimmer gpg:setup ${{ inputs.agent }}
 
       - name: Setup email
         env:
           EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
-        run: mise run -C ~/shimmer email:setup ${{ inputs.agent }}
+        run: shimmer email:setup ${{ inputs.agent }}
 
       - name: Configure git
         run: |
@@ -127,10 +127,10 @@ jobs:
       - name: Setup Matrix
         env:
           MATRIX_PASSWORD: ${{ secrets.AGENT_MATRIX_PASSWORD }}
-        run: mise run -C ~/shimmer matrix:login ${{ inputs.agent }}
+        run: shimmer matrix:login ${{ inputs.agent }}
 
       - name: Accept Matrix room invites
-        run: mise run -C ~/shimmer matrix:invites ${{ inputs.agent }}
+        run: shimmer matrix:invites -u ${{ inputs.agent }}
 
       - name: Clone zettelkasten
         env:
@@ -209,12 +209,12 @@ jobs:
         run: |
           cd "$HOME/$REPO_NAME"
           if [ -n "$AGENT_PASSPHRASE" ]; then
-            mise run -C ~/shimmer agent:run "${{ inputs.agent }}" "${{ steps.message.outputs.msg }}" \
+            shimmer agent:run "${{ inputs.agent }}" "${{ steps.message.outputs.msg }}" \
               --system-prompt-file "${{ steps.prompt.outputs.file }}" \
               --timeout "$RUN_TIMEOUT" \
               --passphrase "$AGENT_PASSPHRASE"
           else
-            mise run -C ~/shimmer agent:run "${{ inputs.agent }}" "${{ steps.message.outputs.msg }}" \
+            shimmer agent:run "${{ inputs.agent }}" "${{ steps.message.outputs.msg }}" \
               --system-prompt-file "${{ steps.prompt.outputs.file }}" \
               --timeout "$RUN_TIMEOUT"
           fi


### PR DESCRIPTION
## Summary

Two fixes for the agent-run workflow template:

1. **Use `shimmer` command** instead of `mise run -C ~/shimmer` - the wrapper script is already set up, so we should use it for cleaner, more readable workflow steps

2. **Fix matrix:invites syntax** - PR #497 changed matrix:invites to use `-u` flag instead of positional username argument

## Problem

After merging PR #497, broadcasts started failing with:
```
[matrix:invites] ERROR unexpected word: brownie
[matrix:invites] ERROR task failed
```

## Changes

| Before | After |
|--------|-------|
| `mise run -C ~/shimmer gpg:setup $agent` | `shimmer gpg:setup $agent` |
| `mise run -C ~/shimmer email:setup $agent` | `shimmer email:setup $agent` |
| `mise run -C ~/shimmer matrix:login $agent` | `shimmer matrix:login $agent` |
| `mise run -C ~/shimmer matrix:invites $agent` | `shimmer matrix:invites -u $agent` |
| `mise run -C ~/shimmer agent:run ...` | `shimmer agent:run ...` |

## Test plan

- [ ] Trigger a broadcast after merging to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)