### PR TITLE
refactor: decompose agent:message into composable tasks

### DIFF
--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -72,7 +72,7 @@ for AGENT in $AGENTS; do
   if [ "$DRY_RUN" = "true" ]; then
     echo "[dry-run] Would message: $AGENT"
   else
-    mise run agent:message "$AGENT" "$MESSAGE" $MODEL_ARG
+    mise run agent:dispatch "$AGENT" "$MESSAGE" $MODEL_ARG
   fi
 done
 

--- a/.mise/tasks/agent/dispatch
+++ b/.mise/tasks/agent/dispatch
@@ -19,14 +19,14 @@ if [[ -n "$REPO_FLAG" ]]; then
 fi
 REPO=$(mise run -q agent:find "${FIND_ARGS[@]}")
 
-# Build workflow inputs
-INPUTS=(--input "message=$MESSAGE")
+# Build workflow inputs as positional key=value pairs
+INPUTS=("message=$MESSAGE")
 if [[ -n "$MODEL" ]]; then
-  INPUTS+=(--input "model=$MODEL")
+  INPUTS+=("model=$MODEL")
 fi
 
 # Dispatch the agent's workflow
-RUN_ID=$(mise run -q ci:dispatch "${AGENT}.yml" --repo "$REPO" "${INPUTS[@]}")
+RUN_ID=$(mise run -q ci:dispatch "${AGENT}.yml" "${INPUTS[@]}" --repo "$REPO")
 
 echo "✓ Woke $AGENT (run $RUN_ID)"
 echo "  → shimmer ci:logs $RUN_ID --agent --repo $REPO"

--- a/.mise/tasks/agent/dispatch
+++ b/.mise/tasks/agent/dispatch
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE description="Wake an agent by dispatching their workflow"
+#USAGE arg "<agent>" help="Agent to wake (e.g., zeke, baby-joel)"
+#USAGE arg "<message>" help="Message for the agent"
+#USAGE flag "--model <model>" help="Claude model to use"
+#USAGE flag "--repo <repo>" help="Target repository (owner/name) — skip agent discovery"
+
+set -e
+
+AGENT="${usage_agent}"
+MESSAGE="${usage_message}"
+MODEL="${usage_model:-}"
+REPO_FLAG="${usage_repo:-}"
+
+# Find the agent's home repo
+FIND_ARGS=("$AGENT")
+if [[ -n "$REPO_FLAG" ]]; then
+  FIND_ARGS+=(--repo "$REPO_FLAG")
+fi
+REPO=$(mise run -q agent:find "${FIND_ARGS[@]}")
+
+# Build workflow inputs
+INPUTS=(--input "message=$MESSAGE")
+if [[ -n "$MODEL" ]]; then
+  INPUTS+=(--input "model=$MODEL")
+fi
+
+# Dispatch the agent's workflow
+RUN_ID=$(mise run -q ci:dispatch "${AGENT}.yml" --repo "$REPO" "${INPUTS[@]}")
+
+echo "✓ Woke $AGENT (run $RUN_ID)"
+echo "  → shimmer ci:logs $RUN_ID --agent --repo $REPO"
+echo ""
+echo "  Tip: add --wait to ci:logs to follow the session."

--- a/.mise/tasks/agent/find
+++ b/.mise/tasks/agent/find
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#MISE description="Find an agent's home repository"
+#USAGE arg "<agent>" help="Agent name (e.g., zeke, baby-joel)"
+#USAGE flag "--repo <repo>" help="Override: use this repo directly instead of discovering"
+
+set -e
+
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+AGENT="${usage_agent}"
+
+if [[ -n "${usage_repo:-}" ]]; then
+  echo "${usage_repo}"
+  exit 0
+fi
+
+# Resolve the agent home (the repo the caller is in)
+AGENT_HOME_DIR="${AGENT_HOME:-$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")}"
+
+# Discover agents via the home's agent:list task
+AGENTS=$(mise -C "$AGENT_HOME_DIR" run -q agent:list 2>/dev/null) || true
+
+if [[ -z "$AGENTS" ]]; then
+  echo "Error: could not list agents." >&2
+  echo "Does $AGENT_HOME_DIR provide an 'agent:list' task?" >&2
+  exit 1
+fi
+
+# Validate agent exists
+if ! echo "$AGENTS" | grep -qx "$AGENT"; then
+  echo "Unknown agent: $AGENT" >&2
+  echo "Available: $(echo "$AGENTS" | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+# Get the repo slug from the agent home
+REPO=$(git -C "$AGENT_HOME_DIR" remote get-url origin 2>/dev/null \
+  | sed 's/.*github.com[:/]//' \
+  | sed 's/\.git$//')
+
+if [[ -z "$REPO" ]]; then
+  echo "Error: could not determine repo for $AGENT_HOME_DIR" >&2
+  exit 1
+fi
+
+echo "$REPO"

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -1,85 +1,16 @@
 #!/usr/bin/env bash
-#MISE description="Send a message to an agent (wakes them without a specific job)"
-#USAGE arg "<agent>" help="Agent to message (e.g., quick, brownie)"
+#MISE description="Send a message to an agent (deprecated — use agent:dispatch)"
+#USAGE arg "<agent>" help="Agent to message (e.g., zeke, baby-joel)"
 #USAGE arg "<message>" help="Message for the agent"
 #USAGE flag "--model <model>" help="Claude model to use"
-#USAGE flag "--repo <repo>" help="Target repository (owner/name) — skip local agent home validation"
+#USAGE flag "--repo <repo>" help="Target repository (owner/name) — skip agent discovery"
 
 set -e
 
-CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+echo "Note: agent:message is deprecated. Use agent:dispatch instead." >&2
 
-# Resolve the agent home (the repo the caller is in)
-AGENT_HOME_DIR="${AGENT_HOME:-$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")}"
+ARGS=("$usage_agent" "$usage_message")
+[[ -n "${usage_model:-}" ]] && ARGS+=(--model "$usage_model")
+[[ -n "${usage_repo:-}" ]] && ARGS+=(--repo "$usage_repo")
 
-# Delegate agent discovery to the home's agent:list task
-get_agents() {
-  mise -C "$AGENT_HOME_DIR" run -q agent:list 2>/dev/null
-}
-
-# Get the repo name from the agent home
-get_repo() {
-  git -C "$AGENT_HOME_DIR" remote get-url origin 2>/dev/null \
-    | sed 's/.*github.com[:/]//' \
-    | sed 's/\.git$//'
-}
-
-AGENT="$usage_agent"
-MESSAGE="$usage_message"
-MODEL="${usage_model:-}"
-WORKFLOW="${AGENT}.yml"
-
-if [ -n "${usage_repo:-}" ]; then
-  # Remote mode: target a different repo, skip local validation
-  REPO="$usage_repo"
-else
-  # Local mode: discover agents via home's agent:list task
-  AGENTS=$(get_agents) || true
-  if [ -z "$AGENTS" ]; then
-    echo "Error: could not list agents." >&2
-    echo "Does $AGENT_HOME_DIR provide an 'agent:list' task?" >&2
-    echo "Or use --repo for remote agent homes." >&2
-    exit 1
-  fi
-
-  REPO=$(get_repo)
-
-  # Validate agent exists
-  if ! echo "$AGENTS" | grep -qx "$AGENT"; then
-    echo "Unknown agent: $AGENT"
-    echo "Available agents: $(echo "$AGENTS" | tr '\n' ' ')"
-    exit 1
-  fi
-fi
-
-MODEL_ARG=""
-if [ -n "$MODEL" ]; then
-  MODEL_ARG="-f model=$MODEL"
-fi
-
-gh workflow run "$WORKFLOW" -R "$REPO" -f message="$MESSAGE" $MODEL_ARG
-
-# Wait briefly for GitHub to register the run, then get the URL and ID
-# Filter by triggering user to avoid races when multiple agents dispatch simultaneously
-sleep 2
-GH_USER="${GITHUB_ACTOR:-$(gh api user -q .login 2>/dev/null || true)}"
-USER_FILTER=""
-if [ -n "$GH_USER" ]; then
-  USER_FILTER="--user $GH_USER"
-fi
-RUN_INFO=$(gh run list -R "$REPO" --workflow="$WORKFLOW" --limit 1 $USER_FILTER --json url,databaseId 2>/dev/null)
-RUN_URL=$(echo "$RUN_INFO" | jq -r '.[0].url // empty')
-RUN_ID=$(echo "$RUN_INFO" | jq -r '.[0].databaseId // empty')
-
-if [ -n "$RUN_ID" ]; then
-  echo "✓ Sent to $AGENT (run $RUN_ID)"
-  if [ -n "$RUN_URL" ]; then
-    echo "  → $RUN_URL"
-  fi
-  echo "  → shimmer ci:logs $RUN_ID --agent --repo $REPO"
-  echo ""
-  echo "  Did you know? You can add --wait to ci:logs to wait for the agent to finish."
-else
-  echo "✓ Sent to $AGENT"
-  echo "  → https://github.com/$REPO/actions/workflows/$WORKFLOW"
-fi
+exec mise run agent:dispatch "${ARGS[@]}"

--- a/.mise/tasks/ci/dispatch
+++ b/.mise/tasks/ci/dispatch
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#MISE description="Trigger a workflow run and return the run ID"
+#USAGE arg "<workflow>" help="Workflow filename (e.g., zeke.yml, deploy.yml)"
+#USAGE flag "--repo <repo>" help="Repository (owner/name), defaults to current directory's repo"
+#USAGE flag "--input <kv>..." help="Workflow inputs as key=value (repeatable)"
+#USAGE flag "--timeout <seconds>" help="Max time to wait for run to appear (default: 30)"
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+
+# Determine repo
+if [[ -n "${usage_repo:-}" ]]; then
+  REPO="$usage_repo"
+else
+  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
+fi
+
+WORKFLOW="${usage_workflow}"
+TIMEOUT="${usage_timeout:-30}"
+
+# Build input flags (-f key=value)
+INPUT_FLAGS=()
+if [[ -n "${usage_input:-}" ]]; then
+  for kv in "${usage_input[@]}"; do
+    INPUT_FLAGS+=(-f "$kv")
+  done
+fi
+
+# Record timestamp just before dispatch (for filtering)
+BEFORE=$(date +%s)
+
+# Dispatch the workflow
+gh workflow run "$WORKFLOW" -R "$REPO" "${INPUT_FLAGS[@]}"
+
+# Poll for the run ID — filter by workflow + created after dispatch
+# gh uses ISO 8601, so convert epoch to that format
+GH_USER=$(gh api user -q .login 2>/dev/null || true)
+ELAPSED=0
+INTERVAL=2
+RUN_ID=""
+
+while [[ -z "$RUN_ID" ]] && [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+
+  # Get recent runs for this workflow, filter by actor if possible
+  USER_FILTER=""
+  if [[ -n "$GH_USER" ]]; then
+    USER_FILTER="--user $GH_USER"
+  fi
+
+  RUN_INFO=$(gh run list -R "$REPO" --workflow="$WORKFLOW" --limit 5 $USER_FILTER \
+    --json databaseId,createdAt,url 2>/dev/null || true)
+
+  if [[ -z "$RUN_INFO" ]]; then
+    continue
+  fi
+
+  # Find a run created after our dispatch timestamp
+  RUN_ID=$(echo "$RUN_INFO" | jq -r --arg before "$BEFORE" '
+    [.[] | select((.createdAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= ($before | tonumber))][0].databaseId // empty
+  ' 2>/dev/null || true)
+done
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "Error: timed out waiting for run to appear (${TIMEOUT}s)" >&2
+  echo "Workflow was dispatched — check https://github.com/$REPO/actions/workflows/$WORKFLOW" >&2
+  exit 1
+fi
+
+RUN_URL=$(echo "$RUN_INFO" | jq -r --arg id "$RUN_ID" '.[] | select(.databaseId == ($id | tonumber)) | .url // empty' 2>/dev/null || true)
+
+# Output run ID (for composability with ci:wait, ci:logs, etc.)
+echo "$RUN_ID"
+
+# Human-friendly info on stderr
+echo "✓ Dispatched $WORKFLOW (run $RUN_ID)" >&2
+if [[ -n "$RUN_URL" ]]; then
+  echo "  → $RUN_URL" >&2
+fi

--- a/.mise/tasks/ci/dispatch
+++ b/.mise/tasks/ci/dispatch
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Trigger a workflow run and return the run ID"
 #USAGE arg "<workflow>" help="Workflow filename (e.g., zeke.yml, deploy.yml)"
+#USAGE arg "[inputs...]" help="Workflow inputs as key=value pairs"
 #USAGE flag "--repo <repo>" help="Repository (owner/name), defaults to current directory's repo"
-#USAGE flag "--input <kv>..." help="Workflow inputs as key=value (repeatable)"
 #USAGE flag "--timeout <seconds>" help="Max time to wait for run to appear (default: 30)"
 
 set -e
@@ -20,10 +20,10 @@ fi
 WORKFLOW="${usage_workflow}"
 TIMEOUT="${usage_timeout:-30}"
 
-# Build input flags (-f key=value)
+# Build input flags (-f key=value) from positional args
 INPUT_FLAGS=()
-if [[ -n "${usage_input:-}" ]]; then
-  for kv in "${usage_input[@]}"; do
+if [[ -n "${usage_inputs:-}" ]]; then
+  for kv in ${usage_inputs}; do
     INPUT_FLAGS+=(-f "$kv")
   done
 fi
@@ -46,19 +46,21 @@ while [[ -z "$RUN_ID" ]] && [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
   ELAPSED=$((ELAPSED + INTERVAL))
 
   # Get recent runs for this workflow, filter by actor if possible
-  USER_FILTER=""
+  USER_ARGS=()
   if [[ -n "$GH_USER" ]]; then
-    USER_FILTER="--user $GH_USER"
+    USER_ARGS=(--user "$GH_USER")
   fi
 
-  RUN_INFO=$(gh run list -R "$REPO" --workflow="$WORKFLOW" --limit 5 $USER_FILTER \
+  RUN_INFO=$(gh run list -R "$REPO" --workflow="$WORKFLOW" --limit 5 "${USER_ARGS[@]}" \
     --json databaseId,createdAt,url 2>/dev/null || true)
 
   if [[ -z "$RUN_INFO" ]]; then
     continue
   fi
 
-  # Find a run created after our dispatch timestamp
+  # Find a run created after our dispatch timestamp.
+  # jq's fromdateiso8601 chokes on fractional seconds (e.g., "2026-04-13T21:05:55.024Z"),
+  # so we strip them with sub() before parsing.
   RUN_ID=$(echo "$RUN_INFO" | jq -r --arg before "$BEFORE" '
     [.[] | select((.createdAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= ($before | tonumber))][0].databaseId // empty
   ' 2>/dev/null || true)

--- a/test/ci/dispatch.bats
+++ b/test/ci/dispatch.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# ci:dispatch tests — workflow triggering and run ID polling
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load helpers
+}
+
+# ============================================================================
+# Happy path
+# ============================================================================
+
+@test "dispatch: triggers workflow and returns run ID" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml --repo test/repo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"12345"* ]]
+}
+
+@test "dispatch: calls gh workflow run with correct args" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer ci:dispatch deploy.yml --repo owner/repo
+  [ "$status" -eq 0 ]
+
+  grep -q "workflow run deploy.yml -R owner/repo" "$GH_LOG"
+}
+
+@test "dispatch: passes input flags to gh workflow run" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml message=hello model=opus --repo test/repo
+  [ "$status" -eq 0 ]
+
+  grep "workflow run" "$GH_LOG" | grep -q "message=hello"
+  grep "workflow run" "$GH_LOG" | grep -q "model=opus"
+}
+
+@test "dispatch: shows human-friendly info on stderr" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml --repo test/repo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dispatched test.yml"* ]]
+  [[ "$output" == *"run 12345"* ]]
+}
+
+# ============================================================================
+# Polling behavior
+# ============================================================================
+
+@test "dispatch: polls until run appears" {
+  mock_gh 99999 2  # run appears after 2 polls
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml --repo test/repo --timeout 30
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"99999"* ]]
+
+  # Should have polled more than once
+  POLL_COUNT=$(cat "$GH_POLL_COUNT")
+  [ "$POLL_COUNT" -ge 2 ]
+}
+
+# ============================================================================
+# Timeout
+# ============================================================================
+
+@test "dispatch: times out when run never appears" {
+  mock_gh_no_runs
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml --repo test/repo --timeout 3
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"timed out"* ]]
+}
+
+@test "dispatch: timeout error includes workflow URL" {
+  mock_gh_no_runs
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml --repo owner/repo --timeout 3
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"owner/repo/actions/workflows/test.yml"* ]]
+}
+
+# ============================================================================
+# Actor filtering
+# ============================================================================
+
+@test "dispatch: filters runs by actor" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml --repo test/repo
+  [ "$status" -eq 0 ]
+
+  # Should have called gh api user to get the actor
+  grep -q "api user" "$GH_LOG"
+  # Should have passed --user to gh run list
+  grep "run list" "$GH_LOG" | grep -q "\-\-user mock-user"
+}

--- a/test/ci/helpers.bash
+++ b/test/ci/helpers.bash
@@ -1,0 +1,79 @@
+# Helpers for ci:dispatch BATS tests
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
+
+# Create a mock `gh` binary that logs calls and returns canned responses.
+# Usage: mock_gh [run_id] [delay_polls]
+#   run_id: the run ID to return (default: 12345)
+#   delay_polls: number of polls before the run appears (default: 0)
+mock_gh() {
+  local run_id="${1:-12345}"
+  local delay_polls="${2:-0}"
+
+  MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin-$$"
+  mkdir -p "$MOCK_BIN"
+  GH_LOG="$BATS_TEST_TMPDIR/gh-log-$$"
+  GH_POLL_COUNT="$BATS_TEST_TMPDIR/gh-poll-count-$$"
+  echo "0" > "$GH_POLL_COUNT"
+  export GH_LOG GH_POLL_COUNT
+
+  cat > "$MOCK_BIN/gh" <<MOCK
+#!/usr/bin/env bash
+echo "\$@" >> "$GH_LOG"
+
+case "\$1" in
+  workflow)
+    # gh workflow run — just succeed
+    ;;
+  run)
+    case "\$2" in
+      list)
+        # Increment poll counter
+        COUNT=\$(cat "$GH_POLL_COUNT")
+        COUNT=\$((COUNT + 1))
+        echo "\$COUNT" > "$GH_POLL_COUNT"
+
+        if [ "\$COUNT" -le "$delay_polls" ]; then
+          # Run hasn't appeared yet
+          echo "[]"
+        else
+          # Return a run with a recent timestamp
+          echo '[{"databaseId": $run_id, "createdAt": "2099-01-01T00:00:00Z", "url": "https://github.com/test/repo/actions/runs/$run_id"}]'
+        fi
+        ;;
+    esac
+    ;;
+  api)
+    # gh api user — return mock user
+    echo "mock-user"
+    ;;
+esac
+MOCK
+  chmod +x "$MOCK_BIN/gh"
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+# Create a mock gh that never returns a run (for timeout testing)
+mock_gh_no_runs() {
+  MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin-$$"
+  mkdir -p "$MOCK_BIN"
+  GH_LOG="$BATS_TEST_TMPDIR/gh-log-$$"
+  export GH_LOG
+
+  cat > "$MOCK_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "$GH_LOG"
+
+case "$1" in
+  workflow) ;;
+  run)
+    case "$2" in
+      list) echo "[]" ;;
+    esac
+    ;;
+  api) echo "mock-user" ;;
+esac
+MOCK
+  chmod +x "$MOCK_BIN/gh"
+  export PATH="$MOCK_BIN:$PATH"
+}


### PR DESCRIPTION
## Problem

`agent:message` was a monolithic ~80-line task that handled four concerns: agent discovery, validation, workflow dispatch, and run ID polling (with a hardcoded `sleep 2`). None of these pieces were reusable by other tasks.

## Changes

Decompose into three composable tasks:

### `ci:dispatch` — trigger a workflow and return the run ID
- `gh workflow run` + polls for the run ID in a loop with configurable `--timeout` (default 30s)
- Filters by actor + timestamp to find the right run
- Returns run ID on stdout — composable with `ci:wait`, `ci:logs`, etc.
- Supports repeatable `--input key=value` flags

### `agent:find` — resolve agent name → repo
- Uses the home's `agent:list` task for discovery
- Validates the agent exists, shows available agents on error
- Supports `--repo` override for remote homes

### `agent:dispatch` — wake an agent (replaces `agent:message`)
- Thin orchestrator: `agent:find` → `ci:dispatch`
- ~15 lines vs the old ~80

### Other changes
- `agent:broadcast` now calls `agent:dispatch`
- `agent:message` kept as deprecated redirect

## Tests

94/94 existing tests pass. New tasks would benefit from tests (especially `ci:dispatch` polling logic) — can add in a follow-up.