### PR TITLE
Update mise-action from v2 to v3

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -76,7 +76,7 @@ jobs:
           echo "Workspace: ~/$REPO_NAME, ~/shimmer, ~/agents/${{ inputs.agent }}"
 
       - name: Set up mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v3
         with:
           install: true
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v3
         with:
           install: true
 


### PR DESCRIPTION
## Summary

- Updates `jdx/mise-action` from `v2` to `v3` in both `agent-run.yml` template and `pr-check.yml`
- Picks up mise >= 2026.2.x which fixes `--help` being passed through to task scripts instead of showing help ([jdx/mise#7893](https://github.com/jdx/mise/pull/7893))

Closes #582

## Test plan

- [ ] PR check workflow runs successfully with the new action version
- [ ] After merge, regenerate downstream workflows (fold) and verify agent runs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)