### PR TITLE
Warn when shim points to a stale repo path

### DIFF
--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -8,7 +8,13 @@ BIN="$BIN_DIR/shimmer"
 mkdir -p "$BIN_DIR"
 cat > "$BIN" <<SCRIPT
 #!/usr/bin/env bash
-SHIMMER_CALLER_PWD="\${SHIMMER_CALLER_PWD:-\$PWD}" exec mise -C "$REPO_DIR" run "\$@"
+REPO="$REPO_DIR"
+if [ ! -d "\$REPO" ]; then
+  echo "shimmer: repo not found at \$REPO" >&2
+  echo "shimmer: re-run 'eval \"\\\$(mise -C /path/to/shimmer run -q shell)\"' to fix" >&2
+  exit 1
+fi
+SHIMMER_CALLER_PWD="\${SHIMMER_CALLER_PWD:-\$PWD}" exec mise -C "\$REPO" run "\$@"
 SCRIPT
 chmod +x "$BIN"
 


### PR DESCRIPTION
## Summary

- The shim now checks if the shimmer repo exists before trying to invoke it
- If the path is stale (repo moved/deleted), prints a clear error with instructions to fix

Follow-up to #569 — addresses c0da's feedback about baked-in `$REPO_DIR`.

## Test plan

- [ ] Normal `shimmer` invocation via shim still works
- [ ] Moving/deleting the shimmer repo and calling the shim shows the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)