### PR TITLE
tidy: auto-promote/demote threads by waiting-on status

### DIFF
--- a/.mise/tasks/human/threads/tidy
+++ b/.mise/tasks/human/threads/tidy
@@ -72,6 +72,9 @@ if converted > 0:
 # success threads are never touched
 
 header, body = split_header_body(content)
+if header is None:
+    import sys
+    print("No header marker found — skipping promote/demote.", file=sys.stderr)
 if header is not None:
     preamble_lines, threads = parse_threads(body)
 

--- a/test/human-threads/tidy.bats
+++ b/test/human-threads/tidy.bats
@@ -19,8 +19,8 @@ $RAW_CODEBLOCK
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "converted 1 codeblock"
 
-  # Should now be a callout (promoted to warning since junior spoke last)
-  grep -q '> \[!warning\]-\|> \[!note\]-' "$HUMAN_PATH"
+  # Should be a warning callout (junior spoke last → waiting on Or → promoted)
+  grep -q '> \[!warning\]-' "$HUMAN_PATH"
   # Should have bolded names
   grep -q '\*\*\[Or\]\*\*' "$HUMAN_PATH"
   grep -q '\*\*\[junior\]\*\*' "$HUMAN_PATH"


### PR DESCRIPTION
## Summary

- `tidy` now auto-sets callout types based on who the thread is waiting on:
  - **waiting on Or** → `[!warning]` with 👈 (bubbles to top after `sort`)
  - **waiting on agent** → `[!note]` (sinks below warnings after `sort`)
  - **resolved** (`[!success]`) → never touched
- Both phases run in one pass: codeblock conversion first, then promote/demote
- Idempotent: running tidy twice produces identical output

### Example

Before:
```markdown
> [!note]- Thread where agent replied last
> **[Or]** Question.
> **[junior]** Answer.
```

After `tidy`:
```markdown
> [!warning]- Thread where agent replied last 👈
> **[Or]** Question.
> **[junior]** Answer.
```

Then `sort` moves it to the top. The workflow becomes: `tidy` → `sort` → done.

## Test plan

- [x] 62 tests passing (7 new for promote/demote)
- [x] Tested against fold's HUMAN.md via copy
- [x] Idempotency verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)