### PR TITLE
Validate workflows.yaml before generating

### DIFF
--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -10,6 +10,12 @@ cd "$TARGET_DIR"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
+# Validate workflows.yaml against schema
+if [[ -f workflows.yaml ]]; then
+  echo "Validating workflows.yaml..."
+  check-jsonschema --schemafile "$SHIMMER_DIR/workflows.schema.json" workflows.yaml
+fi
+
 # Use local template if exists, otherwise use shimmer's
 if [[ -f ".github/templates/agent-scheduled.yml" ]]; then
   TEMPLATE=".github/templates/agent-scheduled.yml"


### PR DESCRIPTION
## Summary

- Adds `check-jsonschema` validation of `workflows.yaml` against the schema at the start of `workflows:generate`
- Generator now fails fast with a clear error instead of silently producing broken workflow files

## Motivation

fold's `junior-daily-checkin` workflow had `schedule: "0 15 * * *"` (scalar string) instead of the array format required since #586. The generator didn't catch this — `yq -r ".schedule | length"` returned 10 (character count), producing 10 empty `cron: ''` entries. The workflow never ran.

With this change, `shimmer workflows:generate` against that `workflows.yaml` would have immediately reported:

```
$.workflows[1].schedule: '0 15 * * *' is not of type 'array'
```

## Test plan

- [x] Verified `check-jsonschema` catches scalar schedule (fold's current broken `workflows.yaml`)
- [x] Verified valid `workflows.yaml` (array schedule) passes validation
- [ ] Run `shimmer workflows:generate` end-to-end after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)