### PR TITLE
fix: use GH_TOKEN in install step for gh CLI auth

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install project tools
         env:
-          GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
           MISE_JOBS: 1  # Serialize — vfox-shiv bootstrap isn't parallel-safe yet
         run: |
           mise trust


### PR DESCRIPTION
The 'Install project tools' step in agent-run.yml used `GITHUB_TOKEN`, but shiv's install task delegates to `gh repo clone` which requires `GH_TOKEN`. This caused HTTP 401 errors when installing shiv packages in CI.

Fix: replace `GITHUB_TOKEN` with `GH_TOKEN` in the install step. `mise-action` already provides `MISE_GITHUB_TOKEN` for mise's own API calls, so `GITHUB_TOKEN` was redundant here.

Tested on fold: [CI Debug run](https://github.com/ricon-family/fold/actions/runs/24418621038) — all shiv packages install successfully with only `GH_TOKEN`.