### PR TITLE
refactor: replace BASH_SOURCE gymnastics with MISE_CONFIG_ROOT, add shell strictness

### DIFF
--- a/.mise/tasks/_agent-preview
+++ b/.mise/tasks/_agent-preview
@@ -2,6 +2,7 @@
 #MISE hide=true
 # Preview script for the interactive agent picker (shimmer as)
 # Called by fzf: _agent-preview <agent> <agent_home_dir>
+set -eo pipefail
 
 AGENT="$1"
 AGENT_HOME_DIR="$2"

--- a/.mise/tasks/_blob-env
+++ b/.mise/tasks/_blob-env
@@ -4,7 +4,7 @@
 # Source this file from blob tasks to get agent, alias, and bucket info.
 #
 # Usage:
-#   source "$(dirname "${BASH_SOURCE[0]}")/_blob-env"
+#   source "$MISE_CONFIG_ROOT/.mise/tasks/_blob-env"
 #
 # After sourcing, these variables are set:
 #   BLOB_AGENT    — detected agent name

--- a/.mise/tasks/_get-agents-dir
+++ b/.mise/tasks/_get-agents-dir
@@ -9,9 +9,9 @@
 #
 # Returns the path to agents/ or fails with exit 1 if not found.
 
-set -eo pipefail
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_DIR="$MISE_CONFIG_ROOT/.mise/tasks"
 TARGET_DIR="${1:-${CALLER_PWD:-.}}"
 
 # Check target directory first
@@ -21,7 +21,7 @@ if [ -d "$TARGET_DIR/agents" ]; then
 fi
 
 # Try git repository root
-if ROOT=$("$SCRIPT_DIR/_get-git-root" "$TARGET_DIR" 2>/dev/null) && [ -d "$ROOT/agents" ]; then
+if ROOT=$("$TASK_DIR/_get-git-root" "$TARGET_DIR" 2>/dev/null) && [ -d "$ROOT/agents" ]; then
   echo "$ROOT/agents"
   exit 0
 fi

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -33,7 +33,7 @@ if [ -z "$AGENT" ]; then
     exit 1
   fi
 
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  TASK_DIR="$MISE_CONFIG_ROOT/.mise/tasks"
   AGENT=$(echo "$AGENTS" | fzf \
     --style=full \
     --height=100% \
@@ -55,7 +55,7 @@ if [ -z "$AGENT" ]; then
       gutter:-1
       info:dim
     " \
-    --preview="$SCRIPT_DIR/_agent-preview {} '$AGENT_HOME_DIR'" \
+    --preview="$TASK_DIR/_agent-preview {} '$AGENT_HOME_DIR'" \
     --preview-window="right,55%,border-rounded,wrap,<60(down,50%,border-horizontal)" \
   ) || exit 1
 

--- a/.mise/tasks/blob/delete
+++ b/.mise/tasks/blob/delete
@@ -2,10 +2,9 @@
 #MISE description="Delete a blob from storage"
 #USAGE arg "<key>" help="Object key to delete"
 
-set -eo pipefail
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../_blob-env"
+source "$MISE_CONFIG_ROOT/.mise/tasks/_blob-env"
 
 KEY="$usage_key"
 

--- a/.mise/tasks/blob/get
+++ b/.mise/tasks/blob/get
@@ -3,10 +3,9 @@
 #USAGE arg "<key>" help="Object key to download"
 #USAGE arg "[dest]" help="Local destination path (default: stdout)"
 
-set -eo pipefail
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../_blob-env"
+source "$MISE_CONFIG_ROOT/.mise/tasks/_blob-env"
 
 KEY="$usage_key"
 DEST="${usage_dest:-}"

--- a/.mise/tasks/blob/list
+++ b/.mise/tasks/blob/list
@@ -3,10 +3,9 @@
 #USAGE arg "[prefix]" help="Key prefix to filter (e.g., sessions/)"
 #USAGE flag "--json" help="Output as JSON"
 
-set -eo pipefail
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../_blob-env"
+source "$MISE_CONFIG_ROOT/.mise/tasks/_blob-env"
 
 PREFIX="${usage_prefix:-}"
 JSON="${usage_json:-false}"

--- a/.mise/tasks/blob/put
+++ b/.mise/tasks/blob/put
@@ -3,10 +3,9 @@
 #USAGE arg "<key>" help="Object key (path in bucket, e.g., sessions/2024-01-15.tar.gz)"
 #USAGE arg "[file]" help="Local file to upload (use - for stdin, omit for stdin)"
 
-set -eo pipefail
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../_blob-env"
+source "$MISE_CONFIG_ROOT/.mise/tasks/_blob-env"
 
 KEY="$usage_key"
 FILE="${usage_file:-}"

--- a/.mise/tasks/email/inspect
+++ b/.mise/tasks/email/inspect
@@ -16,7 +16,7 @@ if [ -z "$ID" ]; then
 fi
 
 # shellcheck source=scripts/imap-init.sh
-source "$(dirname "${BASH_SOURCE[0]}")/scripts/imap-init.sh"
+source "$MISE_CONFIG_ROOT/.mise/tasks/email/scripts/imap-init.sh"
 
 # Fetch message metadata via IMAP
 RESULT=$({

--- a/.mise/tasks/email/quota
+++ b/.mise/tasks/email/quota
@@ -4,7 +4,7 @@
 set -e
 
 # shellcheck source=scripts/imap-init.sh
-source "$(dirname "${BASH_SOURCE[0]}")/scripts/imap-init.sh"
+source "$MISE_CONFIG_ROOT/.mise/tasks/email/scripts/imap-init.sh"
 
 # Query IMAP for quota using GETQUOTAROOT command
 QUOTA_OUTPUT=$({

--- a/.mise/tasks/email/scripts/imap-init.sh
+++ b/.mise/tasks/email/scripts/imap-init.sh
@@ -1,7 +1,7 @@
 # Sourceable helper for email tasks that need direct IMAP access.
 # Sets: AGENT, CONFIG_FILE, PASS
 #
-# Usage: source "$(dirname "${BASH_SOURCE[0]}")/scripts/imap-init.sh"
+# Usage: source "$MISE_CONFIG_ROOT/.mise/tasks/email/scripts/imap-init.sh"
 
 export RUST_LOG=error
 

--- a/.mise/tasks/email/sizes
+++ b/.mise/tasks/email/sizes
@@ -9,7 +9,7 @@ FOLDER="${usage_folder:-}"
 TOP="${usage_top:-5}"
 
 # shellcheck source=scripts/imap-init.sh
-source "$(dirname "${BASH_SOURCE[0]}")/scripts/imap-init.sh"
+source "$MISE_CONFIG_ROOT/.mise/tasks/email/scripts/imap-init.sh"
 
 if [ -n "$FOLDER" ]; then
   FOLDERS=("$FOLDER")

--- a/.mise/tasks/github/welcome
+++ b/.mise/tasks/github/welcome
@@ -54,9 +54,9 @@ echo "Status: ✓ authenticated"
 echo ""
 
 # Show token expiration
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_DIR="$MISE_CONFIG_ROOT/.mise/tasks"
 if [ -n "$EXPIRY" ]; then
-  DAYS_LEFT=$("$SCRIPT_DIR/../_days-until" "$EXPIRY" 2>/dev/null || echo "")
+  DAYS_LEFT=$("$TASK_DIR/_days-until" "$EXPIRY" 2>/dev/null || echo "")
   if [ -n "$DAYS_LEFT" ] && [ "$DAYS_LEFT" -lt 0 ]; then
     echo "Token:  ✗ expired ($EXPIRY)"
     echo "        Rotate: shimmer github:token:regenerate $AGENT"

--- a/.mise/tasks/matrix/invite
+++ b/.mise/tasks/matrix/invite
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Generate Matrix onboarding instructions for external agents"
 #USAGE arg "[username]" help="Their Matrix username (optional, uses placeholder if not provided)"
+set -euo pipefail
 
 USERNAME="${1:-<your-username>}"
 

--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Output shell configuration for global shimmer command (use with eval)"
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_DIR="$MISE_CONFIG_ROOT"
 
 # Create shim so shimmer is callable from scripts and subprocesses
 BIN_DIR="$HOME/.local/bin"

--- a/.mise/tasks/tasks
+++ b/.mise/tasks/tasks
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="List available shimmer tasks (optionally filtered by group)"
 #USAGE arg "[group]" help="Task group prefix to filter by (e.g. email, browser, agent)"
+set -euo pipefail
 
-GROUP="${usage_group:-$1}"
+GROUP="${usage_group:-}"
 
 if [ -n "$GROUP" ]; then
   RESULTS=$(mise tasks | grep "^${GROUP}:")

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -16,7 +16,7 @@ else
 fi
 
 # Task sibling directory (for helpers like _days-until)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_DIR="$MISE_CONFIG_ROOT/.mise/tasks"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -87,7 +87,7 @@ if [ -n "$AGENT" ]; then
     GH_CHECK="✓" GH_HINT="shimmer github:welcome"
 
     if [ -n "$GH_EXPIRY" ]; then
-      DAYS_LEFT=$("$SCRIPT_DIR/_days-until" "$GH_EXPIRY" 2>/dev/null || echo "")
+      DAYS_LEFT=$("$TASK_DIR/_days-until" "$GH_EXPIRY" 2>/dev/null || echo "")
       if [ -n "$DAYS_LEFT" ] && [ "$DAYS_LEFT" -lt 0 ]; then
         GH_CHECK="✗" GH_HINT="shimmer github:token:regenerate $AGENT"
         GH_USER="$GH_USER (token expired)"

--- a/.mise/tasks/whoami
+++ b/.mise/tasks/whoami
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Show current git and GitHub identity"
+set -euo pipefail
 
 echo "Git identity:"
 echo "  Author:    ${GIT_AUTHOR_NAME:-$(git config user.name)} <${GIT_AUTHOR_EMAIL:-$(git config user.email)}>"


### PR DESCRIPTION
Shimmer renovation: standardize path resolution and shell strictness across task files.

## Path resolution: `BASH_SOURCE` → `MISE_CONFIG_ROOT`

11 tasks computed `SCRIPT_DIR` or `REPO_DIR` via `dirname "${BASH_SOURCE[0]}"` gymnastics to reach sibling tasks or lib files. `$MISE_CONFIG_ROOT` is always available in mise file tasks and does the same thing without the fragile path arithmetic.

**Before:**
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
source "$SCRIPT_DIR/../_blob-env"
"$SCRIPT_DIR/_days-until" "$EXPIRY"
```

**After:**
```bash
source "$MISE_CONFIG_ROOT/.mise/tasks/_blob-env"
"$MISE_CONFIG_ROOT/.mise/tasks/_days-until" "$EXPIRY"
```

Affected: `as`, `welcome`, `github/welcome`, `shell`, `_get-agents-dir`, `blob/{delete,get,list,put}`, `email/{quota,inspect,sizes}`, `email/scripts/imap-init.sh`, `_blob-env` (comment only)

## Shell strictness

5 tasks had no `set -e` at all. Added shell strictness:
- `whoami`, `tasks`, `matrix/invite` → `set -euo pipefail`
- `_agent-preview` → `set -eo pipefail` (uses unguarded `$1`/`$2` from fzf)
- `shell` — no change needed (already doesn't use unset vars)

4 blob tasks upgraded from `set -eo pipefail` → `set -euo pipefail`.

## Not touched

- `code/init/_default` — has `BASH_SOURCE` in a heredoc that scaffolds new repos (separate concern)
- Tasks with `set -e` only — upgrading to `-euo` across all ~80 tasks is a bigger sweep that needs individual attention for unset var safety

## Tests

54/54 pass (full suite, no changes to test files).
