### PR TITLE
Improve zettel:welcome for session catchup

### DIFF
--- a/.mise/tasks/zettel/welcome
+++ b/.mise/tasks/zettel/welcome
@@ -169,36 +169,40 @@ for dir in inbox 00_Inbox; do
   fi
 done
 
-# Only show structure if at least one standard dir exists
-if [ -n "$INBOX_DIR" ] || [ -n "$SESSIONS_DIR" ] || [ -n "$NOTES_DIR" ]; then
-  echo "  Structure:"
+# Structure - always show to teach the convention
+echo "  Structure:"
 
-  # Inbox first - encourages processing pending items
-  if [ -n "$INBOX_DIR" ]; then
-    printf "    %-12s → %s/\n" "$INBOX_COUNT pending" "$INBOX_DIR"
-  fi
-
-  # Sessions (more likely to be reviewed than notes)
-  if [ -n "$SESSIONS_DIR" ]; then
-    printf "    %-12s → %s/\n" "$SESSIONS_COUNT sessions" "$SESSIONS_DIR"
-  fi
-
-  # Notes (permanent atomic notes)
-  if [ -n "$NOTES_DIR" ]; then
-    printf "    %-12s → %s/\n" "$NOTES_COUNT notes" "$NOTES_DIR"
-  fi
-
-  # Uncategorized (files not in standard dirs, excluding README.md)
-  TOTAL_COUNT=$(find "$ZETTEL_DIR" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
-  CATEGORIZED=$((NOTES_COUNT + SESSIONS_COUNT + INBOX_COUNT))
-  [ "$HAS_README" = true ] && CATEGORIZED=$((CATEGORIZED + 1))
-  UNCATEGORIZED=$((TOTAL_COUNT - CATEGORIZED))
-  if [ "$UNCATEGORIZED" -gt 0 ]; then
-    printf "    %-12s %s\n" "$UNCATEGORIZED other" "(in root or other dirs)"
-  fi
-
-  echo ""
+# Inbox first - encourages processing pending items
+if [ -n "$INBOX_DIR" ]; then
+  printf "    %-12s → %s/\n" "$INBOX_COUNT pending" "$INBOX_DIR"
+else
+  printf "    %-12s → %s/\n" "0 pending" "inbox"
 fi
+
+# Sessions (more likely to be reviewed than notes)
+if [ -n "$SESSIONS_DIR" ]; then
+  printf "    %-12s → %s/\n" "$SESSIONS_COUNT sessions" "$SESSIONS_DIR"
+else
+  printf "    %-12s → %s/\n" "0 sessions" "sessions"
+fi
+
+# Notes (permanent atomic notes)
+if [ -n "$NOTES_DIR" ]; then
+  printf "    %-12s → %s/\n" "$NOTES_COUNT notes" "$NOTES_DIR"
+else
+  printf "    %-12s → %s/\n" "0 notes" "notes"
+fi
+
+# Uncategorized (files not in standard dirs, excluding README.md)
+TOTAL_COUNT=$(find "$ZETTEL_DIR" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+CATEGORIZED=$((NOTES_COUNT + SESSIONS_COUNT + INBOX_COUNT))
+[ "$HAS_README" = true ] && CATEGORIZED=$((CATEGORIZED + 1))
+UNCATEGORIZED=$((TOTAL_COUNT - CATEGORIZED))
+if [ "$UNCATEGORIZED" -gt 0 ]; then
+  printf "    %-12s %s\n" "$UNCATEGORIZED other" "(in root or other dirs)"
+fi
+
+echo ""
 
 # Git status (brief) - only show if there's something notable
 if [ -d "$ZETTEL_DIR/.git" ]; then


### PR DESCRIPTION
## Summary

Redesigned `shimmer zettel:welcome` to help agents quickly orient when starting a session. The previous version had too much boilerplate and didn't surface what agents actually need: recent activity and structure.

## Before
```
Zettelkasten
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

A zettelkasten ("slip-box") is your external memory...
[30+ lines of explanation]

Recent notes:
  index.md

[self-discovery procedure]
```

## After
```
Zettelkasten
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Path:      /Users/rikonor/agents/brownie/zettelkasten
  README.md: ✓

  Last active: 7 seconds ago

  Recent activity:
    2026-02-01  notes/zettelkasten-tooling-ideas.md
    2026-02-01  sessions/2026-02-01-gpg-setup-fix.md
    2026-01-31  notes/wallpapers.md
    ...

  Structure:
    1 pending    → inbox/
    5 sessions   → sessions/
    4 notes      → notes/

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Search: shimmer zettel:search <query>
```

## Changes

- **Path and README.md at top** - orientation first
- **"Last active"** - time since last work (git-based)
- **Recent activity with dates** - across all subdirs, not just root
- **Structure section** - encourages standard layout (inbox → sessions → notes)
- **Removed boilerplate** - kept only for empty zettelkastens

## Context

Inspired by c0da's email about surfacing recent work. See ricon-family/zettelkasten#4 for discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)