### PR TITLE
Show zettelkasten sync status in welcome commands

### DIFF
--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -146,7 +146,21 @@ if [ -n "$AGENT" ]; then
   ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
   if [ -d "$ZETTEL_DIR" ]; then
     NOTE_COUNT=$(find "$ZETTEL_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
-    print_status "Zettel" "✓" "$NOTE_COUNT notes" "shimmer zettel:welcome"
+    # Check if behind remote
+    ZETTEL_BEHIND=0
+    if [ -d "$ZETTEL_DIR/.git" ]; then
+      ZETTEL_TRACKING=$(git -C "$ZETTEL_DIR" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo "")
+      if [ -n "$ZETTEL_TRACKING" ]; then
+        if timeout 5 git -C "$ZETTEL_DIR" fetch origin 2>/dev/null; then
+          ZETTEL_BEHIND=$(git -C "$ZETTEL_DIR" rev-list --count HEAD.."$ZETTEL_TRACKING" 2>/dev/null || echo 0)
+        fi
+      fi
+    fi
+    if [ "$ZETTEL_BEHIND" -gt 0 ]; then
+      print_status "Zettel" "⚠" "$NOTE_COUNT notes ($ZETTEL_BEHIND behind remote)" "cd $ZETTEL_DIR && git pull"
+    else
+      print_status "Zettel" "✓" "$NOTE_COUNT notes" "shimmer zettel:welcome"
+    fi
   else
     print_status "Zettel" "✗" "none yet" "shimmer zettel:welcome"
   fi

--- a/.mise/tasks/zettel/welcome
+++ b/.mise/tasks/zettel/welcome
@@ -206,8 +206,39 @@ echo ""
 
 # Git status (brief) - only show if there's something notable
 if [ -d "$ZETTEL_DIR/.git" ]; then
+  # Check for uncommitted changes
+  DIRTY=false
   if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-    echo "  Git: uncommitted changes"
+    DIRTY=true
+  fi
+
+  # Check sync status with remote (fetch with timeout, graceful failure if offline)
+  BEHIND=0
+  AHEAD=0
+  TRACKING=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo "")
+  if [ -n "$TRACKING" ]; then
+    if timeout 5 git fetch origin 2>/dev/null; then
+      BEHIND=$(git rev-list --count HEAD.."$TRACKING" 2>/dev/null || echo 0)
+      AHEAD=$(git rev-list --count "$TRACKING"..HEAD 2>/dev/null || echo 0)
+    fi
+  fi
+
+  # Build status message (only show when something is notable)
+  GIT_PARTS=()
+  if [ "$DIRTY" = true ]; then
+    GIT_PARTS+=("uncommitted changes")
+  fi
+  if [ "$AHEAD" -gt 0 ] && [ "$BEHIND" -gt 0 ]; then
+    GIT_PARTS+=("$AHEAD ahead, $BEHIND behind $TRACKING")
+  elif [ "$BEHIND" -gt 0 ]; then
+    GIT_PARTS+=("$BEHIND behind $TRACKING (run: git pull)")
+  elif [ "$AHEAD" -gt 0 ]; then
+    GIT_PARTS+=("$AHEAD ahead of $TRACKING (run: git push)")
+  fi
+
+  if [ ${#GIT_PARTS[@]} -gt 0 ]; then
+    GIT_MSG=$(printf '%s, ' "${GIT_PARTS[@]}")
+    echo "  Git: ${GIT_MSG%, }"
     echo ""
   fi
 fi


### PR DESCRIPTION
## Summary

- `zettel:welcome` now fetches from origin and shows ahead/behind status alongside uncommitted changes
- `welcome` health check flags `⚠` when the zettelkasten is behind remote, with a `git pull` hint

Agents running locally often have stale zettelkasten clones (CI runs push new commits). Previously there was no indication of this — they'd work with outdated notes without knowing.

Closes #518

## Test plan

- [ ] Run `shimmer zettel:welcome` — verify sync status appears when behind
- [ ] Run `shimmer welcome` — verify Zettel line shows `⚠` when behind, `✓` when up to date
- [ ] Test offline/no-remote — verify graceful failure (no error output, sync info just omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)