### PR TITLE
Use mise run instead of shimmer for internal task calls

### DIFF
--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -77,7 +77,7 @@ for AGENT in $AGENTS; do
   if [ "$DRY_RUN" = "true" ]; then
     echo "[dry-run] Would message: $AGENT"
   else
-    shimmer agent:message "$AGENT" "$MESSAGE" $MODEL_ARG
+    mise run agent:message "$AGENT" "$MESSAGE" $MODEL_ARG
   fi
 done
 

--- a/.mise/tasks/ci/logs
+++ b/.mise/tasks/ci/logs
@@ -77,7 +77,7 @@ else
       exit 1
     fi
 
-    shimmer ci:wait "$RUN_ID" --repo "$REPO" --timeout "$WAIT_TIMEOUT" > /dev/null
+    mise run ci:wait "$RUN_ID" --repo "$REPO" --timeout "$WAIT_TIMEOUT" > /dev/null
   fi
 
   gh run view --repo "$REPO" --job="$JOB_ID" --log 2>&1 > "$CACHE_FILE"


### PR DESCRIPTION
## Summary

- `ci/logs` calls `shimmer ci:wait` internally — changed to `mise run ci:wait`
- `agent/broadcast` calls `shimmer agent:message` internally — changed to `mise run agent:message`

Using `shimmer` invokes the global shim, which bypasses the local clone. `mise run` stays within the current repo context.

Also fixed a stale `node_modules` symlink inside `.mise/tasks/browser/scripts/` that was causing mise to discover Playwright internals as tasks (e.g. `browser:scripts:node_modules:playwright:cli`). The symlink was a leftover from before `browser:setup` was updated to target the repo root — removed it and re-ran setup.

## Test plan

- [x] `shimmer tasks browser` no longer shows rogue `browser:scripts:node_modules:*` entries
- [ ] Verify `ci/logs --wait` still works (calls `mise run ci:wait` instead of `shimmer ci:wait`)
- [ ] Verify `agent/broadcast` still dispatches messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)