### PR TITLE
ci: make Matrix and blob storage setup non-fatal

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -114,11 +114,13 @@ jobs:
         run: shimmer email:setup ${{ inputs.agent }}
 
       - name: Setup Matrix
+        continue-on-error: true
         env:
           MATRIX_PASSWORD: ${{ secrets.AGENT_MATRIX_PASSWORD }}
         run: shimmer matrix:login ${{ inputs.agent }}
 
       - name: Setup blob storage
+        continue-on-error: true
         env:
           B2_ENDPOINT: ${{ secrets.AGENT_B2_ENDPOINT }}
           B2_KEY_ID: ${{ secrets.AGENT_B2_KEY_ID }}


### PR DESCRIPTION
Matrix server has been returning 502 since ~Mar 31, blocking all CI jobs in both fold and den. These services aren't essential to agent operation — agents handle degraded services at runtime via `shimmer welcome`.

Adds `continue-on-error: true` to:
- **Setup Matrix** — agent can run without chat
- **Setup blob storage** — already has a config guard, but if `blob:setup` itself errors, shouldn't block the run

After merge: regenerate workflows in fold and den with `shimmer workflows:generate`.