### PR TITLE
Add agent:fork for Claude Code session forking

### DIFF
--- a/.mise/tasks/agent/fork
+++ b/.mise/tasks/agent/fork
@@ -2,7 +2,8 @@
 #MISE description="Fork a Claude Code session"
 #USAGE arg "<session-id>" help="Session ID to fork"
 
-set -e
+set -eu
+shopt -s nullglob
 
 SESSION_ID="$usage_session_id"
 CLAUDE_DIR="$HOME/.claude"
@@ -51,12 +52,19 @@ esac
 
 NEW_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 
+# Clean up on failure
+cleanup() {
+  rm -f "${PROJECT_DIR}${NEW_ID}.jsonl"
+  rm -rf "${PROJECT_DIR}${NEW_ID}"
+}
+trap cleanup ERR
+
 # Copy session JSONL
-cp "${PROJECT_DIR}${SESSION_ID}.jsonl" "${PROJECT_DIR}${NEW_ID}.jsonl"
+cp -a "${PROJECT_DIR}${SESSION_ID}.jsonl" "${PROJECT_DIR}${NEW_ID}.jsonl"
 
 # Copy session directory if it exists (subagents, tool-results)
 if [ -d "${PROJECT_DIR}${SESSION_ID}" ]; then
-  cp -r "${PROJECT_DIR}${SESSION_ID}" "${PROJECT_DIR}${NEW_ID}"
+  cp -a "${PROJECT_DIR}${SESSION_ID}" "${PROJECT_DIR}${NEW_ID}"
 fi
 
 # Update sessions index


### PR DESCRIPTION
## Summary

- Adds `shimmer agent:fork <session-id>` — clones a Claude Code conversation's state files and returns a new session ID that can be resumed independently
- Scans `~/.claude/projects/*/` to find the session, copies the JSONL and any subagent directories, updates `sessions-index.json`
- New session ID printed to stdout (pipeable), human-friendly context on stderr

## Context

Claude Code has a built-in `/fork` command, but it's interactive-only — agents can't invoke it programmatically. This task fills that gap: fork from outside a running session.

Refs: ricon-family/or#61

## Test plan

- [ ] `shimmer agent:fork <valid-id>` — creates new JSONL, updates index, prints new UUID
- [ ] `claude --resume <new-id>` — forked session has full conversation context
- [ ] `shimmer agent:fork <invalid-format>` — errors with "Invalid session ID format"
- [ ] `shimmer agent:fork <nonexistent-uuid>` — errors with "Session not found"

Manually tested all of the above during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)