### PR TITLE
Let stderr through on mutation commands

### DIFF
--- a/.mise/tasks/1password/set
+++ b/.mise/tasks/1password/set
@@ -52,7 +52,7 @@ ITEM="${AGENT} - ${OP_ITEM_SUFFIX}"
 # since the value is already captured in $VALUE.
 if op item get "$ITEM" --vault "$VAULT" < /dev/null &>/dev/null; then
   # Item exists — edit the field
-  op item edit "$ITEM" --vault "$VAULT" "${OP_FIELD_SET}=${VALUE}" < /dev/null >/dev/null 2>&1 || {
+  op item edit "$ITEM" --vault "$VAULT" "${OP_FIELD_SET}=${VALUE}" < /dev/null >/dev/null || {
     echo "ERROR: Failed to update key=$KEY for agent=$AGENT in 1Password" >&2
     echo "       Item: $ITEM / Field: $OP_FIELD_SET" >&2
     exit 1
@@ -62,7 +62,7 @@ else
   op item create --vault "$VAULT" \
     --category "$OP_ITEM_CATEGORY" \
     --title "$ITEM" \
-    "${OP_FIELD_SET}=${VALUE}" < /dev/null >/dev/null 2>&1 || {
+    "${OP_FIELD_SET}=${VALUE}" < /dev/null >/dev/null || {
     echo "ERROR: Failed to create item for key=$KEY agent=$AGENT in 1Password" >&2
     echo "       Item: $ITEM / Category: $OP_ITEM_CATEGORY" >&2
     exit 1

--- a/.mise/tasks/agent/onboard
+++ b/.mise/tasks/agent/onboard
@@ -103,7 +103,7 @@ else
   echo "------------------------------------------------------------"
   echo "[auto] Checking for GitHub verification email..."
 
-  mise -C "$MISE_PROJECT_ROOT" run email:setup "$AGENT" > /dev/null 2>&1
+  mise -C "$MISE_PROJECT_ROOT" run email:setup "$AGENT" > /dev/null
 
   # Poll for GitHub verification email (up to 60 seconds)
   VERIFICATION_CODE=""
@@ -148,11 +148,11 @@ if echo "$MEMBERSHIP" | grep -q '"state":"active"'; then
   echo "[auto] $GITHUB_USERNAME is already an active org member"
 else
   echo "[auto] Inviting $GITHUB_USERNAME to ricon-family org..."
-  gh api --method PUT "orgs/ricon-family/memberships/$GITHUB_USERNAME" -f role=member > /dev/null 2>&1 || true
+  gh api --method PUT "orgs/ricon-family/memberships/$GITHUB_USERNAME" -f role=member > /dev/null || true
 fi
 
 echo "[auto] Adding to agents team (grants write access)..."
-gh api --method PUT "orgs/ricon-family/teams/agents/memberships/$GITHUB_USERNAME" -f role=member > /dev/null 2>&1 || true
+gh api --method PUT "orgs/ricon-family/teams/agents/memberships/$GITHUB_USERNAME" -f role=member > /dev/null || true
 
 echo ""
 echo "[YOU] Accept the org invitation as $GITHUB_USERNAME:"
@@ -205,7 +205,7 @@ fi
 
 # Set display name on GitHub profile
 echo "[auto] Setting GitHub display name to '$AGENT'..."
-GH_TOKEN="$PAT_TOKEN" gh api -X PATCH /user -f "name=$AGENT" --silent 2>/dev/null || true
+GH_TOKEN="$PAT_TOKEN" gh api -X PATCH /user -f "name=$AGENT" --silent || true
 
 wait_for_enter
 


### PR DESCRIPTION
## Summary

- Drop `2>&1` from `op item edit` and `op item create` in `1password/set` — the `|| {` handler catches failure but the real `op` error was being swallowed
- Drop `2>&1` from `email:setup`, GitHub org/team membership, and profile update calls in `agent/onboard` — same pattern, different commands

Probe commands (`op item get`, `op account get`, `command -v`) still suppress stderr since failure is expected there.

Supersedes #634, which found the same `op` stdin issue but was beaten to main by rho's `efc1df3`. The stderr fix from #634 hadn't landed though.

## Test plan

- [x] Verified only mutation commands are changed — probe/check commands untouched
- [x] `|| true` and `|| {` error handling preserved, just with visible stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)