### PR TITLE
Add AGENT_HOME env var for location-independent agent tasks

### DIFF
--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -8,7 +8,7 @@
 set -e
 
 # Get the caller's directory (where shimmer was invoked from)
-CALLER_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${AGENT_HOME:-${SHIMMER_CALLER_PWD:-$(pwd)}}"
 
 # Validate this is an agent home
 validate_agent_home() {

--- a/.mise/tasks/agent/list
+++ b/.mise/tasks/agent/list
@@ -4,7 +4,7 @@
 set -e
 
 # Get the caller's directory (where shimmer was invoked from)
-CALLER_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${AGENT_HOME:-${SHIMMER_CALLER_PWD:-$(pwd)}}"
 
 echo ""
 echo "Available Agents"

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -7,7 +7,7 @@
 set -e
 
 # Get the caller's directory (where shimmer was invoked from)
-CALLER_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${AGENT_HOME:-${SHIMMER_CALLER_PWD:-$(pwd)}}"
 
 # Validate this is an agent home
 validate_agent_home() {

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -56,6 +56,7 @@ echo "export GIT_AUTHOR_EMAIL='$EMAIL'"
 echo "export GIT_COMMITTER_EMAIL='$EMAIL'"
 echo "export GIT_AUTHOR_NAME='$AGENT'"
 echo "export GIT_COMMITTER_NAME='$AGENT'"
+echo "export AGENT_HOME='$(dirname "$AGENTS_DIR")'"
 
 # Print info to stderr so it doesn't interfere with eval
 echo "# Agent identity set: $AGENT ($EMAIL)" >&2


### PR DESCRIPTION
## Summary

- `shimmer as` now exports `AGENT_HOME` pointing to the agent's home repo (fold)
- `agent:message`, `agent:broadcast`, and `agent:list` check `AGENT_HOME` first, falling back to `SHIMMER_CALLER_PWD` then `pwd`
- Agents can now message each other from any working directory, not just fold

## Problem

`shimmer agent:message` required the caller to be in a directory with `agents/` and an `agent-message.yml` workflow. If you were in any other repo:

```
Error: No agents/ directory in /path/to/other/repo
```

This was confusing — "message an agent" should work from anywhere.

## Solution

Agents already carry env vars (`GIT_AUTHOR_EMAIL`, `GH_TOKEN`, etc.) that shimmer relies on. `AGENT_HOME` is a natural addition — it's set once by `shimmer as` and used by any task that needs the home context.

Fallback chain: `AGENT_HOME` → `SHIMMER_CALLER_PWD` → `pwd`

## Test plan

- [x] `shimmer as brownie` outputs `export AGENT_HOME='/Users/.../fold'`
- [x] `shimmer agent:list` works from shimmer repo (resolved via `AGENT_HOME`)
- [x] `shimmer agent:message johnson "..."` works from shimmer repo
- [x] Without `AGENT_HOME`, existing behavior preserved (falls back to `SHIMMER_CALLER_PWD`)

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)