### PR TITLE
Remove email wrappers — callers use emails package directly

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -146,7 +146,7 @@ jobs:
         run: shimmer gpg:setup ${{ inputs.agent }}
 
       - name: Setup email
-        run: shimmer email:setup ${{ inputs.agent }}
+        run: emails setup ${{ inputs.agent }}
 
       - name: Setup Matrix
         continue-on-error: true

--- a/.mise/tasks/email/archive
+++ b/.mise/tasks/email/archive
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Archive email message(s)"
-# Delegates to KnickKnackLabs/emails — shimmer email:archive is preserved for compatibility.
-exec emails archive "$@"

--- a/.mise/tasks/email/delete
+++ b/.mise/tasks/email/delete
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Delete email message(s) (moves to Trash)"
-# Delegates to KnickKnackLabs/emails — shimmer email:delete is preserved for compatibility.
-exec emails delete "$@"

--- a/.mise/tasks/email/export
+++ b/.mise/tasks/email/export
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Export emails to a directory"
-# Delegates to KnickKnackLabs/emails — shimmer email:export is preserved for compatibility.
-exec emails export "$@"

--- a/.mise/tasks/email/inspect
+++ b/.mise/tasks/email/inspect
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Inspect email message structure and metadata"
-# Delegates to KnickKnackLabs/emails — shimmer email:inspect is preserved for compatibility.
-exec emails inspect "$@"

--- a/.mise/tasks/email/list
+++ b/.mise/tasks/email/list
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="List email messages"
-# Delegates to KnickKnackLabs/emails — shimmer email:list is preserved for compatibility.
-exec emails list "$@"

--- a/.mise/tasks/email/purge
+++ b/.mise/tasks/email/purge
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Permanently delete all messages in a folder"
-# Delegates to KnickKnackLabs/emails — shimmer email:purge is preserved for compatibility.
-exec emails purge "$@"

--- a/.mise/tasks/email/quota
+++ b/.mise/tasks/email/quota
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Show email storage quota usage"
-# Delegates to KnickKnackLabs/emails — shimmer email:quota is preserved for compatibility.
-exec emails quota "$@"

--- a/.mise/tasks/email/read
+++ b/.mise/tasks/email/read
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Read an email message"
-# Delegates to KnickKnackLabs/emails — shimmer email:read is preserved for compatibility.
-exec emails read "$@"

--- a/.mise/tasks/email/reply
+++ b/.mise/tasks/email/reply
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Reply to an email message"
-# Delegates to KnickKnackLabs/emails — shimmer email:reply is preserved for compatibility.
-exec emails reply "$@"

--- a/.mise/tasks/email/send
+++ b/.mise/tasks/email/send
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Send a GPG-signed email"
-# Delegates to KnickKnackLabs/emails — shimmer email:send is preserved for compatibility.
-exec emails send "$@"

--- a/.mise/tasks/email/setup
+++ b/.mise/tasks/email/setup
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Setup email (himalaya) for an agent (one-time local setup)"
-# Delegates to KnickKnackLabs/emails — shimmer email:setup is preserved for compatibility.
-exec emails setup "$@"

--- a/.mise/tasks/email/sizes
+++ b/.mise/tasks/email/sizes
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Show per-folder email sizes and largest messages"
-# Delegates to KnickKnackLabs/emails — shimmer email:sizes is preserved for compatibility.
-exec emails sizes "$@"

--- a/.mise/tasks/email/status
+++ b/.mise/tasks/email/status
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Check email (himalaya) setup status for an agent"
-# Delegates to KnickKnackLabs/emails — shimmer email:status is preserved for compatibility.
-exec emails status "$@"

--- a/.mise/tasks/email/wait
+++ b/.mise/tasks/email/wait
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Wait for new email to arrive"
-# Delegates to KnickKnackLabs/emails — shimmer email:wait is preserved for compatibility.
-exec emails wait "$@"

--- a/.mise/tasks/email/welcome
+++ b/.mise/tasks/email/welcome
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Email intro and current status"
-# Delegates to KnickKnackLabs/emails — shimmer email:welcome is preserved for compatibility.
-exec emails welcome "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The `shimmer` command is available globally via a shell alias. It runs tasks fro
 ```bash
 shimmer issue:list    # lists issues for the repo you're in
 shimmer pr:list       # lists PRs for the repo you're in
-shimmer email:list    # checks your inbox
+emails list           # checks your inbox
 ```
 
 Run `shimmer tasks` to see all available tasks. Key ones:
@@ -61,7 +61,7 @@ eval "$(mise -C ~/shimmer run -q shell)"
 
 Each run starts fresh, so check for messages before diving into work:
 
-- **Email** - Check your inbox: `shimmer email:list`
+- **Email** - Check your inbox: `emails list`
 - **Matrix** - Skim recent chats: `shimmer matrix:tail`
 - **GitHub** - Glance at recent activity for any replies
 
@@ -180,6 +180,6 @@ When adding dependencies with pinned versions:
 
 If you're an agent starting fresh:
 1. Run `shimmer welcome` to check your setup
-2. Check for messages (`shimmer email:list`)
+2. Check for messages (`emails list`)
 3. Explore your world - see `docs/agent-zettelkasten.md` for a self-discovery procedure
 4. Check what work is available (`shimmer issue:list`)

--- a/docs/agent-email.md
+++ b/docs/agent-email.md
@@ -1,14 +1,15 @@
 # Agent Email Setup
 
-Agents have their own email addresses at `@ricon.family`. This document explains how to use email as an agent.
+Agents have their own email addresses at `@ricon.family`. Email is managed by the [`emails`](https://github.com/KnickKnackLabs/emails) package (installed via shiv).
 
 ## Quick Reference
 
 ```bash
-shimmer email:list                      # Check inbox
-shimmer email:read <ID>                 # Read a message
-shimmer email:send <to> <subject> [body]  # Send a GPG-signed message
-shimmer email:reply <ID> [body]         # Reply to a message
+emails list                      # Check inbox
+emails read <ID>                 # Read a message
+emails send <to> <subject> [body]  # Send a GPG-signed message
+emails reply <ID> [body]         # Reply to a message
+emails welcome                   # Overview and status
 ```
 
 ## Available Addresses
@@ -23,10 +24,10 @@ To see which agents are currently active, check the `agents/` directory in your 
 
 ### Local setup
 
-For local development, run the setup task (one-time):
+For local development, run setup (one-time):
 
 ```bash
-mise run email:setup <agent>
+emails setup <agent>
 ```
 
 This pulls credentials from 1Password and creates `~/.config/himalaya/config.toml`.
@@ -35,30 +36,28 @@ See `docs/agent-local.md` for full local setup instructions.
 
 ### CI/Workflow setup
 
-In GitHub Actions, email is configured via the `email:setup` task with credentials passed as environment variables:
+In GitHub Actions, email is configured in the agent-run workflow:
 
 ```yaml
 - name: Setup email
   env:
     EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
-  run: mise run email:setup ${{ inputs.agent }}
+  run: emails setup ${{ inputs.agent }}
 ```
 
 ## Using Email
 
-After setup, use `shimmer email:*` commands to manage email:
-
 ### Check inbox
 
 ```bash
-shimmer email:list
-shimmer email:list -n 20    # Show more messages
+emails list
+emails list -n 20    # Show more messages
 ```
 
 ### Read a message
 
 ```bash
-shimmer email:read <ID>
+emails read <ID>
 ```
 
 ### Send a message
@@ -67,31 +66,38 @@ Messages are GPG-signed automatically:
 
 ```bash
 # Body as positional argument (simplest):
-shimmer email:send brownie@ricon.family "Hello" "Message body here."
+emails send brownie@ricon.family "Hello" "Message body here."
 
 # Or with --body flag:
-shimmer email:send brownie@ricon.family "Hello" --body "Message body here."
+emails send brownie@ricon.family "Hello" --body "Message body here."
 
 # Or pipe the body (for longer messages):
-echo "Message body here." | shimmer email:send brownie@ricon.family "Hello"
+echo "Message body here." | emails send brownie@ricon.family "Hello"
 ```
 
 ### Reply to a message
 
 ```bash
 # Body as positional argument (simplest):
-shimmer email:reply <ID> "Your reply here."
+emails reply <ID> "Your reply here."
 
 # Or with --body flag:
-shimmer email:reply <ID> --body "Your reply here."
+emails reply <ID> --body "Your reply here."
 
 # Or pipe the body (for longer messages):
-echo "Your reply here." | shimmer email:reply <ID>
+echo "Your reply here." | emails reply <ID>
+```
+
+### HTML Email
+
+```bash
+emails send user@example.com "Subject" --html -b /path/to/email.html
+emails reply <ID> --html -b '<h1>Thanks!</h1>'
 ```
 
 ## GPG Signing
 
-The `shimmer email:send` and `shimmer email:reply` commands automatically GPG-sign your messages using the same key that signs your git commits, providing a unified cryptographic identity.
+`emails send` and `emails reply` automatically GPG-sign messages using the same key that signs your git commits, providing a unified cryptographic identity.
 
 Under the hood, this uses himalaya's MML (MIME Meta Language) templates with `<#part sign=pgpmime>` tags. If you need direct access to himalaya for advanced use cases:
 
@@ -159,3 +165,7 @@ gpg --keyserver keyserver.ubuntu.com --recv-keys <KEY_ID>
 - Check email at the start of your run to see if there are messages for you
 - Use descriptive subjects so recipients can triage
 - Keep messages concise - email is async, not chat
+
+## Full Documentation
+
+See the [emails README](https://github.com/KnickKnackLabs/emails) for the complete command reference.

--- a/docs/agent-zettelkasten.md
+++ b/docs/agent-zettelkasten.md
@@ -162,8 +162,8 @@ Look for notes about YOU - colleagues may have documented interactions with you.
 
 ```bash
 # Email - async messages, session wrapups, history
-shimmer email:list
-shimmer email:read <id>
+emails list
+emails read <id>
 
 # Matrix - real-time chat
 shimmer matrix:rooms

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -39,17 +39,17 @@ _task() {
 check_email() {
   local config="${HIMALAYA_CONFIG:-$HOME/.config/himalaya/config.toml}"
   if ! [ -f "$config" ] || ! grep -q "accounts.$AGENT" "$config" 2>/dev/null; then
-    print_status "Email" "✗" "not configured" "shimmer email:setup $AGENT"
+    print_status "Email" "✗" "not configured" "emails setup $AGENT"
     return
   fi
 
   local quota_output rc=0
-  quota_output=$(_task --timeout 5 email:quota 2>/dev/null) || rc=$?
+  quota_output=$(timeout 5 emails quota 2>/dev/null) || rc=$?
   if [ "$rc" -eq 124 ]; then
-    print_status "Email" "✗" "timed out after 5s" "shimmer email:welcome"
+    print_status "Email" "✗" "timed out after 5s" "emails welcome"
     return
   elif [ "$rc" -ne 0 ]; then
-    print_status "Email" "✗" "check failed" "shimmer email:welcome"
+    print_status "Email" "✗" "check failed" "emails welcome"
     return
   fi
 
@@ -57,7 +57,7 @@ check_email() {
   quota_percent=$(echo "$quota_output" | grep -oE '[0-9]+%' | tr -d '%')
   # Fallback is safe: if the server were unreachable, quota would have timed out
   # above and we'd have already returned. We only reach here when the server responded.
-  unread_count=$(_task --timeout 5 email:list --unread --count 2>/dev/null || echo "0")
+  unread_count=$(timeout 5 emails list --unread --count 2>/dev/null || echo "0")
 
   if [ -n "$unread_count" ] && [ "$unread_count" -gt 0 ]; then
     status_text="${unread_count} unread"
@@ -67,10 +67,10 @@ check_email() {
   [ -n "$quota_percent" ] && status_text="${status_text} (quota ${quota_percent}%)"
 
   if [ -n "$quota_percent" ] && [ "$quota_percent" -ge 95 ]; then
-    print_status "Email" "✗" "$status_text" "shimmer email:purge"
+    print_status "Email" "✗" "$status_text" "emails purge"
   elif [ -n "$quota_percent" ] && [ "$quota_percent" -ge 80 ]; then
-    print_status "Email" "⚠" "$status_text" "shimmer email:welcome"
+    print_status "Email" "⚠" "$status_text" "emails welcome"
   else
-    print_status "Email" "✓" "$status_text" "shimmer email:welcome"
+    print_status "Email" "✓" "$status_text" "emails welcome"
   fi
 }

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,6 @@ fzf = "0.67.0"                            # Fuzzy finder for interactive pickers
 mc = "RELEASE.2025-08-13T08-35-41Z"      # MinIO client for S3-compatible blob storage
 gum = "0.17.0"                             # Terminal UI components (tables, spinners, etc.)
 bats = "1.13.0"                            # Bash Automated Testing System
-"shiv:emails" = "latest"                      # Email tooling (delegated from email:* tasks)
+"shiv:emails" = "0.1.0"
 "shiv:sessions" = "0.2.0"                   # Agent session transcripts (used by agent task)
 "shiv:threads" = "0.1.0"                    # HUMAN.md thread management

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -8,7 +8,7 @@ This project uses [shimmer](https://github.com/KnickKnackLabs/shimmer) for agent
 
 Key commands:
 - `shimmer welcome` - Check your identity and system health
-- `shimmer email:list` - Check for messages from humans or other agents
+- `emails list` - Check for messages from humans or other agents
 - `shimmer code:welcome` - Info about this codebase
 - `shimmer tasks` - See all available commands
 
@@ -39,7 +39,7 @@ This allows multiple agents to work on the same repo simultaneously without conf
 
 Each run starts fresh, so check for messages before diving into work:
 
-- **Email** - Check your inbox: `shimmer email:list`
+- **Email** - Check your inbox: `emails list`
 - **Matrix** - Skim recent chats: `shimmer matrix:tail`
 - **GitHub** - Glance at recent activity for any replies
 
@@ -76,7 +76,7 @@ Apply critical thinking to your own assumptions - check sources when uncertain.
 
 If you're an agent starting fresh:
 1. Run `shimmer welcome` to check your setup
-2. Check for messages (`shimmer email:list`)
+2. Check for messages (`emails list`)
 3. Check what exists in this repo
 4. Read recent activity (git log, recent files)
 5. Ask what the human needs help with today

--- a/test/welcome/welcome.bats
+++ b/test/welcome/welcome.bats
@@ -2,6 +2,43 @@
 
 setup() {
   load helpers
+  MOCK_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$MOCK_BIN"
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+# Create a mock `emails` binary with custom behavior per subcommand.
+# Usage: mock_emails "quota" 'echo "Usage: 42%"'
+#        mock_emails "list"  'echo "5"'
+# Call multiple times to build up the mock. Each call adds a case branch.
+# Call mock_emails_finish when done to write the final script.
+mock_emails_start() {
+  cat > "$MOCK_BIN/emails" << 'HEADER'
+#!/usr/bin/env bash
+case "$1" in
+HEADER
+}
+
+mock_emails_case() {
+  local subcmd="$1" body="$2"
+  echo "  $subcmd) $body ;;" >> "$MOCK_BIN/emails"
+}
+
+mock_emails_finish() {
+  cat >> "$MOCK_BIN/emails" << 'FOOTER'
+esac
+FOOTER
+  chmod +x "$MOCK_BIN/emails"
+}
+
+# Convenience: mock emails to fail with a specific exit code
+mock_emails_fail() {
+  local code="$1"
+  cat > "$MOCK_BIN/emails" << SCRIPT
+#!/usr/bin/env bash
+exit $code
+SCRIPT
+  chmod +x "$MOCK_BIN/emails"
 }
 
 @test "email: not configured when no himalaya config" {
@@ -15,10 +52,7 @@ setup() {
 
 @test "email: timed out after 5s when server unreachable" {
   setup_email
-  # Mock: simulate timeout exit code (unit test of check_email branching,
-  # not integration test of _task's timeout plumbing)
-  _task() { return 124; }
-  export -f _task
+  mock_emails_fail 124
 
   run check_email
   [[ "$output" == *"✗"* ]]
@@ -27,9 +61,7 @@ setup() {
 
 @test "email: check failed on non-timeout error" {
   setup_email
-  # Mock: simulate a non-timeout failure (e.g., mise config error, task not found)
-  _task() { return 1; }
-  export -f _task
+  mock_emails_fail 1
 
   run check_email
   [[ "$output" == *"✗"* ]]
@@ -38,14 +70,10 @@ setup() {
 
 @test "email: success with unread and low quota" {
   setup_email
-  _task() {
-    if [ "$1" = "--timeout" ]; then shift 2; fi
-    case "$1" in
-      email:quota) echo "Usage: 42%" ;;
-      email:list) echo "5" ;;
-    esac
-  }
-  export -f _task
+  mock_emails_start
+  mock_emails_case "quota" 'echo "Usage: 42%"'
+  mock_emails_case "list" 'echo "5"'
+  mock_emails_finish
 
   run check_email
   [[ "$output" == *"✓"* ]]
@@ -55,14 +83,10 @@ setup() {
 
 @test "email: success with zero unread" {
   setup_email
-  _task() {
-    if [ "$1" = "--timeout" ]; then shift 2; fi
-    case "$1" in
-      email:quota) echo "Usage: 10%" ;;
-      email:list) echo "0" ;;
-    esac
-  }
-  export -f _task
+  mock_emails_start
+  mock_emails_case "quota" 'echo "Usage: 10%"'
+  mock_emails_case "list" 'echo "0"'
+  mock_emails_finish
 
   run check_email
   [[ "$output" == *"✓"* ]]
@@ -71,14 +95,10 @@ setup() {
 
 @test "email: warning when quota >= 80%" {
   setup_email
-  _task() {
-    if [ "$1" = "--timeout" ]; then shift 2; fi
-    case "$1" in
-      email:quota) echo "Usage: 85%" ;;
-      email:list) echo "2" ;;
-    esac
-  }
-  export -f _task
+  mock_emails_start
+  mock_emails_case "quota" 'echo "Usage: 85%"'
+  mock_emails_case "list" 'echo "2"'
+  mock_emails_finish
 
   run check_email
   [[ "$output" == *"⚠"* ]]
@@ -88,18 +108,14 @@ setup() {
 
 @test "email: critical when quota >= 95%" {
   setup_email
-  _task() {
-    if [ "$1" = "--timeout" ]; then shift 2; fi
-    case "$1" in
-      email:quota) echo "Usage: 97%" ;;
-      email:list) echo "12" ;;
-    esac
-  }
-  export -f _task
+  mock_emails_start
+  mock_emails_case "quota" 'echo "Usage: 97%"'
+  mock_emails_case "list" 'echo "12"'
+  mock_emails_finish
 
   run check_email
   [[ "$output" == *"✗"* ]]
   [[ "$output" == *"12 unread"* ]]
   [[ "$output" == *"quota 97%"* ]]
-  [[ "$output" == *"email:purge"* ]]
+  [[ "$output" == *"emails purge"* ]]
 }


### PR DESCRIPTION
Completes the extraction started in #710. Shimmer no longer owns any email functionality.

**Deleted:** 16 wrapper files in `.mise/tasks/email/`

**Updated:**
- `lib/checks.sh` — calls `emails` binary directly (not `_task email:*`)
- CI template — `emails setup` instead of `shimmer email:setup`
- Docs + CLAUDE.md — all references point to `emails` CLI
- Tests — mock `emails` binary instead of `_task` function

**Companion PRs** (update remaining callers):
- ricon-family/fold — CI workflow + CLAUDE.md + notes
- ricon-family/shire — CI workflow + CLAUDE.md
- KnickKnackLabs/hookers — dashboard provider
- KnickKnackLabs/escort — dashboard provider

All 54 shimmer tests pass.