### PR TITLE
Fix eval shell injection in mise task arg parsing (or#146)

### DIFF
--- a/.mise/tasks/browser/run
+++ b/.mise/tasks/browser/run
@@ -11,8 +11,8 @@ set -e
 SCRIPT_NAME="${usage_script:?Usage: shimmer browser:run <script> [args...]}"
 HEADED="${usage_headed:-false}"
 BROWSER_ID="${usage_browser:-}"
-# Variadic args come as a shell-escaped string
-eval "SCRIPT_ARGS=(${usage_args:-})"
+# Variadic args come as a whitespace-separated string
+read -ra SCRIPT_ARGS <<< "${usage_args:-}"
 
 # Determine agent identity
 if [ -n "$GIT_AUTHOR_EMAIL" ]; then

--- a/.mise/tasks/email/delete
+++ b/.mise/tasks/email/delete
@@ -15,12 +15,12 @@ PERMANENT="${usage_permanent:-false}"
 FOLDER="${usage_folder:-INBOX}"
 
 # Parse variadic args - mise passes them as a shell-escaped string, not an array
-# Validate before eval: IDs should only contain digits and whitespace
+# Validate: IDs should only contain digits and whitespace
 if [ -n "$usage_ids" ] && [[ ! "$usage_ids" =~ ^[0-9[:space:]]+$ ]]; then
   echo "Error: IDs must be numeric (got: $usage_ids)"
   exit 1
 fi
-eval "IDS=($usage_ids)"
+read -ra IDS <<< "$usage_ids"
 
 # Reject non-permanent delete from Trash - use email:purge instead
 if echo "$FOLDER" | grep -qi '^trash$' && [ "$PERMANENT" != "true" ]; then

--- a/.mise/tasks/email/export
+++ b/.mise/tasks/email/export
@@ -17,12 +17,12 @@ LIMIT="${usage_limit:-500}"
 ALL="${usage_all:-false}"
 
 # Parse variadic args - mise passes them as a shell-escaped string, not an array
-# Validate before eval: IDs should only contain digits and whitespace
+# Validate: IDs should only contain digits and whitespace
 if [ -n "$usage_ids" ] && [[ ! "$usage_ids" =~ ^[0-9[:space:]]+$ ]]; then
   echo "Error: IDs must be numeric (got: $usage_ids)"
   exit 1
 fi
-eval "IDS=($usage_ids)"
+read -ra IDS <<< "$usage_ids"
 
 # Determine current agent from environment or git config
 if [ -n "$GIT_AUTHOR_EMAIL" ]; then

--- a/.mise/tasks/email/wait
+++ b/.mise/tasks/email/wait
@@ -20,10 +20,9 @@ SCRIPT_DIR="$(dirname "$0")"
 TIMEOUT=$("$SCRIPT_DIR/../_parse-duration" "${usage_timeout:-600}")
 
 # Parse optional query (variadic args - mise passes as shell-escaped string)
-# Use eval to strip mise's quoting, same pattern as email:delete
 QUERY_ARGS=()
 if [ -n "${usage_query:-}" ]; then
-  eval "QUERY_ARGS=($usage_query)"
+  read -ra QUERY_ARGS <<< "$usage_query"
 fi
 
 # Determine current agent from environment or git config


### PR DESCRIPTION
## Summary

- Replace `eval "ARRAY=(${usage_var})"` with `read -ra ARRAY <<< "${usage_var}"` in 4 mise tasks
- `eval` on variadic mise args is a shell injection vector — if the arg string contains command substitutions or semicolons, they execute. `read -ra` splits on whitespace without interpreting shell metacharacters
- **Vulnerable (no validation):** `browser/run`, `email/wait`
- **Mitigated but unnecessary:** `email/delete`, `email/export` (had regex validation, but eval was still gratuitous)

Fixes ricon-family/or#146

## Files changed

- `.mise/tasks/browser/run` — line 15
- `.mise/tasks/email/wait` — line 26
- `.mise/tasks/email/delete` — line 23
- `.mise/tasks/email/export` — line 25

## Test plan

- [ ] Verify `shimmer browser:run <script> arg1 arg2` still passes args correctly
- [ ] Verify `shimmer email:wait from someone` still filters correctly
- [ ] Verify `shimmer email:delete 123 456` still works with multiple IDs
- [ ] Verify `shimmer email:export 123 456` still works with multiple IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)