### PR TITLE
Add sender attribution to agent sessions

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -166,6 +166,13 @@ jobs:
             exit 1
           fi
 
+          # Add dispatch context (who triggered this run)
+          if [ -n "$GITHUB_TRIGGERING_ACTOR" ]; then
+            echo "" >> "$PROMPT_FILE"
+            echo "## Dispatch Context" >> "$PROMPT_FILE"
+            echo "This session was triggered by: $GITHUB_TRIGGERING_ACTOR" >> "$PROMPT_FILE"
+          fi
+
           echo "file=$PROMPT_FILE" >> $GITHUB_OUTPUT
 
       - name: Run CLI

--- a/.mise/tasks/agent/local
+++ b/.mise/tasks/agent/local
@@ -28,4 +28,7 @@ fi
 PROMPT=$(cat "$AGENT_FILE")
 
 cd "${SHIMMER_CALLER_PWD:-.}"
-exec claude --append-system-prompt "$PROMPT"
+exec claude --append-system-prompt "$PROMPT
+
+## Session Context
+This is a local interactive session started via \`shimmer agent:local\`. A human is present and directing you."


### PR DESCRIPTION
## Summary

- When an agent is woken up, they now see who triggered the run in their system prompt ("Dispatch Context" section)
- Uses GitHub's native `GITHUB_TRIGGERING_ACTOR` env var — no message-text injection needed
- Also keeps the "local interactive session" context note in `agent:local`

## How it works

The `agent-run.yml` workflow template appends dispatch context to the system prompt:

```
## Dispatch Context
This session was triggered by: quick-ricon
```

This is unforgeable (comes from GitHub, not the message content) and works for all dispatch types — `agent:message`, `agent:broadcast`, and scheduled jobs.

## Background

Discovered via [ci-experiments env-vars-discovery](https://github.com/KnickKnackLabs/ci-experiments/actions/runs/22380538388) that `GITHUB_TRIGGERING_ACTOR` is available in all workflow runs.

Incident context: an agent received a message from another agent but assumed it came from a human, leading to incorrect actions during a security disclosure.

## Test plan

- [ ] Trigger `agent:message` and verify receiving agent sees dispatch context in system prompt
- [ ] Regenerate workflows in downstream repos after merge

Fixes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)