### PR TITLE
Rename SHIMMER_CALLER_PWD to CALLER_PWD

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -89,7 +89,7 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           cat > "$HOME/.local/bin/shimmer" << 'EOF'
           #!/bin/bash
-          SHIMMER_CALLER_PWD="$PWD" mise -C "$HOME/shimmer" run "$@"
+          CALLER_PWD="$PWD" mise -C "$HOME/shimmer" run "$@"
           EOF
           chmod +x "$HOME/.local/bin/shimmer"
           echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.mise/tasks/_get-agents-dir
+++ b/.mise/tasks/_get-agents-dir
@@ -4,7 +4,7 @@
 # Usage: AGENTS_DIR=$(.mise/tasks/_get-agents-dir [dir])
 #
 # Searches for an agents/ directory in this order:
-# 1. Target directory (or SHIMMER_CALLER_PWD, or current dir)
+# 1. Target directory (or CALLER_PWD, or current dir)
 # 2. Git repository root of that directory
 #
 # Returns the path to agents/ or fails with exit 1 if not found.
@@ -12,7 +12,7 @@
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_DIR="${1:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${1:-${CALLER_PWD:-.}}"
 
 # Check target directory first
 if [ -d "$TARGET_DIR/agents" ]; then

--- a/.mise/tasks/agent/local
+++ b/.mise/tasks/agent/local
@@ -27,7 +27,7 @@ fi
 # against shell injection — special chars are not re-evaluated.
 PROMPT=$(cat "$AGENT_FILE")
 
-cd "${SHIMMER_CALLER_PWD:-.}"
+cd "${CALLER_PWD:-.}"
 exec claude --append-system-prompt "$PROMPT
 
 ## Session Context

--- a/.mise/tasks/agent/refresh-token
+++ b/.mise/tasks/agent/refresh-token
@@ -9,7 +9,7 @@ set -e
 if [ -n "${usage_repo:-}" ]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   cd "$TARGET_DIR"
   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 fi

--- a/.mise/tasks/agent/run
+++ b/.mise/tasks/agent/run
@@ -23,7 +23,7 @@ JOB="${usage_job:-}"
 MODEL="${usage_model:-}"
 
 # Get the caller's directory (where shimmer was invoked from)
-CALLER_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
 
 # Build system prompt if not provided
 if [ -z "$SYSTEM_PROMPT_FILE" ]; then

--- a/.mise/tasks/agent/schedules
+++ b/.mise/tasks/agent/schedules
@@ -4,7 +4,7 @@
 set -e
 
 # Get the caller's directory (where shimmer was invoked from)
-CALLER_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
 cd "$CALLER_DIR"
 
 # Check for workflows.yaml

--- a/.mise/tasks/agent/sync-secrets
+++ b/.mise/tasks/agent/sync-secrets
@@ -7,7 +7,7 @@
 set -e
 
 # Determine target directory (caller's directory when using shimmer alias)
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
 
 AGENT="${usage_agent:-}"

--- a/.mise/tasks/ci/logs
+++ b/.mise/tasks/ci/logs
@@ -16,7 +16,7 @@ set -e
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/ci/wait
+++ b/.mise/tasks/ci/wait
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(dirname "$0")"
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi
 

--- a/.mise/tasks/ci/wait-for-checks
+++ b/.mise/tasks/ci/wait-for-checks
@@ -5,7 +5,7 @@
 set -e
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/code/init/_default
+++ b/.mise/tasks/code/init/_default
@@ -103,7 +103,7 @@ else
   if [[ "$PATH_ARG" == /* ]] || [[ "$PATH_ARG" == ~* ]]; then
     PATH_ARG="${PATH_ARG/#\~/$HOME}"
   else
-    CALLER_DIR="${SHIMMER_CALLER_PWD:-.}"
+    CALLER_DIR="${CALLER_PWD:-.}"
     PATH_ARG="$CALLER_DIR/$PATH_ARG"
   fi
 fi
@@ -204,7 +204,7 @@ cat > "$PATH_ARG/.mise/tasks/shell" << EOF
 #!/usr/bin/env bash
 #MISE description="Output shell configuration for global $COMMAND_ARG command (use with eval)"
 REPO_DIR="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd)"
-echo "alias $COMMAND_ARG='SHIMMER_CALLER_PWD=\"\\\$PWD\" mise -C \"\$REPO_DIR\" run'"
+echo "alias $COMMAND_ARG='CALLER_PWD=\"\\\$PWD\" mise -C \"\$REPO_DIR\" run'"
 EOF
 chmod +x "$PATH_ARG/.mise/tasks/shell"
 echo "  Created: .mise/tasks/shell"

--- a/.mise/tasks/code/welcome
+++ b/.mise/tasks/code/welcome
@@ -4,7 +4,7 @@
 set -e
 
 # Use caller's directory if available, otherwise pwd
-CURRENT_DIR="${SHIMMER_CALLER_PWD:-$(pwd)}"
+CURRENT_DIR="${CALLER_PWD:-$(pwd)}"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/.mise/tasks/discussion/comment
+++ b/.mise/tasks/discussion/comment
@@ -26,7 +26,7 @@ if [[ -z "$BODY" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/discussion/create
+++ b/.mise/tasks/discussion/create
@@ -31,7 +31,7 @@ if [[ -z "$BODY" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/discussion/list
+++ b/.mise/tasks/discussion/list
@@ -5,7 +5,7 @@
 set -eo pipefail
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/discussion/view
+++ b/.mise/tasks/discussion/view
@@ -11,7 +11,7 @@ if [[ -z "$NUMBER" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/issue/claim
+++ b/.mise/tasks/issue/claim
@@ -12,7 +12,7 @@ if [[ -z "$ISSUE_NUM" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/issue/list
+++ b/.mise/tasks/issue/list
@@ -8,7 +8,7 @@ set -eo pipefail
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/issue/propose
+++ b/.mise/tasks/issue/propose
@@ -11,7 +11,7 @@ set -eo pipefail
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/issue/sub-add
+++ b/.mise/tasks/issue/sub-add
@@ -13,7 +13,7 @@ if [[ -z "$PARENT" ]] || [[ -z "$CHILD" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/issue/sub-create
+++ b/.mise/tasks/issue/sub-create
@@ -19,7 +19,7 @@ if [[ -z "$PARENT" ]] || [[ -z "$TITLE" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/issue/sub-list
+++ b/.mise/tasks/issue/sub-list
@@ -11,7 +11,7 @@ if [[ -z "$PARENT" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/issue/view
+++ b/.mise/tasks/issue/view
@@ -15,7 +15,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pm/edit-issue
+++ b/.mise/tasks/pm/edit-issue
@@ -19,7 +19,7 @@ if [[ -z "$ISSUE_NUM" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/pm/field-options
+++ b/.mise/tasks/pm/field-options
@@ -22,7 +22,7 @@ if [[ -z "$FIELD_NAME" ]] || [[ -z "$OPTIONS" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/pm/init
+++ b/.mise/tasks/pm/init
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/pm/list-issues
+++ b/.mise/tasks/pm/list-issues
@@ -5,7 +5,7 @@ set -eo pipefail
 export GH_PAGER=""
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR" 2>/dev/null || true)
 

--- a/.mise/tasks/pm/wip
+++ b/.mise/tasks/pm/wip
@@ -6,7 +6,7 @@ set -eo pipefail
 export GH_PAGER=""
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/pr/approve
+++ b/.mise/tasks/pr/approve
@@ -17,7 +17,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pr/create
+++ b/.mise/tasks/pr/create
@@ -8,7 +8,7 @@
 set -eo pipefail
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/pr/list
+++ b/.mise/tasks/pr/list
@@ -8,7 +8,7 @@ set -eo pipefail
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pr/merge
+++ b/.mise/tasks/pr/merge
@@ -17,7 +17,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pr/view
+++ b/.mise/tasks/pr/view
@@ -17,7 +17,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -14,7 +14,7 @@ if [ ! -d "\$REPO" ]; then
   echo "shimmer: re-run 'eval \"\\\$(mise -C /path/to/shimmer run -q shell)\"' to fix" >&2
   exit 1
 fi
-SHIMMER_CALLER_PWD="\${SHIMMER_CALLER_PWD:-\$PWD}" exec mise -C "\$REPO" run "\$@"
+CALLER_PWD="\${CALLER_PWD:-\$PWD}" exec mise -C "\$REPO" run "\$@"
 SCRIPT
 chmod +x "$BIN"
 
@@ -25,4 +25,4 @@ case ":$PATH:" in
 esac
 
 # Shell alias (captures caller's PWD for interactive use)
-echo "alias shimmer='SHIMMER_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"
+echo "alias shimmer='CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -4,7 +4,7 @@
 set -eo pipefail
 
 # Determine target directory (caller's directory when using shimmer alias)
-TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- Renames `SHIMMER_CALLER_PWD` → `CALLER_PWD` across all 35 task files and the agent-run workflow template
- Standardizes on a generic env var convention set by shiv's shim template
- Any shiv-managed tool now exports `CALLER_PWD`, making the convention tool-agnostic

## Context
Companion to KnickKnackLabs/shiv#10 which adds `export CALLER_PWD="$PWD"` to the shiv shim template.

Together, these fix the broken `shimmer as` command when invoked via the shiv shim — it can now find the `agents/` directory in the caller's working directory.

## Test plan
- [ ] After merging shiv#10, regenerate the shimmer shim with `shiv install shimmer`
- [ ] From `~/fold`, run `eval $(shimmer as)` — should detect agents and offer selection
- [ ] Verify `shimmer code:welcome` shows correct codebase info from caller's directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)