### PR TITLE
Fix release workflow binary verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           cd cli/burrito_out
           chmod +x shimmer_${{ matrix.target }}
-          ./shimmer_${{ matrix.target }} --version
+          ./shimmer_${{ matrix.target }} --help
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Use `--help` instead of `--version` to verify the binary works
- The CLI supports `--help` but not `--version`, causing the verify step to fail

## Context
The test release `v0.0.1-alpha` failed because the "Verify binary" step ran `./shimmer_linux_x86_64 --version`, but the CLI doesn't support the `--version` flag. It just treats it as an unknown argument and then fails because no message was provided.

The `--help` flag is supported and exits cleanly with status 0, making it a suitable verification that the binary is functional.

## Test plan
- [ ] Merge this PR
- [ ] Delete the failed `v0.0.1-alpha` tag and re-create it to trigger the workflow again
- [ ] Verify all three platform builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)