### PR TITLE
fix: shimmer agent --headless uses foreground wake

### DIFF
--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -55,8 +55,8 @@ if [ "$HEADLESS" = "true" ]; then
     SESSION_ID=$(sessions new "${NEW_ARGS[@]}")
   fi
 
-  # Wake the session — launches via zmx, returns immediately
-  WAKE_ARGS=("$SESSION_ID" --message "$MESSAGE")
+  # Wake the session — foreground + headless (blocks until done)
+  WAKE_ARGS=("$SESSION_ID" --headless --message "$MESSAGE")
   [ -n "$TIMEOUT" ] && WAKE_ARGS+=(--meta "timeout=$TIMEOUT")
   sessions wake "${WAKE_ARGS[@]}"
 else

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -64,7 +64,7 @@ setup() {
   # sessions new includes agent.name metadata
   grep "^new " "$SESSIONS_LOG" | grep -q "agent.name=test-agent"
   # sessions wake was called with the session ID from new
-  grep -q "^wake mock-session-id-001 --message review the PR" "$SESSIONS_LOG"
+  grep -q "^wake mock-session-id-001 --headless --message review the PR" "$SESSIONS_LOG"
 }
 
 @test "headless: session name uses full epoch timestamp" {
@@ -94,7 +94,7 @@ setup() {
   # sessions new should NOT be called
   ! grep -q "^new " "$SESSIONS_LOG"
   # sessions wake called with existing session ID
-  grep -q "^wake existing-session-42 --message continue work" "$SESSIONS_LOG"
+  grep -q "^wake existing-session-42 --headless --message continue work" "$SESSIONS_LOG"
 }
 
 @test "headless: forwards model to sessions new" {


### PR DESCRIPTION
Passes `--headless` to `sessions wake` so headless agent sessions run in the foreground and block until done. This fixes CI where GitHub Actions killed the zmx background process before the agent could work.

Depends on: https://github.com/KnickKnackLabs/sessions/pull/40

2 test assertions updated. 54/54 pass.