### PR TITLE
Fix op stdin, 1Password casing, and mise task resolution

### DIFF
--- a/.mise/tasks/1password/set
+++ b/.mise/tasks/1password/set
@@ -48,9 +48,11 @@ VAULT="Agents"
 ITEM="${AGENT} - ${OP_ITEM_SUFFIX}"
 
 # Try edit first (item exists); fall back to create (item doesn't exist)
-if op item get "$ITEM" --vault "$VAULT" &>/dev/null; then
+# Note: op reads stdin for JSON when it detects a pipe, so close stdin (< /dev/null)
+# since the value is already captured in $VALUE.
+if op item get "$ITEM" --vault "$VAULT" < /dev/null &>/dev/null; then
   # Item exists — edit the field
-  op item edit "$ITEM" --vault "$VAULT" "${OP_FIELD_SET}=${VALUE}" >/dev/null 2>&1 || {
+  op item edit "$ITEM" --vault "$VAULT" "${OP_FIELD_SET}=${VALUE}" < /dev/null >/dev/null 2>&1 || {
     echo "ERROR: Failed to update key=$KEY for agent=$AGENT in 1Password" >&2
     echo "       Item: $ITEM / Field: $OP_FIELD_SET" >&2
     exit 1
@@ -60,7 +62,7 @@ else
   op item create --vault "$VAULT" \
     --category "$OP_ITEM_CATEGORY" \
     --title "$ITEM" \
-    "${OP_FIELD_SET}=${VALUE}" >/dev/null 2>&1 || {
+    "${OP_FIELD_SET}=${VALUE}" < /dev/null >/dev/null 2>&1 || {
     echo "ERROR: Failed to create item for key=$KEY agent=$AGENT in 1Password" >&2
     echo "       Item: $ITEM / Category: $OP_ITEM_CATEGORY" >&2
     exit 1

--- a/.mise/tasks/_secret-keys
+++ b/.mise/tasks/_secret-keys
@@ -43,13 +43,13 @@ resolve_key() {
     github-password)
       OP_ITEM_SUFFIX="GitHub";   OP_FIELD_GET="password";    OP_FIELD_SET="password";              OP_ITEM_CATEGORY="login" ;;
     gpg-private-key)
-      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Private Key"; OP_FIELD_SET="Private Key[text]";     OP_ITEM_CATEGORY="secure-note" ;;
+      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Private Key"; OP_FIELD_SET="Private Key[text]";     OP_ITEM_CATEGORY="Secure Note" ;;
     gpg-public-key)
-      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Public Key";  OP_FIELD_SET="Public Key[text]";      OP_ITEM_CATEGORY="secure-note" ;;
+      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Public Key";  OP_FIELD_SET="Public Key[text]";      OP_ITEM_CATEGORY="Secure Note" ;;
     gpg-key-id)
-      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Key ID";      OP_FIELD_SET="Key ID[text]";          OP_ITEM_CATEGORY="secure-note" ;;
+      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Key ID";      OP_FIELD_SET="Key ID[text]";          OP_ITEM_CATEGORY="Secure Note" ;;
     gpg-fingerprint)
-      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Fingerprint"; OP_FIELD_SET="Fingerprint[text]";     OP_ITEM_CATEGORY="secure-note" ;;
+      OP_ITEM_SUFFIX="GPG";     OP_FIELD_GET="Fingerprint"; OP_FIELD_SET="Fingerprint[text]";     OP_ITEM_CATEGORY="Secure Note" ;;
     email-password)
       OP_ITEM_SUFFIX="Email";   OP_FIELD_GET="password";    OP_FIELD_SET="password";              OP_ITEM_CATEGORY="login" ;;
     matrix-password)

--- a/.mise/tasks/agent/onboard
+++ b/.mise/tasks/agent/onboard
@@ -10,12 +10,12 @@ AGENT_UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 EMAIL="${AGENT}@ricon.family"
 VAULT="Agents"
 
-# Remember shimmer's directory for mise run calls after cd
-SHIMMER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-
 # Target caller's repo for GitHub secrets (not shimmer's)
 TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
+
+# After cd, bare `mise run` resolves tasks from cwd (the caller's repo).
+# Use `mise -C "$MISE_PROJECT_ROOT" run -q` to call sibling shimmer tasks.
 
 wait_for_enter() {
   echo ""
@@ -39,8 +39,8 @@ fi
 # (username, email, country) are 1Password-specific and read directly via op.
 echo "Fetching credentials from 1Password..."
 export SHIMMER_SECRETS_PROVIDER=1password
-EMAIL_PASSWORD=$(mise run -q secret:get "$AGENT" email-password 2>/dev/null || echo "")
-GITHUB_PASSWORD=$(mise run -q secret:get "$AGENT" github-password 2>/dev/null || echo "")
+EMAIL_PASSWORD=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" email-password 2>/dev/null || echo "")
+GITHUB_PASSWORD=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" github-password 2>/dev/null || echo "")
 # Account metadata fields — not part of secret:* abstraction (1Password item fields only)
 GITHUB_USERNAME=$(op item get "${AGENT} - GitHub" --vault "$VAULT" --fields username 2>/dev/null || echo "")
 GITHUB_EMAIL=$(op item get "${AGENT} - GitHub" --vault "$VAULT" --fields email 2>/dev/null || echo "")
@@ -103,7 +103,7 @@ else
   echo "------------------------------------------------------------"
   echo "[auto] Checking for GitHub verification email..."
 
-  (cd "$SHIMMER_DIR" && mise run email:setup "$AGENT") > /dev/null 2>&1
+  (mise -C "$MISE_PROJECT_ROOT" run email:setup "$AGENT") > /dev/null 2>&1
 
   # Poll for GitHub verification email (up to 60 seconds)
   VERIFICATION_CODE=""
@@ -168,7 +168,7 @@ echo "      Click: New GPG key"
 echo "      Title: $EMAIL"
 echo "      Key:"
 echo ""
-mise run -q secret:get "$AGENT" gpg-public-key 2>/dev/null || echo "(no GPG public key found — run agent:provision first)"
+mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" gpg-public-key 2>/dev/null || echo "(no GPG public key found — run agent:provision first)"
 echo ""
 
 wait_for_enter
@@ -180,7 +180,7 @@ echo "[auto] Opening browser to create full-access personal token..."
 echo ""
 
 # Run github:token:new-personal (shows credentials, opens incognito browser)
-(cd "$SHIMMER_DIR" && mise run -q github:token:new-personal "$AGENT")
+(mise -C "$MISE_PROJECT_ROOT" run -q github:token:new-personal "$AGENT")
 
 wait_for_enter
 
@@ -193,7 +193,7 @@ echo ""
 
 if [ -n "$PAT_TOKEN" ]; then
   echo "[auto] Storing in secret store..."
-  printf '%s' "$PAT_TOKEN" | mise run -q secret:set "$AGENT" github-pat
+  printf '%s' "$PAT_TOKEN" | mise -C "$MISE_PROJECT_ROOT" run -q secret:set "$AGENT" github-pat
 
   echo "[auto] Storing as GitHub secret ${AGENT_UPPER}_GITHUB_PAT..."
   echo "$PAT_TOKEN" | gh secret set "${AGENT_UPPER}_GITHUB_PAT"
@@ -213,7 +213,7 @@ wait_for_enter
 echo "STEP 8: Matrix Setup"
 echo "------------------------------------------------------------"
 
-MATRIX_PASSWORD=$(mise run -q secret:get "$AGENT" matrix-password 2>/dev/null || echo "")
+MATRIX_PASSWORD=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" matrix-password 2>/dev/null || echo "")
 MATRIX_USER="@${AGENT}:ricon.family"
 
 if [ -z "$MATRIX_PASSWORD" ]; then
@@ -238,10 +238,10 @@ wait_for_enter
 echo "STEP 9: Blob Storage"
 echo "------------------------------------------------------------"
 
-B2_ENDPOINT=$(mise run -q secret:get "$AGENT" b2-endpoint 2>/dev/null || echo "")
-B2_KEY_ID=$(mise run -q secret:get "$AGENT" b2-key-id 2>/dev/null || echo "")
-B2_APPLICATION_KEY=$(mise run -q secret:get "$AGENT" b2-application-key 2>/dev/null || echo "")
-B2_BUCKET=$(mise run -q secret:get "$AGENT" b2-bucket 2>/dev/null || echo "")
+B2_ENDPOINT=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" b2-endpoint 2>/dev/null || echo "")
+B2_KEY_ID=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" b2-key-id 2>/dev/null || echo "")
+B2_APPLICATION_KEY=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" b2-application-key 2>/dev/null || echo "")
+B2_BUCKET=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" b2-bucket 2>/dev/null || echo "")
 
 if [ -z "$B2_ENDPOINT" ] || [ -z "$B2_KEY_ID" ] || [ -z "$B2_APPLICATION_KEY" ] || [ -z "$B2_BUCKET" ]; then
   echo "[WARN] B2 credentials not found in secret store, skipping blob storage setup"
@@ -259,14 +259,14 @@ else
   echo "$B2_BUCKET" | gh secret set "${AGENT_UPPER}_B2_BUCKET"
 
   echo "[auto] Configuring mc alias..."
-  (cd "$SHIMMER_DIR" && B2_ENDPOINT="$B2_ENDPOINT" B2_KEY_ID="$B2_KEY_ID" B2_APPLICATION_KEY="$B2_APPLICATION_KEY" mise run blob:setup "$AGENT")
+  (B2_ENDPOINT="$B2_ENDPOINT" B2_KEY_ID="$B2_KEY_ID" B2_APPLICATION_KEY="$B2_APPLICATION_KEY" mise -C "$MISE_PROJECT_ROOT" run blob:setup "$AGENT")
 
   echo "[auto] Verifying blob storage..."
   (
     # blob:welcome uses GIT_AUTHOR_EMAIL for agent detection
     export GIT_AUTHOR_EMAIL="$EMAIL"
     export B2_BUCKET="$B2_BUCKET"
-    cd "$SHIMMER_DIR" && mise run -q blob:welcome
+    mise -C "$MISE_PROJECT_ROOT" run -q blob:welcome
   )
 fi
 
@@ -279,14 +279,14 @@ echo "[auto] Running shimmer welcome as $AGENT to verify identity..."
 echo ""
 
 # Set agent identity and run welcome to verify the full local identity chain
-PAT=$(mise run -q secret:get "$AGENT" github-pat 2>/dev/null || true)
+PAT=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" github-pat 2>/dev/null || true)
 (
   export GH_TOKEN="$PAT"
   export GIT_AUTHOR_EMAIL="$EMAIL"
   export GIT_COMMITTER_EMAIL="$EMAIL"
   export GIT_AUTHOR_NAME="$AGENT"
   export GIT_COMMITTER_NAME="$AGENT"
-  cd "$SHIMMER_DIR" && mise run -q welcome
+  mise -C "$MISE_PROJECT_ROOT" run -q welcome
 )
 
 wait_for_enter

--- a/.mise/tasks/agent/provision
+++ b/.mise/tasks/agent/provision
@@ -20,6 +20,9 @@ UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
 
+# After cd, bare `mise run` resolves tasks from cwd (the caller's repo).
+# Use `mise -C "$MISE_PROJECT_ROOT" run -q` to call sibling shimmer tasks.
+
 echo "=== Provisioning agent: $AGENT ==="
 echo ""
 
@@ -62,7 +65,7 @@ generate_passphrase() {
 CREDENTIAL_KEYS=(email-password github-password matrix-password passphrase)
 
 for key in "${CREDENTIAL_KEYS[@]}"; do
-  if mise run -q secret:get "$AGENT" "$key" &>/dev/null; then
+  if mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" "$key" &>/dev/null; then
     echo "[auto] $key already stored"
   else
     if [ "$key" = "passphrase" ]; then
@@ -71,7 +74,7 @@ for key in "${CREDENTIAL_KEYS[@]}"; do
       value=$(generate_password)
     fi
     echo "[auto] Generating and storing $key..."
-    printf '%s' "$value" | mise run -q secret:set "$AGENT" "$key"
+    printf '%s' "$value" | mise -C "$MISE_PROJECT_ROOT" run -q secret:set "$AGENT" "$key"
   fi
 done
 
@@ -92,7 +95,7 @@ fi
 
 if ! gpg --list-keys "$EMAIL" >/dev/null 2>&1; then
   # Try to import from secret store first (idempotent re-provision)
-  STORED_PRIVATE_KEY=$(mise run -q secret:get "$AGENT" gpg-private-key 2>/dev/null || true)
+  STORED_PRIVATE_KEY=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" gpg-private-key 2>/dev/null || true)
   if [ -n "$STORED_PRIVATE_KEY" ]; then
     echo "[auto] Importing GPG key from secret store ($PROVIDER)..."
     printf '%s' "$STORED_PRIVATE_KEY" | gpg --batch --import 2>&1 | grep -v "^gpg: Total" || true
@@ -144,7 +147,7 @@ echo "--- Secret Store ($PROVIDER) ---"
 
 store() {
   local key="$1"; local value="$2"
-  if ! printf '%s' "$value" | mise run -q secret:set "$AGENT" "$key"; then
+  if ! printf '%s' "$value" | mise -C "$MISE_PROJECT_ROOT" run -q secret:set "$AGENT" "$key"; then
     echo "  WARN: Failed to store $key — check provider ($PROVIDER) configuration" >&2
     STORE_FAILURES=$((STORE_FAILURES + 1))
   fi
@@ -152,7 +155,7 @@ store() {
 STORE_FAILURES=0
 
 if [ "$GPG_NEWLY_GENERATED" = "true" ] || \
-   ! mise run -q secret:get "$AGENT" gpg-private-key &>/dev/null; then
+   ! mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" gpg-private-key &>/dev/null; then
   echo "[auto] Storing GPG keys..."
   store gpg-private-key "$PRIVATE_KEY"
   store gpg-public-key "$PUBLIC_KEY"
@@ -160,6 +163,28 @@ if [ "$GPG_NEWLY_GENERATED" = "true" ] || \
   store gpg-fingerprint "$FINGERPRINT"
 else
   echo "[auto] GPG keys already stored"
+fi
+
+# === 1Password Metadata ===
+# The secret:set abstraction only stores the bare value. Enrich 1Password items
+# with usernames, URLs, and other metadata that the old provision flow included.
+# This is 1Password-specific; keychain doesn't support this metadata.
+if [ "$PROVIDER" = "1password" ]; then
+  echo ""
+  echo "--- 1Password Metadata ---"
+  VAULT="Agents"
+  op item edit "${AGENT} - Email" --vault "$VAULT" \
+    username="$AGENT" "email[text]=$EMAIL" --url "https://mail.ricon.family" \
+    < /dev/null >/dev/null 2>&1 && echo "[auto] Enriched ${AGENT} - Email" || echo "  WARN: Failed to enrich ${AGENT} - Email"
+  op item edit "${AGENT} - GitHub" --vault "$VAULT" \
+    username="${AGENT}-ricon" "email[text]=$EMAIL" "country[text]=United States of America" --url "https://github.com" \
+    < /dev/null >/dev/null 2>&1 && echo "[auto] Enriched ${AGENT} - GitHub" || echo "  WARN: Failed to enrich ${AGENT} - GitHub"
+  op item edit "${AGENT} - Matrix" --vault "$VAULT" \
+    username="@${AGENT}:ricon.family" --url "https://matrix.ricon.family" \
+    < /dev/null >/dev/null 2>&1 && echo "[auto] Enriched ${AGENT} - Matrix" || echo "  WARN: Failed to enrich ${AGENT} - Matrix"
+  op item edit "${AGENT} - GPG" --vault "$VAULT" \
+    "Email[text]=$EMAIL" "GitHub Title[text]=$EMAIL" \
+    < /dev/null >/dev/null 2>&1 && echo "[auto] Enriched ${AGENT} - GPG" || echo "  WARN: Failed to enrich ${AGENT} - GPG"
 fi
 
 echo ""

--- a/.mise/tasks/agent/sync-secrets
+++ b/.mise/tasks/agent/sync-secrets
@@ -85,7 +85,7 @@ sync_agent() {
     gh_name=$(gh_secret_name "$agent_upper" "$key") || continue
 
     local value
-    value=$(mise run -q secret:get "$agent" "$key" 2>/dev/null) || true
+    value=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$agent" "$key" 2>/dev/null) || true
 
     if [ -n "$value" ]; then
       if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
## Summary
- Add `< /dev/null` to `op` commands in `1password/set` — prevents `op` from reading stdin when it detects a pipe
- Fix 1Password category from `secure-note` to `Secure Note` in `_secret-keys` (correct casing for `op item create`)
- Replace `SHIMMER_DIR` + `cd` pattern with `mise -C "$MISE_PROJECT_ROOT"` in `agent/onboard`, `agent/provision`, and `agent/sync-secrets` so sibling shimmer tasks resolve correctly regardless of cwd
- Add 1Password metadata enrichment to `agent/provision` (usernames, URLs, emails on vault items)

## Test plan
- [ ] Run `shimmer agent:provision` for a test agent and verify credentials are stored correctly
- [ ] Verify `op item edit` commands don't hang waiting for stdin
- [ ] Verify GPG items are created with `Secure Note` category (not `secure-note`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)