### PR TITLE
feat: add codebase linting + setup task

### DIFF
--- a/.mise/tasks/agent/schedules
+++ b/.mise/tasks/agent/schedules
@@ -55,5 +55,5 @@ for i in $(seq 0 $((WORKFLOW_COUNT - 1))); do
     status="?"
   fi
 
-  printf "%-8s %-12s %-10s %-24s %s\n" "$status" "$NAME" "$AGENT" "$SCHEDULE" "$MESSAGE"
+  printf "%-8s %-12s %-10s %-24s %s\n" "$status" "$NAME" "$AGENT" "$SCHEDULE" "$MESSAGE" # codebase:ignore
 done

--- a/.mise/tasks/code/init/welcome
+++ b/.mise/tasks/code/init/welcome
@@ -38,7 +38,7 @@ echo ""
 if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
   REPOS=$(gh repo list ricon-family --limit 20 --json name,description --jq '.[] | "  \(.name)\t\(.description // "-")"' 2>/dev/null || true)
   if [ -n "$REPOS" ]; then
-    echo "$REPOS" | column -t -s $'\t'
+    echo "$REPOS" | column -t -s $'\t' # codebase:ignore
   else
     echo "  (couldn't fetch repos - check gh auth)"
   fi

--- a/.mise/tasks/github/org/list
+++ b/.mise/tasks/github/org/list
@@ -31,7 +31,7 @@ while IFS= read -r org; do
   PRIVATE_REPOS=$(echo "$INFO" | jq -r '.total_private_repos // 0')
   REPO_COUNT=$((PUBLIC_REPOS + PRIVATE_REPOS))
 
-  printf "  %-24s %-8s %3d repos  %3d members" "$org" "$ROLE" "$REPO_COUNT" "$MEMBERS"
+  printf "  %-24s %-8s %3d repos  %3d members" "$org" "$ROLE" "$REPO_COUNT" "$MEMBERS" # codebase:ignore
   if [[ -n "$DESC" ]]; then
     echo "  $DESC"
   else

--- a/.mise/tasks/github/repo/list
+++ b/.mise/tasks/github/repo/list
@@ -70,7 +70,7 @@ list_repos() {
       suffix=" (archived)"
     fi
 
-    printf "  %-24s %-8s %-40s %s%s\n" "$name" "$visibility" "$nameWithOwner" "$age" "$suffix"
+    printf "  %-24s %-8s %-40s %s%s\n" "$name" "$visibility" "$nameWithOwner" "$age" "$suffix" # codebase:ignore
   done
 
   # Summary

--- a/.mise/tasks/metrics/activity
+++ b/.mise/tasks/metrics/activity
@@ -34,7 +34,7 @@ echo "$PR_DATA" | jq -r --arg days "$DAYS" '
   sort_by(-.total) |
   .[] |
   "\(.agent)\t\(.total) PRs (\(.merged) merged, \(.closed) closed, \(.open) open)"
-' 2>/dev/null | column -t -s $'\t' || echo "No agent PR data found"
+' 2>/dev/null | column -t -s $'\t' || echo "No agent PR data found" # codebase:ignore
 
 echo ""
 echo "=== Issues by Agent ==="
@@ -55,7 +55,7 @@ echo "$ISSUE_DATA" | jq -r --arg days "$DAYS" '
   sort_by(-.total) |
   .[] |
   "\(.agent)\t\(.total) issues (\(.open) open, \(.closed) closed)"
-' 2>/dev/null | column -t -s $'\t' || echo "No agent issue data found"
+' 2>/dev/null | column -t -s $'\t' || echo "No agent issue data found" # codebase:ignore
 
 echo ""
 echo "=== Merge Conflict Status ==="

--- a/.mise/tasks/metrics/usage
+++ b/.mise/tasks/metrics/usage
@@ -33,7 +33,7 @@ gh run list --limit 500 --json workflowName,createdAt,updatedAt,status,conclusio
   sort_by(-.total) |
   .[] |
   "\(.workflow)\t\(.total)\t\(.success) ok\t\(.failure) fail\t\(.skipped) skip"
-' | column -t -s $'\t'
+' | column -t -s $'\t' # codebase:ignore
 
 echo ""
 echo "=== Run Duration Estimates ==="
@@ -53,7 +53,7 @@ gh run list --limit 500 --status success --json workflowName,createdAt,updatedAt
   sort_by(-.total_min) |
   .[] |
   "\(.workflow)\t\(.count) runs\t~\(.avg_min)m avg\t\(.total_min)m total"
-' | column -t -s $'\t'
+' | column -t -s $'\t' # codebase:ignore
 
 echo ""
 echo "=== Totals ==="

--- a/.mise/tasks/pr/list
+++ b/.mise/tasks/pr/list
@@ -87,7 +87,7 @@ echo "$PRS" | while read -r pr; do
   # Format changes
   CHANGES="+${ADDITIONS}/-${DELETIONS}"
 
-  printf "  #%-4s  %-14s  %-12s  %4s  %s%s\n" "$NUMBER" "$STATUS" "$CHANGES" "$AGE" "$TITLE" "$STALE"
+  printf "  #%-4s  %-14s  %-12s  %4s  %s%s\n" "$NUMBER" "$STATUS" "$CHANGES" "$AGE" "$TITLE" "$STALE" # codebase:ignore
 done
 
 echo ""

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="Set up dev environment (hooks, tools)"
+set -euo pipefail
+
+echo "Setting up $(basename "$MISE_CONFIG_ROOT")..."
+
+if command -v codebase &>/dev/null; then
+  cd "$MISE_CONFIG_ROOT" && codebase pre-commit
+else
+  echo "WARN: codebase not found — run 'mise install' first" >&2
+fi
+
+echo "Done."

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ experimental = true
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
+"shiv:codebase" = "0.1.0"                 # Codebase linting + migrations
 node = "22"                               # LTS
 "github:pimalaya/himalaya" = "1.2.0"      # Email CLI for agents
 "1password-cli" = "2.32.0"                # Credential management
@@ -20,3 +21,9 @@ bats = "1.13.0"                            # Bash Automated Testing System
 "shiv:emails" = "0.2.0"
 "shiv:sessions" = "0.3.0"                   # Agent session transcripts (used by agent task)
 "shiv:threads" = "0.1.0"                    # HUMAN.md thread management
+
+[_.codebase]
+lint = ["mise-settings", "gum-table"]
+
+[_.codebase.scope]
+gum-table = ".mise/tasks"


### PR DESCRIPTION
Adds codebase lint pre-commit hook.

- `[plugins]` vfox-shiv + `shiv:codebase` as tool dependency
- `setup` task runs `codebase pre-commit`
- `[_.codebase]` config and ignore markers already in place from earlier commit

After merging: `mise install && mise run setup`