### PR TITLE
Add model selection per workflow

### DIFF
--- a/.github/templates/agent-message.yml
+++ b/.github/templates/agent-message.yml
@@ -30,6 +30,10 @@ on:
         description: 'Message for the agent'
         required: true
         type: string
+      model:
+        description: 'Claude model to use (optional)'
+        required: false
+        type: string
 
 jobs:
   brownie:
@@ -38,6 +42,7 @@ jobs:
     with:
       agent: brownie
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.BROWNIE_GITHUB_PAT }}
@@ -52,6 +57,7 @@ jobs:
     with:
       agent: c0da
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.C0DA_GITHUB_PAT }}
@@ -66,6 +72,7 @@ jobs:
     with:
       agent: johnson
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.JOHNSON_GITHUB_PAT }}
@@ -80,6 +87,7 @@ jobs:
     with:
       agent: junior
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.JUNIOR_GITHUB_PAT }}
@@ -94,6 +102,7 @@ jobs:
     with:
       agent: k7r2
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.K7R2_GITHUB_PAT }}
@@ -108,6 +117,7 @@ jobs:
     with:
       agent: quick
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.QUICK_GITHUB_PAT }}
@@ -122,6 +132,7 @@ jobs:
     with:
       agent: rho
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.RHO_GITHUB_PAT }}
@@ -136,6 +147,7 @@ jobs:
     with:
       agent: x1f9
       message: ${{ inputs.message }}
+      model: ${{ inputs.model }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.X1F9_GITHUB_PAT }}

--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -16,6 +16,10 @@ on:
         description: 'Message/instruction for the agent'
         required: true
         type: string
+      model:
+        description: 'Claude model to use (optional, defaults to opus)'
+        required: false
+        type: string
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -166,17 +170,23 @@ jobs:
           RUN_TIMEOUT: 540
           AGENT_PASSPHRASE: ${{ secrets.AGENT_PASSPHRASE }}
           INPUT_MESSAGE: ${{ inputs.message }}
+          INPUT_MODEL: ${{ inputs.model }}
         run: |
           cd "$HOME/$REPO_NAME"
           echo "### AGENT SESSION START ###"
+
+          # Build optional flags
+          OPTIONAL_FLAGS=""
           if [ -n "$AGENT_PASSPHRASE" ]; then
-            shimmer agent:run "${{ inputs.agent }}" "$INPUT_MESSAGE" \
-              --system-prompt-file "${{ steps.prompt.outputs.file }}" \
-              --timeout "$RUN_TIMEOUT" \
-              --passphrase "$AGENT_PASSPHRASE"
-          else
-            shimmer agent:run "${{ inputs.agent }}" "$INPUT_MESSAGE" \
-              --system-prompt-file "${{ steps.prompt.outputs.file }}" \
-              --timeout "$RUN_TIMEOUT"
+            OPTIONAL_FLAGS="$OPTIONAL_FLAGS --passphrase $AGENT_PASSPHRASE"
           fi
+          if [ -n "$INPUT_MODEL" ]; then
+            OPTIONAL_FLAGS="$OPTIONAL_FLAGS --model $INPUT_MODEL"
+          fi
+
+          shimmer agent:run "${{ inputs.agent }}" "$INPUT_MESSAGE" \
+            --system-prompt-file "${{ steps.prompt.outputs.file }}" \
+            --timeout "$RUN_TIMEOUT" \
+            $OPTIONAL_FLAGS
+
           echo "### AGENT SESSION END ###"

--- a/.github/templates/agent-scheduled.yml
+++ b/.github/templates/agent-scheduled.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       agent: ${AGENT}
       message: ${MESSAGE}
+      model: ${MODEL}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       AGENT_GITHUB_PAT: ${{ secrets.${AGENT_UPPER}_GITHUB_PAT }}

--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -3,6 +3,7 @@
 #USAGE arg "<message>" help="Message for all agents"
 #USAGE flag "-s --stagger <seconds>" help="Seconds to wait between agents (default: 30)"
 #USAGE flag "--dry-run" help="Show what would be done without triggering"
+#USAGE flag "--model <model>" help="Claude model to use"
 
 set -e
 
@@ -61,6 +62,7 @@ fi
 MESSAGE="$1"
 STAGGER="${usage_stagger:-30}"
 DRY_RUN="${usage_dry_run:-false}"
+MODEL="${usage_model:-}"
 WORKFLOW="agent-message.yml"
 REPO=$(get_repo)
 
@@ -84,11 +86,16 @@ for AGENT in $AGENTS; do
     fi
   fi
 
+  MODEL_ARG=""
+  if [ -n "$MODEL" ]; then
+    MODEL_ARG="-f model=$MODEL"
+  fi
+
   if [ "$DRY_RUN" = "true" ]; then
     echo "[dry-run] Would message: $AGENT"
   else
     echo "Messaging: $AGENT"
-    gh workflow run "$WORKFLOW" -R "$REPO" -f agent="$AGENT" -f message="$MESSAGE"
+    gh workflow run "$WORKFLOW" -R "$REPO" -f agent="$AGENT" -f message="$MESSAGE" $MODEL_ARG
   fi
 done
 

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -2,6 +2,7 @@
 #MISE description="Send a message to an agent (wakes them without a specific job)"
 #USAGE arg "<agent>" help="Agent to message (e.g., quick, brownie)"
 #USAGE arg "<message>" help="Message for the agent"
+#USAGE flag "--model <model>" help="Claude model to use"
 
 set -e
 
@@ -55,6 +56,7 @@ fi
 
 AGENT="$1"
 MESSAGE="$2"
+MODEL="${usage_model:-}"
 REPO=$(get_repo)
 WORKFLOW="agent-message.yml"
 
@@ -65,7 +67,12 @@ if ! get_agents | grep -qx "$AGENT"; then
   exit 1
 fi
 
-gh workflow run "$WORKFLOW" -R "$REPO" -f agent="$AGENT" -f message="$MESSAGE"
+MODEL_ARG=""
+if [ -n "$MODEL" ]; then
+  MODEL_ARG="-f model=$MODEL"
+fi
+
+gh workflow run "$WORKFLOW" -R "$REPO" -f agent="$AGENT" -f message="$MESSAGE" $MODEL_ARG
 
 echo "Sent message to $AGENT on $REPO"
 

--- a/.mise/tasks/agent/run
+++ b/.mise/tasks/agent/run
@@ -6,6 +6,7 @@
 #USAGE flag "--passphrase <phrase>" help="Admin override passphrase"
 #USAGE flag "--system-prompt-file <file>" help="Path to system prompt file"
 #USAGE flag "--job <job>" help="Job name (used to find job prompt)"
+#USAGE flag "--model <model>" help="Claude model to use"
 
 set -e
 
@@ -19,6 +20,7 @@ TIMEOUT="${usage_timeout:-540}"
 PASSPHRASE="${usage_passphrase:-}"
 SYSTEM_PROMPT_FILE="${usage_system_prompt_file:-}"
 JOB="${usage_job:-}"
+MODEL="${usage_model:-}"
 
 # Get the caller's directory (where shimmer was invoked from)
 CALLER_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
@@ -72,6 +74,10 @@ CLI_ARGS=(
 
 if [ -n "$PASSPHRASE" ]; then
   CLI_ARGS+=(--passphrase "$PASSPHRASE")
+fi
+
+if [ -n "$MODEL" ]; then
+  CLI_ARGS+=(--model "$MODEL")
 fi
 
 # Run the CLI

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -45,16 +45,22 @@ if [[ "$WORKFLOW_COUNT" -gt 0 ]]; then
     AGENT=$(yq -r ".workflows[$i].agent" workflows.yaml)
     SCHEDULE=$(yq -r ".workflows[$i].schedule" workflows.yaml)
     MESSAGE=$(yq -r ".workflows[$i].message" workflows.yaml)
+    MODEL=$(yq -r ".workflows[$i].model // \"\"" workflows.yaml)
     AGENT_UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]')
 
     OUTPUT_FILE="$OUTPUT_DIR/${NAME}.yml"
 
     # Export for envsubst, using temp file for message to handle special chars
-    export NAME AGENT SCHEDULE AGENT_UPPER
+    export NAME AGENT SCHEDULE AGENT_UPPER MODEL
 
     # Use sed to replace MESSAGE separately (envsubst doesn't handle multiline well)
-    envsubst '${NAME} ${AGENT} ${SCHEDULE} ${AGENT_UPPER}' < "$TEMPLATE" | \
+    envsubst '${NAME} ${AGENT} ${SCHEDULE} ${AGENT_UPPER} ${MODEL}' < "$TEMPLATE" | \
       sed "s|\${MESSAGE}|$MESSAGE|g" > "$OUTPUT_FILE"
+
+    # Remove empty model line if no model specified
+    if [[ -z "$MODEL" ]]; then
+      sed -i '' '/^      model: *$/d' "$OUTPUT_FILE"
+    fi
 
     echo "Generated: ${NAME}.yml"
   done

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -38,6 +38,15 @@
         "message": {
           "type": "string",
           "description": "Message/instruction for the agent"
+        },
+        "model": {
+          "type": "string",
+          "description": "Claude model to use (defaults to opus if not specified)",
+          "enum": [
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Summary

- Adds `model` field to workflows.yaml schema for per-workflow model selection
- Plumbs model through the entire chain: workflows.yaml → templates → tasks → CLI
- Enables cost optimization by using cheaper models for well-defined tasks

## Changes

| File | Change |
|------|--------|
| `workflows.schema.json` | Added `model` enum (opus/sonnet/haiku 4.5) |
| `agent:run` task | Added `--model` flag |
| `agent:message` task | Added `--model` flag |
| `agent:broadcast` task | Added `--model` flag |
| `agent-run.yml` template | Accepts model input, passes to CLI |
| `agent-scheduled.yml` template | Passes model input |
| `agent-message.yml` template | Passes model to all 8 agent jobs |
| `workflows/generate` | Extracts model, removes empty line if unset |

## Usage

```yaml
workflows:
  - name: ghl-referral
    agent: c0da
    model: claude-sonnet-4-5-20250929  # optional, defaults to opus
    schedule: "*/30 14-22 * * 1-5"
    message: "..."
```

## Test plan

- [x] `workflows:generate` works with no model (omits line)
- [x] `workflows:generate` works with model specified (includes line)
- [x] Generated YAML is valid

Closes #524

🤖 Generated with [Claude Code](https://claude.ai/code)