### PR TITLE
Add shim so shimmer is callable from subprocesses

### DIFF
--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 #MISE description="Output shell configuration for global shimmer command (use with eval)"
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-# Pass caller's PWD so tasks can know where shimmer was invoked from
+
+# Create shim so shimmer is callable from scripts and subprocesses
+BIN_DIR="$HOME/.local/bin"
+BIN="$BIN_DIR/shimmer"
+mkdir -p "$BIN_DIR"
+cat > "$BIN" <<SCRIPT
+#!/usr/bin/env bash
+SHIMMER_CALLER_PWD="\${SHIMMER_CALLER_PWD:-\$PWD}" exec mise -C "$REPO_DIR" run "\$@"
+SCRIPT
+chmod +x "$BIN"
+
+# Ensure ~/.local/bin is on PATH (skip if already there)
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) echo "export PATH=\"$BIN_DIR:\$PATH\"" ;;
+esac
+
+# Shell alias (captures caller's PWD for interactive use)
 echo "alias shimmer='SHIMMER_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"


### PR DESCRIPTION
## Summary

- The `shell` task now creates a shim at `~/.local/bin/shimmer` alongside the existing alias
- This makes `shimmer` callable from scripts, mise tasks, and other non-interactive contexts where shell aliases aren't available
- PATH export for `~/.local/bin` is only added if not already present

## Context

Discovered while building a quiz runner in the frames repo — mise tasks that tried to call `shimmer agent:run` failed because the alias doesn't exist in script context. The shim solves this without changing the existing alias-based workflow.

## Test plan

- [ ] `eval "$(mise -C ~/shimmer run -q shell)"` still outputs alias
- [ ] `~/.local/bin/shimmer whoami` works
- [ ] Calling `shimmer` from within a mise task works
- [ ] PATH export is skipped when `~/.local/bin` is already on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)