### PR TITLE
feat: add --repo flag to agent:message for cross-home messaging

### DIFF
--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -67,7 +67,7 @@ gh workflow run "$WORKFLOW" -R "$REPO" -f agent="$AGENT" -f message="$MESSAGE" $
 # Wait briefly for GitHub to register the run, then get the URL and ID
 # Filter by triggering user to avoid races when multiple agents dispatch simultaneously
 sleep 2
-GH_USER=$(gh api user -q .login 2>/dev/null || true)
+GH_USER="${GITHUB_ACTOR:-$(gh api user -q .login 2>/dev/null || true)}"
 USER_FILTER=""
 if [ -n "$GH_USER" ]; then
   USER_FILTER="--user $GH_USER"


### PR DESCRIPTION
## Summary

- Adds `--repo <owner/name>` flag to `agent:message`
- When `--repo` is provided, the command targets the specified repository directly, skipping `AGENT_HOME` validation and local agent discovery
- This enables agents in one home (e.g., den) to wake agents in another (e.g., fold) without needing the target's `agents/` directory locally
- Without `--repo`, behavior is completely unchanged

## Motivation

Den agents (Zeke, Baby Joel) can now message fold agents directly:

```bash
# Before: only works if AGENT_HOME points to fold
shimmer agent:message c0da "review this PR"

# After: works from any agent home
shimmer agent:message --repo ricon-family/fold c0da "review this PR"
```

Tested live — successfully dispatched c0da from den to review [KnickKnackLabs/shiv#55](https://github.com/KnickKnackLabs/shiv/pull/55) using the raw `gh workflow run` equivalent. This PR wraps that into the existing shimmer UX.

## Test plan

- [x] `shimmer agent:message --help` shows new `--repo` flag
- [x] Verified `gh workflow run agent-message.yml -R ricon-family/fold -f agent=c0da -f message="..."` works (the underlying call)
- [ ] Test with `--repo` flag end-to-end once merged
- [ ] Verify existing behavior without `--repo` is unchanged

## Related

- [#659](https://github.com/KnickKnackLabs/shimmer/issues/659) — `ci:logs` proxy issue (companion fix for reading remote agent logs)