### PR TITLE
Add ci:wait task and shared duration parser

### DIFF
--- a/.mise/tasks/_parse-duration
+++ b/.mise/tasks/_parse-duration
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE hide=true
+#MISE description="Parse a human-friendly duration string into seconds"
+
+set -e
+
+INPUT="${1:-}"
+
+if [ -z "$INPUT" ]; then
+  echo "Usage: _parse-duration <duration>" >&2
+  echo "Examples: 300, 30s, 5m, 1h, forever" >&2
+  exit 1
+fi
+
+if [ "$INPUT" = "forever" ]; then
+  echo "-1"
+  exit 0
+fi
+
+# Match number with optional suffix
+if [[ "$INPUT" =~ ^([0-9]+)([smh])?$ ]]; then
+  VALUE="${BASH_REMATCH[1]}"
+  SUFFIX="${BASH_REMATCH[2]}"
+
+  case "$SUFFIX" in
+    s|"") echo "$VALUE" ;;
+    m)    echo $((VALUE * 60)) ;;
+    h)    echo $((VALUE * 3600)) ;;
+  esac
+  exit 0
+fi
+
+echo "Invalid duration: $INPUT (expected: 300, 30s, 5m, 1h, or forever)" >&2
+exit 1

--- a/.mise/tasks/ci/logs
+++ b/.mise/tasks/ci/logs
@@ -8,7 +8,7 @@
 #USAGE flag "--info" help="Show log metadata (total lines, jobs) without content"
 #USAGE flag "--agent" help="Show only the agent session (between markers)"
 #USAGE flag "--repo <repo>" help="Repository (owner/name), defaults to current directory's repo"
-#USAGE flag "--wait [timeout]" help="Wait for job to complete (default: 600s, or 'forever')"
+#USAGE flag "--wait [timeout]" help="Wait for run to complete (default: 600s, supports 5m/1h/forever)"
 
 set -e
 
@@ -31,17 +31,12 @@ INFO_ONLY="${usage_info:-false}"
 AGENT_ONLY="${usage_agent:-false}"
 
 # Parse --wait flag
-# Supports: --wait (default 600s), --wait <seconds>, --wait forever
 # Uses raw args check because mise doesn't set usage_wait for bare --wait
 WAIT_TIMEOUT=""
 if [[ -n "${usage_wait:-}" ]]; then
-  if [[ "$usage_wait" == "forever" ]]; then
-    WAIT_TIMEOUT=-1
-  else
-    WAIT_TIMEOUT="$usage_wait"
-  fi
+  WAIT_TIMEOUT="$usage_wait"
 elif [[ " $* " == *" --wait "* ]] || [[ "$*" == "--wait" ]] || [[ "$*" == *" --wait" ]]; then
-  WAIT_TIMEOUT=600
+  WAIT_TIMEOUT="600"
 fi
 
 if [[ -z "$RUN_ID_ARG" ]]; then
@@ -75,27 +70,14 @@ else
   JOB_ID=$(echo "$JOB_INFO" | jq -r '.id')
   JOB_STATUS=$(echo "$JOB_INFO" | jq -r '.status')
 
-  if [[ "$JOB_STATUS" == "in_progress" ]] || [[ "$JOB_STATUS" == "queued" ]]; then
+  if [[ "$JOB_STATUS" == "in_progress" ]] || [[ "$JOB_STATUS" == "queued" ]] || [[ "$JOB_STATUS" == "waiting" ]]; then
     if [[ -z "$WAIT_TIMEOUT" ]]; then
       echo "job $JOB_ID is still $JOB_STATUS; logs will be available when it is complete"
       echo "Tip: use --wait to wait for completion"
       exit 1
     fi
 
-    # Poll until job completes or timeout
-    ELAPSED=0
-    while [[ "$JOB_STATUS" == "in_progress" ]] || [[ "$JOB_STATUS" == "queued" ]]; do
-      printf "\rWaiting for job $JOB_ID ($JOB_STATUS)... ${ELAPSED}s"
-      sleep 10
-      ELAPSED=$((ELAPSED + 10))
-      if [[ "$WAIT_TIMEOUT" -gt 0 ]] && [[ "$ELAPSED" -ge "$WAIT_TIMEOUT" ]]; then
-        echo ""
-        echo "Timeout after ${ELAPSED}s"
-        exit 1
-      fi
-      JOB_STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs -q "[.jobs[] | select(.databaseId == $JOB_ID)][0].status")
-    done
-    echo ""  # newline after \r progress
+    shimmer ci:wait "$RUN_ID" --repo "$REPO" --timeout "$WAIT_TIMEOUT" > /dev/null
   fi
 
   gh run view --repo "$REPO" --job="$JOB_ID" --log 2>&1 > "$CACHE_FILE"

--- a/.mise/tasks/ci/wait
+++ b/.mise/tasks/ci/wait
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#MISE description="Wait for a workflow run to complete"
+#USAGE arg "<run_id>" help="Run ID (numeric) or workflow name"
+#USAGE flag "--timeout <duration>" help="Max wait time (default: 600s, supports 5m/1h/forever)"
+#USAGE flag "--interval <seconds>" help="Poll interval in seconds (default: 10)"
+#USAGE flag "--repo <repo>" help="Repository (owner/name), defaults to current directory's repo"
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+
+# Determine repo
+if [[ -n "${usage_repo:-}" ]]; then
+  REPO="$usage_repo"
+else
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
+fi
+
+# Parse timeout
+TIMEOUT=$("$SCRIPT_DIR/../_parse-duration" "${usage_timeout:-600}")
+INTERVAL="${usage_interval:-10}"
+
+RUN_ID_ARG="${usage_run_id:-}"
+
+if [[ -z "$RUN_ID_ARG" ]]; then
+  echo "Usage: ci:wait <run_id> [--repo owner/name] [--timeout duration] [--interval seconds]" >&2
+  exit 1
+fi
+
+# Resolve workflow name to run ID if not numeric
+if [[ "$RUN_ID_ARG" =~ ^[0-9]+$ ]]; then
+  RUN_ID="$RUN_ID_ARG"
+else
+  WORKFLOW="$RUN_ID_ARG"
+  RUN_ID=$(gh run list --repo "$REPO" --workflow="$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId')
+  if [[ -z "$RUN_ID" ]]; then
+    echo "No runs found for workflow: $WORKFLOW" >&2
+    exit 1
+  fi
+fi
+
+# Check current status
+RUN_JSON=$(gh run view "$RUN_ID" --repo "$REPO" --json status,conclusion)
+RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+
+if [[ "$RUN_STATUS" == "completed" ]]; then
+  echo "$RUN_JSON" | jq -r '.conclusion'
+  exit 0
+fi
+
+if [[ "$RUN_STATUS" != "in_progress" ]] && [[ "$RUN_STATUS" != "queued" ]] && [[ "$RUN_STATUS" != "waiting" ]]; then
+  echo "Warning: unexpected run status: $RUN_STATUS" >&2
+fi
+
+# Poll until complete or timeout
+ELAPSED=0
+while [[ "$RUN_STATUS" != "completed" ]]; do
+  printf "\rWaiting for run %s (%s)... %ds" "$RUN_ID" "$RUN_STATUS" "$ELAPSED" >&2
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+
+  if [[ "$TIMEOUT" -gt 0 ]] && [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
+    echo "" >&2
+    echo "Timeout after ${ELAPSED}s" >&2
+    exit 1
+  fi
+
+  RUN_STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status -q '.status')
+done
+
+echo "" >&2
+
+# Output final conclusion
+CONCLUSION=$(gh run view "$RUN_ID" --repo "$REPO" --json conclusion -q '.conclusion')
+echo "$CONCLUSION"

--- a/.mise/tasks/email/wait
+++ b/.mise/tasks/email/wait
@@ -2,7 +2,7 @@
 #MISE description="Wait for new email to arrive"
 #USAGE flag "-f --folder <folder>" help="Folder to watch (default: INBOX)"
 #USAGE flag "-n --count <n>" help="Wait for at least N new messages (default: 1)"
-#USAGE flag "--timeout <seconds>" help="Max wait time in seconds (default: 600, or 'forever')"
+#USAGE flag "--timeout <duration>" help="Max wait time (default: 600s, supports 5m/1h/forever)"
 #USAGE flag "--interval <seconds>" help="Poll interval in seconds (default: 30)"
 #USAGE arg "[query...]" var=#true help="Optional himalaya query filter (e.g. 'from groups.io')"
 
@@ -16,11 +16,8 @@ COUNT="${usage_count:-1}"
 INTERVAL="${usage_interval:-30}"
 
 # Parse timeout
-if [[ "${usage_timeout:-}" == "forever" ]]; then
-  TIMEOUT=-1
-else
-  TIMEOUT="${usage_timeout:-600}"
-fi
+SCRIPT_DIR="$(dirname "$0")"
+TIMEOUT=$("$SCRIPT_DIR/../_parse-duration" "${usage_timeout:-600}")
 
 # Parse optional query (variadic args - mise passes as shell-escaped string)
 # Use eval to strip mise's quoting, same pattern as email:delete


### PR DESCRIPTION
## Summary
- New `ci:wait` task — standalone polling for workflow run completion
- New `_parse-duration` helper — converts human-friendly durations (`5m`, `1h`, `forever`) to seconds
- `ci:logs --wait` now delegates to `ci:wait` instead of inline polling
- `email:wait --timeout` now uses `_parse-duration` (gains `5m`/`1h` support for free)

## Test plan
- [x] `_parse-duration`: `300` → 300, `5m` → 300, `1h` → 3600, `30s` → 30, `forever` → -1, `garbage` → error
- [x] `ci:wait <completed-run>` — returns conclusion immediately
- [x] `ci:wait --help` — shows usage with duration examples
- [x] `ci:logs <run> --wait --info` — still works, delegates to ci:wait

Closes #533, closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)