### PR TITLE
refactor: delegate agent discovery to home's agent:list task

### DIFF
--- a/.mise/tasks/_agent-preview
+++ b/.mise/tasks/_agent-preview
@@ -1,18 +1,34 @@
 #!/usr/bin/env bash
 #MISE hide=true
 # Preview script for the interactive agent picker (shimmer as)
-# Called by fzf: _agent-preview <agent> <agents_dir>
+# Called by fzf: _agent-preview <agent> <agent_home_dir>
 
 AGENT="$1"
-AGENTS_DIR="$2"
+AGENT_HOME_DIR="$2"
 
 echo "$AGENT@ricon.family"
 echo ""
 
-# Identity snippet
-IDENTITY_FILE="$AGENTS_DIR/$AGENT/CLAUDE.md"
-if [ -f "$IDENTITY_FILE" ]; then
-  head -8 "$IDENTITY_FILE"
+# Identity snippet via the home's agent:identity task
+IDENTITY_FILE=$(mise -C "$AGENT_HOME_DIR" run -q agent:identity "$AGENT" 2>/dev/null) || true
+if [ -n "$IDENTITY_FILE" ] && [ -f "$IDENTITY_FILE" ]; then
+  # Skip frontmatter, show first 8 content lines
+  in_fm=false past_fm=false count=0
+  while IFS= read -r line; do
+    if ! $past_fm; then
+      if [[ "$line" == "---" ]]; then
+        if $in_fm; then past_fm=true; fi
+        in_fm=true
+        continue
+      fi
+      $in_fm && continue
+      past_fm=true
+    fi
+    [ -z "$line" ] && [ "$count" -eq 0 ] && continue
+    echo "$line"
+    count=$((count + 1))
+    [ "$count" -ge 8 ] && break
+  done < "$IDENTITY_FILE"
   echo ""
 fi
 

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -30,6 +30,7 @@ if [ -z "$AGENT" ]; then
     exit 1
   fi
 
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   AGENT=$(echo "$AGENTS" | fzf \
     --style=full \
     --height=100% \
@@ -37,6 +38,7 @@ if [ -z "$AGENT" ]; then
     --border=rounded \
     --border-label=" shimmer as " \
     --border-label-pos=3 \
+    --preview-label=" Activity " \
     --pointer="▸" \
     --prompt="  " \
     --ghost="Type to filter..." \
@@ -50,6 +52,8 @@ if [ -z "$AGENT" ]; then
       gutter:-1
       info:dim
     " \
+    --preview="$SCRIPT_DIR/_agent-preview {} '$AGENT_HOME_DIR'" \
+    --preview-window="right,55%,border-rounded,wrap,<60(down,50%,border-horizontal)" \
   ) || exit 1
 
   if [ -z "$AGENT" ]; then
@@ -92,10 +96,12 @@ if [ -n "$B2_BUCKET" ]; then
   echo "export B2_BUCKET='$B2_BUCKET'"
 fi
 
-# Resolve agent identity file via the home's agent:identity task
+# Resolve agent identity content via the home's agent:identity task
 IDENTITY=$(mise -C "$AGENT_HOME_DIR" run -q agent:identity "$AGENT" 2>/dev/null) || true
 if [ -n "$IDENTITY" ]; then
-  echo "export AGENT_IDENTITY='$IDENTITY'"
+  # Export as multi-line env var using $'...' quoting
+  ESCAPED=$(printf '%s' "$IDENTITY" | sed "s/'/'\\\\''/g")
+  echo "export AGENT_IDENTITY='$ESCAPED'"
 else
   echo "# Note: agent home has no agent:identity task — AGENT_IDENTITY not set" >&2
 fi

--- a/test/as/discovery.bats
+++ b/test/as/discovery.bats
@@ -18,11 +18,11 @@ teardown() {
   echo "$output" | grep -qx "bob"
 }
 
-@test "discovery: resolves identity via home's agent:identity task" {
+@test "discovery: agent:identity returns content, not path" {
   setup_test_home "alice"
   run mise -C "$TEST_HOME" run -q agent:identity alice
   [ "$status" -eq 0 ]
-  [[ "$output" == *"notes/alice.md"* ]]
+  [[ "$output" == *"You are alice."* ]]
 }
 
 # ============ Full as flow (secret:get mocked) ============
@@ -50,7 +50,7 @@ teardown() {
   echo "$output" | grep -q "$(basename "$TEST_HOME")"
 }
 
-@test "as: sets AGENT_IDENTITY to identity file" {
+@test "as: AGENT_IDENTITY contains identity content" {
   setup_test_home "alice"
   mock_task "secret/get" 'echo "ghp_fake"'
   mock_shimmer
@@ -58,7 +58,7 @@ teardown() {
   run run_as alice
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "export AGENT_IDENTITY="
-  echo "$output" | grep -q "notes/alice.md"
+  echo "$output" | grep -q "You are alice."
 }
 
 @test "as: works for each agent independently" {

--- a/test/as/helpers.bash
+++ b/test/as/helpers.bash
@@ -25,15 +25,15 @@ $(printf 'echo "%s"\n' "${agents[@]}")
 TASK
   chmod +x "$TEST_HOME/.mise/tasks/agent/list"
 
-  # agent:identity
+  # agent:identity — returns content, not path
   cat > "$TEST_HOME/.mise/tasks/agent/identity" <<'TASK'
 #!/usr/bin/env bash
-#MISE description="Resolve identity"
+#MISE description="Output identity content"
 AGENT="$1"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 IDENTITY_FILE="$DIR/notes/$AGENT.md"
 if [ -f "$IDENTITY_FILE" ]; then
-  echo "$IDENTITY_FILE"
+  cat "$IDENTITY_FILE"
 else
   echo "Error: no identity for $AGENT" >&2
   exit 1


### PR DESCRIPTION
## Summary

- `shimmer as` now calls `<home> agent:list` instead of scanning an `agents/` directory
- Removes dependency on `_get-agents-dir` helper
- Each agent home defines its own discovery mechanism
- 9 new BATS tests with mock-first include overlay for DI

## Agent home contract

Agent homes are expected to expose these mise tasks:
- `agent:list` — output agent names, one per line
- `agent:identity <name>` — output path to identity file
- `human` — output path to HUMAN.md

## Test pattern

Tests use a "mock-first include overlay" — an empty mise project whose `task_config.includes` lists mock tasks before shimmer's real tasks. First include wins, so mocks override without copying anything. This lets us mock `secret:get` without touching 1Password.

## Related PRs

- ricon-family/den — adds `agent:list` task, removes `agents/` directory
- ricon-family/fold — adds `agent:list` task, removes `agents/` directory