### PR TITLE
Replace SHIMMER_DIR with MISE_PROJECT_ROOT in remaining 11 tasks

### DIFF
--- a/.mise/tasks/code/init/_default
+++ b/.mise/tasks/code/init/_default
@@ -3,10 +3,7 @@
 #MISE alias="code:init"
 set -eo pipefail
 
-# Find shimmer directory (for template)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-TEMPLATE_FILE="$SHIMMER_DIR/templates/CLAUDE.md"
+TEMPLATE_FILE="$MISE_PROJECT_ROOT/templates/CLAUDE.md"
 
 # Known orgs
 ORGS=("ricon-family" "KnickKnackLabs")

--- a/.mise/tasks/code/init/welcome
+++ b/.mise/tasks/code/init/welcome
@@ -3,9 +3,6 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Starting New Projects"
@@ -52,6 +49,6 @@ fi
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
-echo "Full documentation: $SHIMMER_DIR/docs/new-project.md"
+echo "Full documentation: $MISE_PROJECT_ROOT/docs/new-project.md"
 echo "List agents:        shimmer agent:list"
 echo ""

--- a/.mise/tasks/human/threads/archive
+++ b/.mise/tasks/human/threads/archive
@@ -2,10 +2,7 @@
 #MISE description="Move resolved threads from HUMAN.md to HUMAN.archive.md"
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-
-HUMAN_PATH=$("$SHIMMER_DIR/.mise/tasks/_get-human-path")
+HUMAN_PATH=$("$MISE_PROJECT_ROOT/.mise/tasks/_get-human-path")
 
 if [ ! -f "$HUMAN_PATH" ]; then
   echo "No HUMAN.md found at $HUMAN_PATH — run: shimmer human:threads:init" >&2
@@ -15,7 +12,7 @@ fi
 # Archive lives next to HUMAN.md
 ARCHIVE_PATH="${HUMAN_PATH%.md}.archive.md"
 
-HUMAN_PATH="$HUMAN_PATH" ARCHIVE_PATH="$ARCHIVE_PATH" PYTHONPATH="$SHIMMER_DIR/lib" python3 << 'PYEOF'
+HUMAN_PATH="$HUMAN_PATH" ARCHIVE_PATH="$ARCHIVE_PATH" PYTHONPATH="$MISE_PROJECT_ROOT/lib" python3 << 'PYEOF'
 import os
 from datetime import date
 from human_threads import split_header_body, parse_threads

--- a/.mise/tasks/human/threads/init
+++ b/.mise/tasks/human/threads/init
@@ -3,12 +3,10 @@
 #USAGE flag "--force" help="Overwrite header only in existing HUMAN.md"
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-TEMPLATE_FILE="$SHIMMER_DIR/templates/HUMAN.md"
+TEMPLATE_FILE="$MISE_PROJECT_ROOT/templates/HUMAN.md"
 
 # Resolve HUMAN.md path via home delegation
-HUMAN_PATH=$("$SHIMMER_DIR/.mise/tasks/_get-human-path")
+HUMAN_PATH=$("$MISE_PROJECT_ROOT/.mise/tasks/_get-human-path")
 
 if [ ! -f "$TEMPLATE_FILE" ]; then
   echo "Error: template not found at $TEMPLATE_FILE" >&2

--- a/.mise/tasks/human/threads/list
+++ b/.mise/tasks/human/threads/list
@@ -2,17 +2,14 @@
 #MISE description="List HUMAN.md threads with status and who's waiting"
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-
-HUMAN_PATH=$("$SHIMMER_DIR/.mise/tasks/_get-human-path")
+HUMAN_PATH=$("$MISE_PROJECT_ROOT/.mise/tasks/_get-human-path")
 
 if [ ! -f "$HUMAN_PATH" ]; then
   echo "No HUMAN.md found at $HUMAN_PATH — run: shimmer human:threads:init" >&2
   exit 1
 fi
 
-output=$(HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$SHIMMER_DIR/lib" python3 << 'PYEOF'
+output=$(HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$MISE_PROJECT_ROOT/lib" python3 << 'PYEOF'
 import os
 from human_threads import (
     split_header_body, parse_threads, extract_thread_body,

--- a/.mise/tasks/human/threads/sort
+++ b/.mise/tasks/human/threads/sort
@@ -2,17 +2,14 @@
 #MISE description="Reorder HUMAN.md threads: warning first, then note, then success"
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-
-HUMAN_PATH=$("$SHIMMER_DIR/.mise/tasks/_get-human-path")
+HUMAN_PATH=$("$MISE_PROJECT_ROOT/.mise/tasks/_get-human-path")
 
 if [ ! -f "$HUMAN_PATH" ]; then
   echo "No HUMAN.md found at $HUMAN_PATH — run: shimmer human:threads:init" >&2
   exit 1
 fi
 
-HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$SHIMMER_DIR/lib" python3 << 'PYEOF'
+HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$MISE_PROJECT_ROOT/lib" python3 << 'PYEOF'
 import os
 from human_threads import split_header_body, parse_threads
 

--- a/.mise/tasks/human/threads/status
+++ b/.mise/tasks/human/threads/status
@@ -2,17 +2,14 @@
 #MISE description="Quick summary of HUMAN.md thread counts by status"
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-
-HUMAN_PATH=$("$SHIMMER_DIR/.mise/tasks/_get-human-path")
+HUMAN_PATH=$("$MISE_PROJECT_ROOT/.mise/tasks/_get-human-path")
 
 if [ ! -f "$HUMAN_PATH" ]; then
   echo "No HUMAN.md found at $HUMAN_PATH — run: shimmer human:threads:init" >&2
   exit 1
 fi
 
-HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$SHIMMER_DIR/lib" python3 << 'PYEOF'
+HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$MISE_PROJECT_ROOT/lib" python3 << 'PYEOF'
 import os
 from human_threads import (
     split_header_body, parse_threads, extract_thread_body,

--- a/.mise/tasks/human/threads/tidy
+++ b/.mise/tasks/human/threads/tidy
@@ -2,17 +2,14 @@
 #MISE description="Tidy HUMAN.md: convert raw codeblocks to callouts, promote/demote thread types"
 set -eo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-
-HUMAN_PATH=$("$SHIMMER_DIR/.mise/tasks/_get-human-path")
+HUMAN_PATH=$("$MISE_PROJECT_ROOT/.mise/tasks/_get-human-path")
 
 if [ ! -f "$HUMAN_PATH" ]; then
   echo "No HUMAN.md found at $HUMAN_PATH — run: shimmer human:threads:init" >&2
   exit 1
 fi
 
-HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$SHIMMER_DIR/lib" python3 << 'PYEOF'
+HUMAN_PATH="$HUMAN_PATH" PYTHONPATH="$MISE_PROJECT_ROOT/lib" python3 << 'PYEOF'
 import re, os
 from human_threads import (
     NAME_PAT, CALLOUT_OPENER,

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -12,9 +12,8 @@ else
   AGENT=""
 fi
 
-# Get shimmer repo location (tasks are in .mise/tasks/)
+# Task sibling directory (for helpers like _days-until)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -82,10 +81,10 @@ if [ -n "$AGENT" ]; then
   # Email check
   CONFIG_FILE="${HOME}/.config/himalaya/config.toml"
   if [ -f "$CONFIG_FILE" ] && grep -q "accounts.$AGENT" "$CONFIG_FILE" 2>/dev/null; then
-    # Get quota and unread count (run from shimmer dir to find tasks)
-    QUOTA_OUTPUT=$(cd "$SHIMMER_DIR" && mise run -q email:quota 2>/dev/null || echo "")
+    # Get quota and unread count
+    QUOTA_OUTPUT=$(mise -C "$MISE_PROJECT_ROOT" run -q email:quota 2>/dev/null || echo "")
     QUOTA_PERCENT=$(echo "$QUOTA_OUTPUT" | grep -oE '[0-9]+%' | tr -d '%')
-    UNREAD_COUNT=$(cd "$SHIMMER_DIR" && mise run -q email:list --unread --count 2>/dev/null || echo "0")
+    UNREAD_COUNT=$(mise -C "$MISE_PROJECT_ROOT" run -q email:list --unread --count 2>/dev/null || echo "0")
 
     # Build status string
     if [ -n "$UNREAD_COUNT" ] && [ "$UNREAD_COUNT" -gt 0 ]; then
@@ -170,7 +169,7 @@ if [ -n "$AGENT" ]; then
   if command -v mc &>/dev/null && mc alias list "$AGENT" 2>/dev/null | grep -q "$AGENT"; then
     B2_BUCKET_VAL="${B2_BUCKET:-}"
     if [ -z "$B2_BUCKET_VAL" ]; then
-      B2_BUCKET_VAL=$(mise run -q secret:get "$AGENT" b2-bucket 2>/dev/null) || B2_BUCKET_VAL=""
+      B2_BUCKET_VAL=$(mise -C "$MISE_PROJECT_ROOT" run -q secret:get "$AGENT" b2-bucket 2>/dev/null) || B2_BUCKET_VAL=""
     fi
     if [ -n "$B2_BUCKET_VAL" ]; then
       OBJ_COUNT=$(mc ls --recursive --json "${AGENT}/${B2_BUCKET_VAL}" 2>/dev/null | jq -s 'length' 2>/dev/null || echo "?")

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -7,20 +7,17 @@ set -eo pipefail
 TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-
 # Validate workflows.yaml against schema
 if [[ -f workflows.yaml ]]; then
   echo "Validating workflows.yaml..."
-  check-jsonschema --schemafile "$SHIMMER_DIR/workflows.schema.json" workflows.yaml
+  check-jsonschema --schemafile "$MISE_PROJECT_ROOT/workflows.schema.json" workflows.yaml
 fi
 
 # Use local template if exists, otherwise use shimmer's
 if [[ -f ".github/templates/agent-scheduled.yml" ]]; then
   TEMPLATE=".github/templates/agent-scheduled.yml"
 else
-  TEMPLATE="$SHIMMER_DIR/.github/templates/agent-scheduled.yml"
+  TEMPLATE="$MISE_PROJECT_ROOT/.github/templates/agent-scheduled.yml"
 fi
 OUTPUT_DIR=".github/workflows"
 CHECK_MODE="${usage_check:-false}"
@@ -36,9 +33,9 @@ mkdir -p "$OUTPUT_DIR"
 
 # Copy base workflow templates from shimmer
 echo "Copying base templates from shimmer..."
-cp "$SHIMMER_DIR/.github/templates/agent-run.yml" "$OUTPUT_DIR/agent-run.yml"
+cp "$MISE_PROJECT_ROOT/.github/templates/agent-run.yml" "$OUTPUT_DIR/agent-run.yml"
 echo "Generated: agent-run.yml"
-cp "$SHIMMER_DIR/.github/templates/agent-message.yml" "$OUTPUT_DIR/agent-message.yml"
+cp "$MISE_PROJECT_ROOT/.github/templates/agent-message.yml" "$OUTPUT_DIR/agent-message.yml"
 echo "Generated: agent-message.yml"
 
 # Read workflows from manifest

--- a/.mise/tasks/zettel/welcome
+++ b/.mise/tasks/zettel/welcome
@@ -12,10 +12,6 @@ else
   AGENT=""
 fi
 
-# Get shimmer repo location
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHIMMER_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-
 if [ -z "$AGENT" ]; then
   echo ""
   echo "Zettelkasten"
@@ -47,7 +43,7 @@ if [ ! -d "$ZETTEL_DIR" ]; then
   echo "    echo '# README' > README.md"
   echo ""
   echo "  Then explore your world and document what you find."
-  echo "  Full guide: $SHIMMER_DIR/docs/agent-zettelkasten.md"
+  echo "  Full guide: $MISE_PROJECT_ROOT/docs/agent-zettelkasten.md"
   echo ""
   exit 0
 fi


### PR DESCRIPTION
## Summary

Completes the migration started in #652. Replaces the manual `SHIMMER_DIR` computation pattern (`BASH_SOURCE` + `cd` + `pwd`) with mise's built-in `MISE_PROJECT_ROOT` environment variable across all remaining tasks that used it.

- **welcome** — 3 sibling task calls (`email:quota`, `email:list`, `secret:get`) now use `mise -C "$MISE_PROJECT_ROOT" run`; kept `SCRIPT_DIR` since it's still used for the `_days-until` helper
- **zettel/welcome** — path reference to docs
- **workflows/generate** — schema path, template paths (5 references)
- **code/init/_default** — template path
- **code/init/welcome** — docs path
- **human/threads/{init,tidy,sort,archive,status,list}** — `_get-human-path` helper path and `PYTHONPATH` for `lib/`

11 files changed, -55/+24 lines. Net deletion of 31 lines of boilerplate.

**Not in scope:** `matrix/invite` also references `SHIMMER_DIR`, but in generated onboarding documentation (user-facing instructions), not for task resolution. Flagging it separately.

## Test plan
- [ ] Run `shimmer welcome` — verify all status checks still work
- [ ] Run `shimmer zettel:welcome` — verify docs path resolves
- [ ] Run `shimmer human:threads:status` — verify PYTHONPATH and `_get-human-path` resolve
- [ ] Run `shimmer workflows:generate --check` in a repo with `workflows.yaml` — verify schema/template paths resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)