### PR TITLE
Fix ci:logs selecting wrong job in multi-agent runs

### DIFF
--- a/.mise/tasks/ci/logs
+++ b/.mise/tasks/ci/logs
@@ -71,7 +71,7 @@ if [[ -f "$CACHE_FILE" ]] && [[ "$NO_CACHE" != "true" ]] && [[ "$RUN_STATUS" == 
 else
   # Get the first non-skipped job (skipped jobs are common in multi-agent dispatch runs)
   JOB_INFO=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs \
-    -q '([.jobs[] | select(.conclusion == "skipped" | not)] | if length > 0 then .[0] else .[0] end) | {id: .databaseId, status: .status}')
+    -q '(([.jobs[] | select(.conclusion == "skipped" | not)][0]) // .jobs[0]) | {id: .databaseId, status: .status}')
   JOB_ID=$(echo "$JOB_INFO" | jq -r '.id')
   JOB_STATUS=$(echo "$JOB_INFO" | jq -r '.status')
 


### PR DESCRIPTION
## Summary

- `ci:logs` used `.jobs[0]` to select which job to fetch logs for and poll during `--wait`
- In multi-agent dispatch runs, `.jobs[0]` is the sender (skipped immediately), not the target agent
- This caused `--wait` to skip the polling loop (sender already "completed") and fetched empty logs
- Now selects the first non-skipped job, and polls the correct job by ID

## Test plan

- [ ] `shimmer ci:logs <multi-agent-run> --agent --repo ricon-family/fold` — fetches the correct agent's logs
- [ ] `shimmer ci:logs <in-progress-run> --wait --agent --repo ricon-family/fold` — waits for the right job
- [ ] `shimmer ci:logs <single-job-run>` — still works (no skipped jobs to filter)

Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)