### PR TITLE
Replace Playwright with Patchright for browser automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ Thumbs.db
 # Build artifacts
 cli/shimmer
 
-# Browser automation (symlink to mise-installed playwright)
+# Browser automation (symlink to mise-installed patchright)
 node_modules

--- a/.mise/tasks/browser/launch
+++ b/.mise/tasks/browser/launch
@@ -38,10 +38,10 @@ if [ -f "$PID_FILE" ]; then
   rm -f "$PID_FILE"
 fi
 
-# Find Chromium binary via Playwright (run from scripts/ where node_modules lives)
+# Find Chromium binary via Patchright (run from scripts/ where node_modules lives)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHROMIUM_PATH=$(cd "$SCRIPT_DIR/scripts" && node -e "
-  import { chromium } from 'playwright';
+  import { chromium } from 'patchright';
   console.log(chromium.executablePath());
 " 2>/dev/null) || true
 

--- a/.mise/tasks/browser/scripts/_cdp.mjs
+++ b/.mise/tasks/browser/scripts/_cdp.mjs
@@ -5,7 +5,7 @@
 // Connects to a running Chromium via CDP, performs one action, disconnects.
 // The browser keeps running after disconnect.
 
-import { chromium } from 'playwright';
+import { chromium } from 'patchright';
 import { parseArgs } from 'node:util';
 import { readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { chmodSync } from 'node:fs';

--- a/.mise/tasks/browser/scripts/_harness.mjs
+++ b/.mise/tasks/browser/scripts/_harness.mjs
@@ -1,10 +1,10 @@
-// _harness.mjs — Playwright harness for shimmer browser tasks
+// _harness.mjs — Patchright harness for shimmer browser tasks
 //
 // Modes:
 //   login: Save storageState after authenticating (auto or interactive)
 //   run:   Load storageState, run a script module, close browser
 
-import { chromium } from 'playwright';
+import { chromium } from 'patchright';
 import { parseArgs } from 'node:util';
 import { existsSync, chmodSync } from 'node:fs';
 import { pathToFileURL, fileURLToPath } from 'node:url';

--- a/.mise/tasks/browser/setup
+++ b/.mise/tasks/browser/setup
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
-#MISE description="Install Playwright browser (Chromium only)"
+#MISE description="Install Patchright browser (Chromium only)"
 
 set -e
 
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/shimmer/browser"
 export PLAYWRIGHT_BROWSERS_PATH="$CACHE_DIR"
 
-echo "Installing Playwright Chromium..."
+echo "Installing Patchright Chromium..."
 echo "  Browser cache: $CACHE_DIR"
 echo ""
 
-npx playwright install chromium
+npx patchright install chromium
 
 # ESM imports can't use NODE_PATH, so create a node_modules symlink at the
-# repo root pointing to mise's playwright install. This keeps it out of
+# repo root pointing to mise's patchright install. This keeps it out of
 # .mise/tasks/ (where mise would discover executables inside it as tasks).
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-PLAYWRIGHT_MODULES="$(mise where npm:playwright)/lib/node_modules"
-if [ -d "$PLAYWRIGHT_MODULES" ]; then
-  ln -sfn "$PLAYWRIGHT_MODULES" "$REPO_ROOT/node_modules"
-  echo "  Linked node_modules → $PLAYWRIGHT_MODULES"
+PATCHRIGHT_MODULES="$(mise where npm:patchright)/lib/node_modules"
+if [ -d "$PATCHRIGHT_MODULES" ]; then
+  ln -sfn "$PATCHRIGHT_MODULES" "$REPO_ROOT/node_modules"
+  echo "  Linked node_modules → $PATCHRIGHT_MODULES"
 fi
 
 echo ""

--- a/mise.toml
+++ b/mise.toml
@@ -9,5 +9,5 @@ zig = "0.15.2"                            # Required for Burrito cross-compilati
 "pipx:check-jsonschema" = "0.36.0"        # JSON Schema validation
 jq = "1.8.1"                              # JSON processing
 yq = "4.50.1"                             # YAML processing
-"npm:playwright" = "1.58"                 # Browser automation
+"npm:patchright" = "1.57"                  # Browser automation (undetected Playwright fork)
 fzf = "0.67.0"                            # Fuzzy finder for interactive pickers


### PR DESCRIPTION
## Summary

- Swaps Playwright for [Patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright), an undetected Playwright fork
- Drop-in replacement: same API, just different import (`from 'patchright'` instead of `from 'playwright'`)
- Patchright patches CDP leaks that sites like Google use to detect and block automated browsers

## Why

Google blocks Playwright's Chromium during sign-in with "This browser or app may not be secure." Tested Patchright locally and it gets through.

## Changes

- `mise.toml`: `npm:patchright` replaces `npm:playwright`
- `browser/setup`: installs Patchright's Chromium
- `_harness.mjs`, `_cdp.mjs`, `browser/launch`: updated imports
- `.gitignore`: updated comment

Closes #599

## Test plan

- [ ] Run `shimmer browser:setup` to install Patchright Chromium
- [ ] Run `shimmer browser:login recorder.google.com --interactive` and verify Google login works
- [ ] Run `shimmer browser:login github.com` and verify GitHub login still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)