### PR TITLE
fix(ci:dispatch): handle spaces in variadic input values

### DIFF
--- a/.mise/tasks/ci/dispatch
+++ b/.mise/tasks/ci/dispatch
@@ -20,12 +20,14 @@ fi
 WORKFLOW="${usage_workflow}"
 TIMEOUT="${usage_timeout:-30}"
 
-# Build input flags (-f key=value) from positional args
+# Build input flags (-f key=value) from positional args.
+# usage_inputs is a shell-escaped string (e.g., "'message=hello world' 'model=opus'").
+# xargs respects the quoting; printf '%s\0' gives us null-delimited items.
 INPUT_FLAGS=()
 if [[ -n "${usage_inputs:-}" ]]; then
-  for kv in ${usage_inputs}; do
+  while IFS= read -r -d '' kv; do
     INPUT_FLAGS+=(-f "$kv")
-  done
+  done < <(printf '%s' "${usage_inputs}" | xargs printf '%s\0')
 fi
 
 # Record timestamp just before dispatch (for filtering)

--- a/test/ci/dispatch.bats
+++ b/test/ci/dispatch.bats
@@ -41,6 +41,17 @@ setup() {
   grep "workflow run" "$GH_LOG" | grep -q "model=opus"
 }
 
+@test "dispatch: preserves spaces in input values" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer ci:dispatch test.yml "message=hello world from CI" model=opus --repo test/repo
+  [ "$status" -eq 0 ]
+
+  # The full value including spaces should appear as a single -f arg
+  grep "workflow run" "$GH_LOG" | grep -q "message=hello world from CI"
+}
+
 @test "dispatch: shows human-friendly info on stderr" {
   mock_gh 12345
   mock_shimmer


### PR DESCRIPTION
Fixes #719

## Problem

`ci:dispatch` word-splits variadic inputs on spaces, breaking values that contain spaces. `shimmer agent:dispatch k7r2 "Please review vfox-shiv PR"" fails with:

```
field "review" requires a value separated by an '=' sign
```

Mise passes variadic args as a shell-escaped string: `'message=Please review...' 'model=opus'`. The unquoted `for kv in ${usage_inputs}` splits on every space.

## Fix

Replace the `for` loop with `xargs printf '%s\0'` + `read -d ''` to parse the quoted string safely. Uses null delimiter (`\0`) instead of newline — values can't contain null bytes but could theoretically contain newlines.

Follows the pattern from fold's `notes/mise-conventions.md`, upgraded from `\n` to `\0` delimiter for correctness.

## Test

Added "dispatch: preserves spaces in input values" test. All 103 tests pass.