### PR TITLE
fix(email): use UIDs instead of sequence numbers in sizes and inspect

### DIFF
--- a/.mise/tasks/email/inspect
+++ b/.mise/tasks/email/inspect
@@ -25,7 +25,7 @@ RESULT=$({
   sleep 0.3
   echo "b SELECT \"$FOLDER\""
   sleep 0.3
-  echo "c FETCH $ID (RFC822.SIZE BODYSTRUCTURE BODY[HEADER.FIELDS (From To Subject Date Content-Type)])"
+  echo "c UID FETCH $ID (RFC822.SIZE BODYSTRUCTURE BODY[HEADER.FIELDS (From To Subject Date Content-Type)])"
   sleep 0.5
   echo "d LOGOUT"
 } | openssl s_client -connect mail.ricon.family:993 -quiet 2>/dev/null)

--- a/.mise/tasks/email/sizes
+++ b/.mise/tasks/email/sizes
@@ -25,7 +25,7 @@ for F in "${FOLDERS[@]}"; do
     sleep 0.3
     echo "b SELECT \"$F\""
     sleep 0.3
-    echo "c FETCH 1:* (UID RFC822.SIZE)"
+    echo "c UID FETCH 1:* (RFC822.SIZE)"
     sleep 0.5
     echo "d LOGOUT"
   } | openssl s_client -connect mail.ricon.family:993 -quiet 2>/dev/null)
@@ -42,7 +42,7 @@ for F in "${FOLDERS[@]}"; do
   ID_SIZES=$(echo "$RESULT" | grep "RFC822.SIZE" | awk -F'[* ()]+' '{
     id=""; size=""
     for (i=1; i<=NF; i++) {
-      if ($i == "FETCH") id = $(i-1)
+      if ($i == "UID") id = $(i+1)
       if ($i == "RFC822.SIZE") size = $(i+1)
     }
     if (id && size) print id, size


### PR DESCRIPTION
**Problem:** `email:sizes` and `email:inspect` used raw IMAP `FETCH` commands with sequence numbers, while `email:list` (via himalaya) uses UIDs. This meant IDs shown by `sizes` couldn't be passed to `inspect`, `delete`, or `read` — and vice versa. Worse, passing a UID to a sequence-number command could silently operate on the wrong message.

**Fix:** Use `UID FETCH` in both commands and extract the UID from the IMAP response.

Three-line change, verified locally with `mise run`.