### PR TITLE
Migrate agent discovery to home's agent:list task

### DIFF
--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -8,22 +8,15 @@
 
 set -e
 
-if [ -z "${AGENT_HOME:-}" ]; then
-  echo "Error: AGENT_HOME not set" >&2
-  echo "Run: eval \$(shimmer as <agent>)" >&2
-  exit 1
-fi
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
 
-# Validate this is an agent home
-if [ ! -d "$AGENT_HOME/agents" ]; then
-  echo "Error: No agents/ directory in $AGENT_HOME" >&2
-  exit 1
-fi
+# Resolve the agent home
+AGENT_HOME_DIR="${AGENT_HOME:-$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")}"
 
-if [ ! -f "$AGENT_HOME/.github/workflows/agent-message.yml" ]; then
-  echo "Error: No agent-message.yml workflow in $AGENT_HOME" >&2
-  exit 1
-fi
+# Delegate agent discovery to the home's agent:list task
+get_agents() {
+  mise -C "$AGENT_HOME_DIR" run -q agent:list 2>/dev/null
+}
 
 MESSAGE="$usage_message"
 STAGGER="${usage_stagger:-30}"
@@ -31,10 +24,13 @@ DRY_RUN="${usage_dry_run:-false}"
 MODEL="${usage_model:-}"
 AGENTS_FLAG="${usage_agents:-}"
 
-# Discover or filter agents
-ALL_AGENTS=$(ls -d "$AGENT_HOME/agents"/*/ 2>/dev/null \
-  | xargs -n1 basename \
-  | sort)
+# Discover agents
+ALL_AGENTS=$(get_agents) || true
+if [ -z "$ALL_AGENTS" ]; then
+  echo "Error: could not list agents." >&2
+  echo "Does $AGENT_HOME_DIR provide an 'agent:list' task?" >&2
+  exit 1
+fi
 
 if [ -n "$AGENTS_FLAG" ]; then
   # Filter to requested agents, validate each exists

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -7,16 +7,19 @@
 
 set -e
 
-# Discover agents from AGENT_HOME
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+
+# Resolve the agent home (the repo the caller is in)
+AGENT_HOME_DIR="${AGENT_HOME:-$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")}"
+
+# Delegate agent discovery to the home's agent:list task
 get_agents() {
-  ls -d "$AGENT_HOME/agents"/*/ 2>/dev/null \
-    | xargs -n1 basename \
-    | sort
+  mise -C "$AGENT_HOME_DIR" run -q agent:list 2>/dev/null
 }
 
-# Get the repo name from AGENT_HOME
+# Get the repo name from the agent home
 get_repo() {
-  git -C "$AGENT_HOME" remote get-url origin 2>/dev/null \
+  git -C "$AGENT_HOME_DIR" remote get-url origin 2>/dev/null \
     | sed 's/.*github.com[:/]//' \
     | sed 's/\.git$//'
 }
@@ -30,29 +33,21 @@ if [ -n "${usage_repo:-}" ]; then
   # Remote mode: target a different repo, skip local validation
   REPO="$usage_repo"
 else
-  # Local mode: use AGENT_HOME (original behavior)
-  if [ -z "${AGENT_HOME:-}" ]; then
-    echo "Error: AGENT_HOME not set (use --repo for remote agent homes)" >&2
-    echo "Run: eval \$(shimmer as <agent>)" >&2
-    exit 1
-  fi
-
-  if [ ! -d "$AGENT_HOME/agents" ]; then
-    echo "Error: No agents/ directory in $AGENT_HOME" >&2
-    exit 1
-  fi
-
-  if [ ! -f "$AGENT_HOME/.github/workflows/agent-message.yml" ]; then
-    echo "Error: No agent-message.yml workflow in $AGENT_HOME" >&2
+  # Local mode: discover agents via home's agent:list task
+  AGENTS=$(get_agents) || true
+  if [ -z "$AGENTS" ]; then
+    echo "Error: could not list agents." >&2
+    echo "Does $AGENT_HOME_DIR provide an 'agent:list' task?" >&2
+    echo "Or use --repo for remote agent homes." >&2
     exit 1
   fi
 
   REPO=$(get_repo)
 
-  # Validate agent exists locally
-  if ! get_agents | grep -qx "$AGENT"; then
+  # Validate agent exists
+  if ! echo "$AGENTS" | grep -qx "$AGENT"; then
     echo "Unknown agent: $AGENT"
-    echo "Available agents: $(get_agents | tr '\n' ' ')"
+    echo "Available agents: $(echo "$AGENTS" | tr '\n' ' ')"
     exit 1
   fi
 fi

--- a/.mise/tasks/agent/sync-secrets
+++ b/.mise/tasks/agent/sync-secrets
@@ -24,18 +24,16 @@ fi
 
 export SHIMMER_SECRETS_PROVIDER="$PROVIDER"
 
-# Discover agents from the agents/ directory
+# Delegate agent discovery to the home's agent:list task
 get_agents() {
-  if [ -d "agents" ]; then
-    ls -d agents/*/ 2>/dev/null \
-      | xargs -n1 basename \
-      | sort
-  else
-    echo "ERROR: No agents/ directory found. Cannot discover agents." >&2
-    echo "Either run from a repo with an agents/ directory or specify a single agent:" >&2
-    echo "  shimmer agent:sync-secrets <agent>" >&2
+  local home_dir
+  home_dir=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$TARGET_DIR")
+  mise -C "$home_dir" run -q agent:list 2>/dev/null || {
+    echo "ERROR: Could not list agents." >&2
+    echo "Does the home provide an 'agent:list' task?" >&2
+    echo "Or specify a single agent: shimmer agent:sync-secrets <agent>" >&2
     return 1
-  fi
+  }
 }
 
 # Map from secret key to GitHub secret name suffix

--- a/.mise/tasks/ci/watch
+++ b/.mise/tasks/ci/watch
@@ -5,12 +5,11 @@
 
 set -e
 
-# Discover agents from the caller's agents directory
+# Delegate agent discovery to the home's agent:list task
 get_agents() {
-  local agents_dir="${CALLER_PWD:-.}/agents"
-  ls -d "$agents_dir"/*/ 2>/dev/null \
-    | xargs -n1 basename \
-    | sort
+  local home_dir
+  home_dir=$(git -C "${CALLER_PWD:-.}" rev-parse --show-toplevel 2>/dev/null || echo "${CALLER_PWD:-.}")
+  mise -C "$home_dir" run -q agent:list 2>/dev/null
 }
 
 # Discover jobs for a specific agent


### PR DESCRIPTION
## Summary

Four tasks were still using `ls -d agents/*/` to discover agents instead of delegating to the home's `agent:list` task. This broke in homes like fold that removed their `agents/` directory.

## Migrated tasks

- `agent:message` — also resolves `AGENT_HOME` from caller dir (no longer requires `AGENT_HOME` env var for local mode)
- `agent:broadcast` — same pattern
- `agent:sync-secrets` — same pattern
- `ci:watch` — same pattern

All now follow the pattern established in `as`:
```bash
mise -C "$AGENT_HOME_DIR" run -q agent:list
```

## Context

The `as` task was already updated to use `agent:list`. These four were missed. Discovered when `shimmer agent:message` failed from fold with "No agents/ directory" — fold removed its `agents/` directory since agent discovery is now handled by the `agent:list` task.

## Test plan

- [x] Verified `agent:message --repo` still works (dispatched 4 agents successfully)
- [x] Code review: all four tasks follow the same pattern as `as`
- [ ] Needs testing of local mode with a home that provides `agent:list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)