### PR TITLE
Add agent:local for interactive local sessions

### DIFF
--- a/.mise/tasks/agent/local
+++ b/.mise/tasks/agent/local
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#MISE description="Start a local interactive Claude session as an agent"
+#MISE quiet=true
+
+set -e
+
+# Derive agent name from environment (set by `shimmer as`)
+if [ -z "$GIT_AUTHOR_NAME" ]; then
+  echo "No agent identity detected. Run: eval \$(shimmer as <agent>)" >&2
+  exit 1
+fi
+AGENT="$GIT_AUTHOR_NAME"
+
+if [ -z "$AGENT_HOME" ]; then
+  echo "AGENT_HOME not set. Run: eval \$(shimmer as <agent>)" >&2
+  exit 1
+fi
+
+# Find agent identity file
+AGENT_FILE="${AGENT_HOME}/agents/${AGENT}.txt"
+if [ ! -f "$AGENT_FILE" ]; then
+  echo "Agent identity not found: $AGENT_FILE" >&2
+  exit 1
+fi
+
+# Read prompt and pass to claude. Double-quoted variable expansion is safe
+# against shell injection — special chars are not re-evaluated.
+PROMPT=$(cat "$AGENT_FILE")
+
+cd "${SHIMMER_CALLER_PWD:-.}"
+exec claude --append-system-prompt "$PROMPT"


### PR DESCRIPTION
## Summary

- New `shimmer agent:local` task starts an interactive `claude` session with the agent's identity prompt injected
- Derives agent name from `GIT_AUTHOR_NAME` (set by `shimmer as`)
- Finds identity file via `AGENT_HOME/agents/<name>.txt`
- Runs in the caller's directory (via `SHIMMER_CALLER_PWD`)

Usage:
```bash
eval $(shimmer as quick)
shimmer agent:local
```

This replaces the manual workflow of running bare `claude` after `shimmer as`, which doesn't inject the agent identity prompt.

Closes #528

## Test plan

- [x] Verified env var resolution (`GIT_AUTHOR_NAME`, `AGENT_HOME`)
- [x] Verified identity file found at correct path
- [ ] Manual test: run `shimmer agent:local` and confirm agent identity is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)