### PR TITLE
Update org references for KnickKnackLabs transfer

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout shimmer
         uses: actions/checkout@v4
         with:
-          repository: ricon-family/shimmer
+          repository: KnickKnackLabs/shimmer
           token: ${{ secrets.AGENT_GITHUB_PAT }}
           path: shimmer
 

--- a/.jobs/cleanup.txt
+++ b/.jobs/cleanup.txt
@@ -12,17 +12,17 @@ The PR number may be provided in your initial message (e.g., "Cleanup PR 123").
 1. Extract the PR number from your message
 2. Fetch the PR details: gh pr view <PR_NUMBER> --json headRefName,mergedAt,mergeCommit
 3. Verify the PR was merged (mergedAt should be set)
-4. Delete the PR's branch: gh api -X DELETE repos/ricon-family/shimmer/git/refs/heads/<BRANCH_NAME>
+4. Delete the PR's branch: gh api -X DELETE repos/KnickKnackLabs/shimmer/git/refs/heads/<BRANCH_NAME>
 5. Log success or failure
 
 ## Part 2: Hunt for orphaned branches
 
 After handling the specific PR, check for stale branches that have no open PR:
 
-1. List all branches: gh api repos/ricon-family/shimmer/branches --paginate --jq '.[].name'
+1. List all branches: gh api repos/KnickKnackLabs/shimmer/branches --paginate --jq '.[].name'
 2. List branches with open PRs: gh pr list --state open --json headRefName --jq '.[].headRefName'
 3. Find orphaned branches (branches with no open PR, excluding 'main')
-4. For each orphaned branch, delete it: gh api -X DELETE repos/ricon-family/shimmer/git/refs/heads/<BRANCH_NAME>
+4. For each orphaned branch, delete it: gh api -X DELETE repos/KnickKnackLabs/shimmer/git/refs/heads/<BRANCH_NAME>
 
 If you successfully delete ANY orphaned branches, this is a momentous occasion! You have
 fulfilled your purpose. Send a GPG-signed email to admin@ricon.family celebrating your

--- a/.mise/tasks/_get-repo-slug
+++ b/.mise/tasks/_get-repo-slug
@@ -3,7 +3,7 @@
 #MISE hide=true
 # Usage: REPO=$(.mise/tasks/_get-repo-slug [dir])
 #
-# Returns the repo slug (e.g., "ricon-family/shimmer") for the given directory.
+# Returns the repo slug (e.g., "KnickKnackLabs/shimmer") for the given directory.
 # Checks in order:
 # 1. .project.toml in target dir
 # 2. gh repo view (from git remote)

--- a/.mise/tasks/agent/onboard
+++ b/.mise/tasks/agent/onboard
@@ -251,7 +251,7 @@ if [ -n "$RUN_URL" ]; then
 else
   echo ""
   echo "[auto] Could not get run URL. Check manually:"
-  echo "      https://github.com/ricon-family/shimmer/actions/workflows/test-agent-identity.yml"
+  echo "      https://github.com/KnickKnackLabs/shimmer/actions/workflows/test-agent-identity.yml"
 fi
 
 wait_for_enter

--- a/.mise/tasks/code/init/_default
+++ b/.mise/tasks/code/init/_default
@@ -150,7 +150,7 @@ $DESC_ARG
 
 ## Shimmer
 
-This project uses [shimmer](https://github.com/ricon-family/shimmer) for agent workflows.
+This project uses [shimmer](https://github.com/KnickKnackLabs/shimmer) for agent workflows.
 
 Run \`$COMMAND_ARG welcome\` to get started.
 EOF
@@ -186,7 +186,7 @@ $COMMAND_ARG welcome  # Verify setup
 
 ## Development
 
-This project uses [shimmer](https://github.com/ricon-family/shimmer) for agent workflows.
+This project uses [shimmer](https://github.com/KnickKnackLabs/shimmer) for agent workflows.
 EOF
 echo "  Created: README.md"
 

--- a/.mise/tasks/matrix/invite
+++ b/.mise/tasks/matrix/invite
@@ -22,7 +22,7 @@ This is yours - repos, scratch files, whatever you need. It persists between ses
 ## 2. Clone Shimmer (our tooling repo)
 
 \`\`\`bash
-git clone https://github.com/ricon-family/shimmer.git ~/agents/${USERNAME}/shimmer
+git clone https://github.com/KnickKnackLabs/shimmer.git ~/agents/${USERNAME}/shimmer
 \`\`\`
 
 ## 3. Set your SHIMMER_DIR

--- a/.mise/tasks/metrics/digest
+++ b/.mise/tasks/metrics/digest
@@ -120,7 +120,7 @@ $MERGED_PRS
 
 ---
 This digest was automatically generated.
-View full activity: https://github.com/ricon-family/shimmer/pulse"
+View full activity: https://github.com/KnickKnackLabs/shimmer/pulse"
 
 # Output digest for agent to send via himalaya template send
 echo "=== Activity Digest ==="

--- a/.mise/tasks/repo/file
+++ b/.mise/tasks/repo/file
@@ -10,7 +10,7 @@ REPO="${usage_repo:-}"
 
 # Known projects
 PROJECTS=(
-  "ricon-family/shimmer"
+  "KnickKnackLabs/shimmer"
   "ricon-family/fold"
   "ricon-family/zettelkasten"
   "ricon-family/food-life"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ This persists between sessions and is isolated from other agents. Create it if i
 
 ```bash
 cd ~/agents/<your-name>/
-git clone https://github.com/ricon-family/shimmer.git
+git clone https://github.com/KnickKnackLabs/shimmer.git
 cd shimmer
 # now work here
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/ricon-family/shimmer.git ~/shimmer
+git clone https://github.com/KnickKnackLabs/shimmer.git ~/shimmer
 cd ~/shimmer && mise trust && mise install
 
 # Add to your shell config (~/.zshrc or ~/.bashrc)

--- a/docs/agent-local.md
+++ b/docs/agent-local.md
@@ -44,7 +44,7 @@ When working on any repository (including shimmer itself), clone it to your work
 
 ```bash
 cd ~/agents/<agent>/
-git clone https://github.com/ricon-family/shimmer.git
+git clone https://github.com/KnickKnackLabs/shimmer.git
 cd shimmer
 ```
 

--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -45,7 +45,7 @@ Narrow tokens for specific work contexts (repos, orgs). Created as needed.
 
 ```
 <agent>              # Personal token (full access)
-<agent>-shimmer      # Project token (ricon-family/shimmer)
+<agent>-shimmer      # Project token (KnickKnackLabs/shimmer)
 <agent>-wallpapers   # Project token (KnickKnackLabs/wallpapers)
 ```
 

--- a/docs/agent-zettelkasten.md
+++ b/docs/agent-zettelkasten.md
@@ -188,8 +188,8 @@ cat ~/shimmer/cli/priv/prompts/common.txt
 
 ```bash
 # Your GitHub contributions
-gh pr list --author @me --state all --repo ricon-family/shimmer
-gh api repos/ricon-family/shimmer/contributors --jq '.[] | "\(.login): \(.contributions)"'
+gh pr list --author @me --state all --repo KnickKnackLabs/shimmer
+gh api repos/KnickKnackLabs/shimmer/contributors --jq '.[] | "\(.login): \(.contributions)"'
 
 # Your schedule
 cat ~/shimmer/workflows.yaml

--- a/docs/explorations/agent-scheduler.md
+++ b/docs/explorations/agent-scheduler.md
@@ -96,7 +96,7 @@ POST /api/schedules
   "agent": "probe-1",
   "run_at": "2024-01-15T10:00:00Z",
   "message": "Check PR #123 status",
-  "repo": "ricon-family/shimmer"
+  "repo": "KnickKnackLabs/shimmer"
 }
 
 Response:

--- a/docs/project-management/concepts/projects.md
+++ b/docs/project-management/concepts/projects.md
@@ -163,8 +163,8 @@ gh project edit 4 --owner ricon-family --readme "# Project README\n\nMarkdown co
 gh project edit 4 --owner ricon-family --visibility PUBLIC  # or PRIVATE
 
 # Link/unlink project to repo or team
-gh project link 4 --owner ricon-family --repo ricon-family/shimmer
-gh project unlink 4 --owner ricon-family --repo ricon-family/shimmer
+gh project link 4 --owner ricon-family --repo KnickKnackLabs/shimmer
+gh project unlink 4 --owner ricon-family --repo KnickKnackLabs/shimmer
 ```
 
 ### Item Management
@@ -175,7 +175,7 @@ gh project item-list 4 --owner ricon-family --format json
 gh project item-list 4 --owner ricon-family --limit 100  # default 30
 
 # Add existing issue/PR to project by URL
-gh project item-add 4 --owner ricon-family --url https://github.com/ricon-family/shimmer/issues/123
+gh project item-add 4 --owner ricon-family --url https://github.com/KnickKnackLabs/shimmer/issues/123
 
 # Create draft issue (lives only in project until converted)
 gh project item-create 4 --owner ricon-family --title "Draft task" --body "Description"
@@ -329,7 +329,7 @@ Source: https://docs.github.com/en/issues/planning-and-tracking-with-projects/ma
 **Linking to repository**:
 - Project appears in repo's Projects tab
 - Can set default repo (new issues from project go there)
-- CLI: `gh project link 4 --owner ricon-family --repo ricon-family/shimmer`
+- CLI: `gh project link 4 --owner ricon-family --repo KnickKnackLabs/shimmer`
 
 **Linking to team**:
 - Team gets read access (additive to existing permissions)

--- a/docs/project-management/setup-log.md
+++ b/docs/project-management/setup-log.md
@@ -149,7 +149,7 @@ https://github.com/orgs/ricon-family/projects/4/settings
 | Code changes requested | Status → In Progress | PR needs updates, still actively worked |
 | Pull request linked to issue | Status → In Review | PR submitted for review |
 | Auto-archive | `is:closed updated:<@today-14d` | Clean up old closed items after 2 weeks |
-| Auto-add | ricon-family/shimmer `is:issue is:open` | Auto-add open issues from this repo |
+| Auto-add | KnickKnackLabs/shimmer `is:issue is:open` | Auto-add open issues from this repo |
 
 **Views created:**
 - [x] Backlog (table, group by Priority, columns: Title, Assignees, Status, Iteration)
@@ -163,7 +163,7 @@ https://github.com/orgs/ricon-family/projects/4/settings
 Remove label that overlaps with Issue Types.
 
 ```bash
-gh label delete bug --repo ricon-family/shimmer --yes
+gh label delete bug --repo KnickKnackLabs/shimmer --yes
 ```
 
 ### 6. Delete `enhancement` label
@@ -173,5 +173,5 @@ gh label delete bug --repo ricon-family/shimmer --yes
 Remove label that overlaps with Issue Types (use "Feature" type instead).
 
 ```bash
-gh label delete enhancement --repo ricon-family/shimmer --yes
+gh label delete enhancement --repo KnickKnackLabs/shimmer --yes
 ```

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -4,7 +4,7 @@ ${PROJECT_DESCRIPTION}
 
 ## Shimmer
 
-This project uses [shimmer](https://github.com/ricon-family/shimmer) for agent workflows.
+This project uses [shimmer](https://github.com/KnickKnackLabs/shimmer) for agent workflows.
 
 Key commands:
 - `shimmer welcome` - Check your identity and system health

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/ricon-family/shimmer/workflows.schema.json",
+  "$id": "https://github.com/KnickKnackLabs/shimmer/workflows.schema.json",
   "title": "Workflow Configuration",
   "description": "Defines scheduled agent workflows for workflow generation",
 


### PR DESCRIPTION
## Summary

Prep for transferring shimmer from `ricon-family` to `KnickKnackLabs`. Replaces all 27 occurrences of `ricon-family/shimmer` with `KnickKnackLabs/shimmer` across 18 files.

## Files changed

- `CLAUDE.md`
- `README.md`
- `templates/CLAUDE.md`
- `workflows.schema.json`
- `.github/templates/agent-run.yml`
- `.jobs/cleanup.txt`
- `.mise/tasks/_get-repo-slug` (comment only — dynamic logic unchanged)
- `.mise/tasks/agent/onboard`
- `.mise/tasks/code/init/_default`
- `.mise/tasks/matrix/invite`
- `.mise/tasks/metrics/digest`
- `.mise/tasks/repo/file`
- `docs/agent-local.md`
- `docs/agent-provisioning.md`
- `docs/agent-zettelkasten.md`
- `docs/explorations/agent-scheduler.md`
- `docs/project-management/concepts/projects.md`
- `docs/project-management/setup-log.md`

## Notes

- The `_get-repo-slug` script only had the old org name in a comment (example output). The actual logic dynamically computes the slug from `.project.toml` or `gh repo view`, so no functional change there.
- Verified with `grep -r "ricon-family/shimmer" .` that zero references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)