### PR TITLE
Add calendar:* tasks using calendula + mxroute CalDAV

### DIFF
--- a/.mise/tasks/calendar/events
+++ b/.mise/tasks/calendar/events
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#MISE description="List calendar events"
+#USAGE arg "[calendar]" help="Calendar ID (default: calendar)"
+
+set -e
+
+if ! command -v calendula &> /dev/null; then
+  echo "ERROR: calendula not found. Run: mise install" >&2
+  exit 1
+fi
+
+CALENDAR="${usage_calendar:-calendar}"
+
+calendula items list "$CALENDAR"

--- a/.mise/tasks/calendar/events
+++ b/.mise/tasks/calendar/events
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #MISE description="List calendar events"
-#USAGE arg "[calendar]" help="Calendar ID (default: calendar)"
+#USAGE arg "<calendar>" help="Calendar ID (run calendar:list to see available calendars)"
 
-set -e
+set -eu
 
 if ! command -v calendula &> /dev/null; then
   echo "ERROR: calendula not found. Run: mise install" >&2
   exit 1
 fi
 
-CALENDAR="${usage_calendar:-calendar}"
+CALENDAR="${usage_calendar:?}"
 
 calendula items list "$CALENDAR"

--- a/.mise/tasks/calendar/list
+++ b/.mise/tasks/calendar/list
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#MISE description="List available calendars"
+
+set -e
+
+if ! command -v calendula &> /dev/null; then
+  echo "ERROR: calendula not found. Run: mise install" >&2
+  exit 1
+fi
+
+calendula calendars list "$@"

--- a/.mise/tasks/calendar/list
+++ b/.mise/tasks/calendar/list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="List available calendars"
 
-set -e
+set -eu
 
 if ! command -v calendula &> /dev/null; then
   echo "ERROR: calendula not found. Run: mise install" >&2

--- a/.mise/tasks/calendar/setup
+++ b/.mise/tasks/calendar/setup
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#MISE description="Setup calendar (calendula) for an agent (one-time local setup)"
+#USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
+
+set -e
+
+AGENT="${usage_agent:?}"
+EMAIL="${AGENT}@ricon.family"
+DAV_HOST="dav.mxroute.com"
+
+CONFIG_DIR="${HOME}/.config/calendula"
+CONFIG_FILE="${CONFIG_DIR}/config.toml"
+
+# Check if calendula is available
+if ! command -v calendula &> /dev/null; then
+  echo "ERROR: calendula command not found."
+  echo "Install with: mise install (calendula is managed by mise)"
+  exit 1
+fi
+
+# Check if already configured
+if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+  echo "Calendar already configured for $EMAIL"
+  echo "Config: $CONFIG_FILE"
+  echo ""
+  echo "To reconfigure, delete or edit the config file:"
+  echo "  rm $CONFIG_FILE"
+  echo "  \$EDITOR $CONFIG_FILE"
+  exit 0
+fi
+
+# Get password: env var > 1Password > error
+if [ -z "$EMAIL_PASSWORD" ]; then
+  if command -v op &> /dev/null && op account get &> /dev/null; then
+    echo "Fetching email password from 1Password..."
+    EMAIL_PASSWORD=$(op item get "${AGENT} - Email" --vault Agents --fields password --reveal 2>/dev/null || true)
+    if [ -n "$EMAIL_PASSWORD" ]; then
+      echo "Using password from 1Password"
+    fi
+  fi
+fi
+
+if [ -z "$EMAIL_PASSWORD" ]; then
+  echo "ERROR: Could not get email password for $AGENT"
+  echo ""
+  echo "Options:"
+  echo "  1. Sign into 1Password: op signin"
+  echo "  2. Set EMAIL_PASSWORD env var manually"
+  exit 1
+fi
+
+mkdir -p "$CONFIG_DIR"
+
+# Escape password for TOML basic string: backslash first, then quotes
+ESCAPED_PASSWORD=$(printf '%s' "$EMAIL_PASSWORD" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+# Build the account config block
+ACCOUNT_CONFIG=$(cat <<ACCOUNT_EOF
+[accounts.$AGENT]
+default = true
+
+caldav.discover.host = "$DAV_HOST"
+caldav.discover.port = 443
+caldav.discover.scheme = "https"
+
+caldav.auth.basic.username = "$EMAIL"
+caldav.auth.basic.password.raw = "$ESCAPED_PASSWORD"
+ACCOUNT_EOF
+)
+
+# Write or append config
+if [ -f "$CONFIG_FILE" ]; then
+  # Config exists - remove default=true from other accounts and append new one
+  sed -i.bak 's/^default = true$/default = false/' "$CONFIG_FILE"
+  rm -f "${CONFIG_FILE}.bak"
+  printf '\n%s\n' "$ACCOUNT_CONFIG" >> "$CONFIG_FILE"
+else
+  # Fresh config
+  printf '%s\n' "$ACCOUNT_CONFIG" > "$CONFIG_FILE"
+fi
+
+echo ""
+echo "Calendar configured for $EMAIL"
+echo "  Config: $CONFIG_FILE"
+echo "  CalDAV: https://$DAV_HOST"
+echo ""
+echo "Test with: calendula calendars list"

--- a/.mise/tasks/calendar/setup
+++ b/.mise/tasks/calendar/setup
@@ -2,7 +2,7 @@
 #MISE description="Setup calendar (calendula) for an agent (one-time local setup)"
 #USAGE arg "<agent>" help="Agent name (e.g., quick, brownie)"
 
-set -e
+set -eu
 
 AGENT="${usage_agent:?}"
 EMAIL="${AGENT}@ricon.family"
@@ -19,7 +19,7 @@ if ! command -v calendula &> /dev/null; then
 fi
 
 # Check if already configured
-if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
+if [ -f "$CONFIG_FILE" ] && grep -q "accounts\\.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
   echo "Calendar already configured for $EMAIL"
   echo "Config: $CONFIG_FILE"
   echo ""
@@ -50,8 +50,13 @@ if [ -z "$EMAIL_PASSWORD" ]; then
 fi
 
 mkdir -p "$CONFIG_DIR"
+chmod 700 "$CONFIG_DIR"
 
 # Escape password for TOML basic string: backslash first, then quotes
+# Note: this handles backslashes and double-quotes. If a password contains
+# control characters (tabs, newlines), this would produce invalid TOML.
+# Our 1Password-generated passwords don't contain these, but if they ever
+# do, switch to TOML literal strings or validate first.
 ESCAPED_PASSWORD=$(printf '%s' "$EMAIL_PASSWORD" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
 # Build the account config block
@@ -78,6 +83,9 @@ else
   # Fresh config
   printf '%s\n' "$ACCOUNT_CONFIG" > "$CONFIG_FILE"
 fi
+
+# Config contains raw password — restrict permissions
+chmod 600 "$CONFIG_FILE"
 
 echo ""
 echo "Calendar configured for $EMAIL"

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@ zig = "0.15.2"                            # Required for Burrito cross-compilati
 "npm:@anthropic-ai/claude-code" = "2.1.12" # Claude Code CLI
 "npm:claude-code-logger" = "latest"       # For inspecting Claude Code context
 "ubi:pimalaya/himalaya" = "1.1.0"         # Email CLI for agents
+"github:pimalaya/calendula" = "0.1.0"    # Calendar CLI for agents
 "1password-cli" = "2.32.0"                # Credential management
 "pipx:check-jsonschema" = "0.36.0"        # JSON Schema validation
 jq = "1.8.1"                              # JSON processing


### PR DESCRIPTION
## Summary
- Initial calendar support for agents using [calendula](https://github.com/pimalaya/calendula) (pimalaya project, same ecosystem as himalaya)
- `calendar:setup`: one-time config, mirrors `email:setup` — pulls password from 1Password, writes raw creds to calendula config
- `calendar:list`: list available calendars
- `calendar:events`: list events in a calendar
- Adds calendula `0.1.0` to `mise.toml` via `github:` backend

## Test plan
- [x] `calendar:setup` writes config with correct CalDAV endpoint (`dav.mxroute.com`)
- [x] `calendar:list` connects and lists calendars from mxroute
- [x] `calendar:events` lists events (empty calendar, but round-trip works)

## Next steps
- `calendar:add` — create events
- `calendar:welcome` — calendar status for orient flow
- Explore contributing upstream to calendula

Relates to #574