### PR TITLE
Refactor agent:broadcast to delegate to agent:message

### DIFF
--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -17,6 +17,12 @@ if [ ! -d "$CALLER_DIR/agents" ]; then
   exit 1
 fi
 
+if [ ! -f "$CALLER_DIR/.github/workflows/agent-message.yml" ]; then
+  echo "Error: No agent-message.yml workflow in $CALLER_DIR" >&2
+  echo "Run this from an agent home (a codebase with agents/ and agent workflows)" >&2
+  exit 1
+fi
+
 MESSAGE="$usage_message"
 STAGGER="${usage_stagger:-30}"
 DRY_RUN="${usage_dry_run:-false}"

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -41,19 +41,6 @@ get_repo() {
 
 validate_agent_home
 
-if [ $# -lt 2 ]; then
-  echo "Usage: shimmer agent:message <agent> <message>"
-  echo ""
-  echo "Sends a message to an agent, waking them without a specific job."
-  echo "The agent receives the message and decides how to respond."
-  echo ""
-  echo "Agent home: $CALLER_DIR"
-  echo "Agents: $(get_agents | tr '\n' ' ')"
-  echo ""
-  echo "Example: shimmer agent:message quick \"Please vote on issue #467\""
-  exit 1
-fi
-
 AGENT="$usage_agent"
 MESSAGE="$usage_message"
 MODEL="${usage_model:-}"


### PR DESCRIPTION
## Summary

- `agent:broadcast` now calls `shimmer agent:message` for each agent instead of duplicating the workflow dispatch logic
- Adds `--agents` flag for targeting a subset: `shimmer agent:broadcast --agents quick,brownie "message"`
- Fixes `$1`/`$2` positional arg usage in `agent:message` (same flag-parsing bug fixed in broadcast via c83b9b6)
- Validates agent names when using `--agents`, with clear error on unknown agents

Net: -62 lines added, +36 lines — simpler code with more functionality.

Closes #557

## Test plan

- [x] `shimmer agent:broadcast --dry-run "msg"` — all 8 agents
- [x] `shimmer agent:broadcast --dry-run --agents quick,brownie "msg"` — subset
- [x] `shimmer agent:broadcast --dry-run --agents quick,fakename "msg"` — error on invalid agent
- [x] `shimmer agent:broadcast --dry-run --stagger 0 --agents quick "msg"` — flag ordering
- [x] `shimmer agent:message --help` — still works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)