### PR TITLE
fix: add shell to agent-run workflow dependencies

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           shiv install shimmer
           shiv install sessions
+          shiv install shell
           shiv install secrets
           shiv install rudi
           shiv install notes


### PR DESCRIPTION
## Problem

`sessions wake` requires `shell` (KnickKnackLabs/shell) to spawn agents via zmx. The agent-run workflow template installs shimmer, sessions, secrets, rudi, and notes — but not shell.

This causes all headless agent dispatches via `shimmer agent:message` to fail immediately:

```
Error: shell is required (shiv install shell)
```

Discovered when c0da's review dispatch for zmx#5 failed: [fold run 23973164202](https://github.com/ricon-family/fold/actions/runs/23973164202).

## Fix

Add `shiv install shell` to the template. One line.

## After merge

Regenerate workflows in any repo that uses this template (`shimmer workflows:generate`).