### PR TITLE
Support multiple cron expressions in workflow schedule

### DIFF
--- a/.github/templates/agent-scheduled.yml
+++ b/.github/templates/agent-scheduled.yml
@@ -2,7 +2,7 @@ name: ${NAME}
 
 on:
   schedule:
-    - cron: '${SCHEDULE}'
+__SCHEDULE_ENTRIES__
   workflow_dispatch:
 
 jobs:

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -7,8 +7,8 @@ set -eo pipefail
 TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
 
-# Shimmer is always at ~/shimmer (where the global command lives)
-SHIMMER_DIR="$HOME/shimmer"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 # Use local template if exists, otherwise use shimmer's
 if [[ -f ".github/templates/agent-scheduled.yml" ]]; then
@@ -43,19 +43,35 @@ if [[ "$WORKFLOW_COUNT" -gt 0 ]]; then
   for i in $(seq 0 $((WORKFLOW_COUNT - 1))); do
     NAME=$(yq -r ".workflows[$i].name" workflows.yaml)
     AGENT=$(yq -r ".workflows[$i].agent" workflows.yaml)
-    SCHEDULE=$(yq -r ".workflows[$i].schedule" workflows.yaml)
     MESSAGE=$(yq -r ".workflows[$i].message" workflows.yaml)
     MODEL=$(yq -r ".workflows[$i].model // \"\"" workflows.yaml)
     AGENT_UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]')
 
+    # Build schedule entries (array of cron expressions)
+    SCHEDULE_ENTRIES=""
+    SCHEDULE_COUNT=$(yq -r ".workflows[$i].schedule | length" workflows.yaml)
+    for j in $(seq 0 $((SCHEDULE_COUNT - 1))); do
+      CRON=$(yq -r ".workflows[$i].schedule[$j]" workflows.yaml)
+      SCHEDULE_ENTRIES+="    - cron: '${CRON}'"$'\n'
+    done
+
     OUTPUT_FILE="$OUTPUT_DIR/${NAME}.yml"
 
     # Export for envsubst, using temp file for message to handle special chars
-    export NAME AGENT SCHEDULE AGENT_UPPER MODEL
+    export NAME AGENT AGENT_UPPER MODEL
 
     # Use sed to replace MESSAGE separately (envsubst doesn't handle multiline well)
-    envsubst '${NAME} ${AGENT} ${SCHEDULE} ${AGENT_UPPER} ${MODEL}' < "$TEMPLATE" | \
+    envsubst '${NAME} ${AGENT} ${AGENT_UPPER} ${MODEL}' < "$TEMPLATE" | \
       sed "s|\${MESSAGE}|$MESSAGE|g" > "$OUTPUT_FILE"
+
+    # Replace schedule placeholder with cron entries (sed r reads from file, handles multiline)
+    SCHED_TMP=$(mktemp)
+    printf '%s' "$SCHEDULE_ENTRIES" > "$SCHED_TMP"
+    sed -i '' -e "/__SCHEDULE_ENTRIES__/{
+r $SCHED_TMP
+d
+}" "$OUTPUT_FILE"
+    rm "$SCHED_TMP"
 
     # Remove empty model line if no model specified
     if [[ -z "$MODEL" ]]; then

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -31,9 +31,13 @@
           "description": "Agent to run (e.g., c0da, quick)"
         },
         "schedule": {
-          "type": "string",
-          "description": "Cron expression (e.g., '0 */4 * * *' for every 4 hours)",
-          "pattern": "^[0-9*,/-]+ [0-9*,/-]+ [0-9*,/-]+ [0-9*,/-]+ [0-9*,/-]+$"
+          "type": "array",
+          "description": "Cron expressions (e.g., ['0 */4 * * *'] for every 4 hours)",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9*,/-]+ [0-9*,/-]+ [0-9*,/-]+ [0-9*,/-]+ [0-9*,/-]+$"
+          },
+          "minItems": 1
         },
         "message": {
           "type": "string",


### PR DESCRIPTION
## Summary

- **Schema**: `schedule` field now takes an array of cron strings (was a single string)
- **Generator**: Builds multiple `- cron:` entries from the array, using sed file-read for clean multiline handling
- **Template**: Uses a placeholder replaced at generation time instead of envsubst
- **Bonus**: Fixed `SHIMMER_DIR` in generator to derive from script location (matching other tasks) instead of hardcoding `~/shimmer`

This is a **breaking change** to `workflows.yaml` format — existing files need to wrap their single cron in an array. The only consumer is fold, which needs a one-line update.

Example:
```yaml
# Before
schedule: "0 14,16,18,20,22 * * 1-5"

# After (single)
schedule:
  - "0 14,16,18,20,22 * * 1-5"

# After (multiple — the new capability)
schedule:
  - "0 14,16,18,20,22 * * 1-5"
  - "0 14,18,22 * * 0,6"
```

## Motivation

GHL referral workflow needs weekday + weekend schedules at different frequencies (every 2h vs every 4h). GitHub Actions supports multiple `- cron:` entries natively; we just needed our schema and generator to support it.

Closes #585

## Test plan

- [x] Tested single-cron array generates correctly (one `- cron:` line)
- [x] Tested multi-cron array generates correctly (multiple `- cron:` lines)
- [x] Tested via mise (`mise run workflows:generate`) end-to-end
- [x] Verified `SCRIPT_DIR`-based shimmer resolution works
- [ ] Update fold's `workflows.yaml` to array format after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)