### PR TITLE
feat: validate and sanitize GPG keys in sync-secrets and gpg:setup

### DIFF
--- a/.mise/tasks/agent/sync-secrets
+++ b/.mise/tasks/agent/sync-secrets
@@ -7,6 +7,8 @@
 
 set -e
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/lib/gpg.sh"
+
 # Determine target directory (caller's directory when using shimmer alias)
 TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
 cd "$TARGET_DIR"
@@ -84,6 +86,19 @@ sync_agent() {
     value=$(secrets get "$agent/$key" 2>/dev/null) || true
 
     if [ -n "$value" ]; then
+      # Strip wrapping quotes (some providers quote multiline values)
+      if [ "$key" = "gpg-private-key" ] || [ "$key" = "gpg-public-key" ]; then
+        value=$(strip_wrapping_quotes "$value")
+      fi
+
+      # Validate GPG keys before upload
+      if [ "$key" = "gpg-private-key" ]; then
+        if ! validate_gpg_key "$value"; then
+          echo "  [ERROR] $gh_name failed validation, skipping" >&2
+          continue
+        fi
+      fi
+
       if [ "$DRY_RUN" = "true" ]; then
         echo "  [dry-run] Would sync $gh_name"
       else

--- a/.mise/tasks/agent/sync-secrets
+++ b/.mise/tasks/agent/sync-secrets
@@ -92,7 +92,7 @@ sync_agent() {
       fi
 
       # Validate GPG keys before upload
-      if [ "$key" = "gpg-private-key" ]; then
+      if [ "$key" = "gpg-private-key" ] || [ "$key" = "gpg-public-key" ]; then
         if ! validate_gpg_key "$value"; then
           echo "  [ERROR] $gh_name failed validation, skipping" >&2
           continue

--- a/.mise/tasks/gpg/setup
+++ b/.mise/tasks/gpg/setup
@@ -31,11 +31,6 @@ else
     }
   fi
 
-  if [ ${#GPG_PRIVATE_KEY} -lt 100 ]; then
-    echo "ERROR: Retrieved GPG key seems too short or empty"
-    exit 1
-  fi
-
   # Strip wrapping quotes (some providers/uploads introduce them)
   GPG_PRIVATE_KEY=$(strip_wrapping_quotes "$GPG_PRIVATE_KEY")
 

--- a/.mise/tasks/gpg/setup
+++ b/.mise/tasks/gpg/setup
@@ -4,6 +4,8 @@
 
 set -e
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/lib/gpg.sh"
+
 # Bridge env var during migration
 export SECRETS_PROVIDER="${SECRETS_PROVIDER:-${SHIMMER_SECRETS_PROVIDER:-}}"
 
@@ -31,6 +33,17 @@ else
 
   if [ ${#GPG_PRIVATE_KEY} -lt 100 ]; then
     echo "ERROR: Retrieved GPG key seems too short or empty"
+    exit 1
+  fi
+
+  # Strip wrapping quotes (some providers/uploads introduce them)
+  GPG_PRIVATE_KEY=$(strip_wrapping_quotes "$GPG_PRIVATE_KEY")
+
+  # Validate before importing
+  if ! validate_gpg_key "$GPG_PRIVATE_KEY"; then
+    echo "" >&2
+    echo "Hint: the key may have been corrupted during upload." >&2
+    echo "Try re-syncing: shimmer agent:sync-secrets $AGENT" >&2
     exit 1
   fi
 

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS test suite"
+#USAGE arg "[args]..." var=true help="Test suites, files, or bats flags"
+#USAGE example "all"    "mise run test"
+#USAGE example "suite"  "mise run test gpg"
+#USAGE example "file"   "mise run test test/gpg/gpg.bats"
+#USAGE example "filter" "mise run test -- --filter 'strip_wrapping'"
 set -eo pipefail
 
-exec bats --recursive "$MISE_CONFIG_ROOT/test/"
+TEST_DIR="$MISE_CONFIG_ROOT/test"
+
+args=()
+has_target=false
+
+for arg in "$@"; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
+    args+=("$TEST_DIR/$arg")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    args+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  args+=("--recursive" "$TEST_DIR/")
+fi
+
+bats "${args[@]}"

--- a/lib/gpg.sh
+++ b/lib/gpg.sh
@@ -1,0 +1,55 @@
+# Shared GPG helper functions for shimmer
+#
+# Sourced by gpg:setup and agent:sync-secrets.
+
+# Strip wrapping double quotes from a value if present.
+# Some secret providers (notably 1password CLI) may quote multiline values.
+# Usage: value=$(strip_wrapping_quotes "$value")
+strip_wrapping_quotes() {
+  local value="$1"
+  if [[ "$value" == \"*\" ]]; then
+    value="${value#\"}"
+    value="${value%\"}"
+  fi
+  echo "$value"
+}
+
+# Validate that a string is a parseable GPG key.
+# Uses gpg --import --dry-run (no side effects).
+# Returns 0 on success, 1 on failure with a diagnostic message on stderr.
+# Usage: validate_gpg_key "$key_data"
+validate_gpg_key() {
+  local key_data="$1"
+
+  if [ -z "$key_data" ]; then
+    echo "GPG key is empty" >&2
+    return 1
+  fi
+
+  # Check for wrapping quotes (common corruption)
+  if [[ "$key_data" == \"* ]]; then
+    echo "GPG key is wrapped in literal double quotes — strip them before use" >&2
+    return 1
+  fi
+
+  # Check for armor header
+  if ! echo "$key_data" | head -1 | grep -q "^-----BEGIN PGP"; then
+    local first_chars
+    first_chars=$(echo "$key_data" | head -c 20)
+    echo "GPG key doesn't start with PGP armor header (starts with: ${first_chars}...)" >&2
+    return 1
+  fi
+
+  # Dry-run import to verify GPG can parse it
+  local tmpfile
+  tmpfile=$(mktemp)
+  printf '%s' "$key_data" > "$tmpfile"
+  local output
+  if ! output=$(gpg --batch --import --dry-run "$tmpfile" 2>&1); then
+    rm -f "$tmpfile"
+    echo "GPG cannot parse key: $output" >&2
+    return 1
+  fi
+  rm -f "$tmpfile"
+  return 0
+}

--- a/lib/gpg.sh
+++ b/lib/gpg.sh
@@ -11,7 +11,7 @@ strip_wrapping_quotes() {
     value="${value#\"}"
     value="${value%\"}"
   fi
-  echo "$value"
+  printf '%s\n' "$value"
 }
 
 # Validate that a string is a parseable GPG key.
@@ -26,9 +26,9 @@ validate_gpg_key() {
     return 1
   fi
 
-  # Check for wrapping quotes (common corruption)
+  # Check for leading quote (likely corrupted — wrapping quotes not fully stripped)
   if [[ "$key_data" == \"* ]]; then
-    echo "GPG key is wrapped in literal double quotes — strip them before use" >&2
+    echo "GPG key starts with a double quote — likely corrupted" >&2
     return 1
   fi
 
@@ -43,13 +43,12 @@ validate_gpg_key() {
   # Dry-run import to verify GPG can parse it
   local tmpfile
   tmpfile=$(mktemp)
+  trap 'rm -f "$tmpfile"' RETURN
   printf '%s' "$key_data" > "$tmpfile"
   local output
   if ! output=$(gpg --batch --import --dry-run "$tmpfile" 2>&1); then
-    rm -f "$tmpfile"
     echo "GPG cannot parse key: $output" >&2
     return 1
   fi
-  rm -f "$tmpfile"
   return 0
 }

--- a/test/gpg/gpg.bats
+++ b/test/gpg/gpg.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# Tests for lib/gpg.sh helpers and gpg:setup task
+
+load helpers.bash
+
+setup() {
+  source "$SHIMMER_DIR/lib/gpg.sh"
+  generate_test_gpg_key
+}
+
+teardown() {
+  cleanup_test_gpg
+}
+
+# --- strip_wrapping_quotes ---
+
+@test "strip_wrapping_quotes: removes wrapping double quotes" {
+  result=$(strip_wrapping_quotes '"hello world"')
+  [ "$result" = "hello world" ]
+}
+
+@test "strip_wrapping_quotes: leaves unquoted strings unchanged" {
+  result=$(strip_wrapping_quotes 'hello world')
+  [ "$result" = "hello world" ]
+}
+
+@test "strip_wrapping_quotes: leaves strings with only leading quote unchanged" {
+  result=$(strip_wrapping_quotes '"hello world')
+  [ "$result" = '"hello world' ]
+}
+
+@test "strip_wrapping_quotes: leaves strings with only trailing quote unchanged" {
+  result=$(strip_wrapping_quotes 'hello world"')
+  [ "$result" = 'hello world"' ]
+}
+
+@test "strip_wrapping_quotes: handles empty string" {
+  result=$(strip_wrapping_quotes '')
+  [ "$result" = "" ]
+}
+
+@test "strip_wrapping_quotes: preserves internal quotes" {
+  result=$(strip_wrapping_quotes '"hello "world" bye"')
+  [ "$result" = 'hello "world" bye' ]
+}
+
+@test "strip_wrapping_quotes: handles multiline PGP key with quotes" {
+  quoted_key=$(quote_wrap "$VALID_GPG_KEY")
+  result=$(strip_wrapping_quotes "$quoted_key")
+  # First line should be the armor header, not a quote
+  first_line=$(echo "$result" | head -1)
+  [ "$first_line" = "-----BEGIN PGP PRIVATE KEY BLOCK-----" ]
+}
+
+# --- validate_gpg_key ---
+
+@test "validate_gpg_key: accepts a valid GPG private key" {
+  run validate_gpg_key "$VALID_GPG_KEY"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_gpg_key: rejects empty input" {
+  run validate_gpg_key ""
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty"* ]]
+}
+
+@test "validate_gpg_key: rejects key wrapped in quotes" {
+  quoted_key=$(quote_wrap "$VALID_GPG_KEY")
+  run validate_gpg_key "$quoted_key"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"wrapped in literal double quotes"* ]]
+}
+
+@test "validate_gpg_key: rejects garbage data" {
+  run validate_gpg_key "not a gpg key at all"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"doesn't start with PGP armor header"* ]]
+}
+
+@test "validate_gpg_key: rejects truncated key with valid header" {
+  truncated="-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+mQENBF
+-----END PGP PRIVATE KEY BLOCK-----"
+  run validate_gpg_key "$truncated"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"GPG cannot parse key"* ]]
+}
+
+# --- gpg:setup integration ---
+
+@test "gpg:setup: imports a valid key from env" {
+  mock_shimmer
+
+  export GPG_PRIVATE_KEY="$VALID_GPG_KEY"
+  run shimmer gpg:setup test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GPG configured for test@ricon.family"* ]]
+}
+
+@test "gpg:setup: imports a quoted key from env (auto-strips quotes)" {
+  mock_shimmer
+
+  export GPG_PRIVATE_KEY=$(quote_wrap "$VALID_GPG_KEY")
+  run shimmer gpg:setup test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GPG configured for test@ricon.family"* ]]
+}
+
+@test "gpg:setup: rejects garbage key with helpful error" {
+  mock_shimmer
+
+  # Must be >100 chars to pass length check and reach validation
+  export GPG_PRIVATE_KEY=$(python3 -c "print('x' * 200)")
+  run shimmer gpg:setup test
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"doesn't start with PGP armor header"* ]]
+}

--- a/test/gpg/gpg.bats
+++ b/test/gpg/gpg.bats
@@ -69,7 +69,7 @@ teardown() {
   quoted_key=$(quote_wrap "$VALID_GPG_KEY")
   run validate_gpg_key "$quoted_key"
   [ "$status" -eq 1 ]
-  [[ "$output" == *"wrapped in literal double quotes"* ]]
+  [[ "$output" == *"starts with a double quote"* ]]
 }
 
 @test "validate_gpg_key: rejects garbage data" {

--- a/test/gpg/helpers.bash
+++ b/test/gpg/helpers.bash
@@ -3,10 +3,6 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
 
 # Generate a real GPG key for testing.
-# Uses a temporary GNUPGHOME so it doesn't pollute the real keyring.
-# Sets VALID_GPG_KEY (armor) and TEST_GNUPGHOME.
-# Usage: generate_test_gpg_key
-# Generate a real GPG key for testing.
 # Uses a short socket path to avoid gpg-agent socket length limits.
 # Sets VALID_GPG_KEY (armor) and TEST_GNUPGHOME.
 generate_test_gpg_key() {
@@ -43,7 +39,7 @@ EOF
 # Wrap a value in literal double quotes (simulates the corruption).
 # Usage: quoted=$(quote_wrap "$value")
 quote_wrap() {
-  echo "\"$1\""
+  printf '"%s"' "$1"
 }
 
 # Clean up gpg-agent and temp dirs.

--- a/test/gpg/helpers.bash
+++ b/test/gpg/helpers.bash
@@ -1,0 +1,53 @@
+# Helpers for shimmer GPG BATS tests
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
+
+# Generate a real GPG key for testing.
+# Uses a temporary GNUPGHOME so it doesn't pollute the real keyring.
+# Sets VALID_GPG_KEY (armor) and TEST_GNUPGHOME.
+# Usage: generate_test_gpg_key
+# Generate a real GPG key for testing.
+# Uses a short socket path to avoid gpg-agent socket length limits.
+# Sets VALID_GPG_KEY (armor) and TEST_GNUPGHOME.
+generate_test_gpg_key() {
+  # gpg-agent fails if the socket path exceeds ~104 chars.
+  # BATS_TEST_TMPDIR can be very long, so use /tmp instead.
+  local keygen_dir="/tmp/bats-gpg-keygen-$$"
+  mkdir -p "$keygen_dir"
+  chmod 700 "$keygen_dir"
+
+  GNUPGHOME="$keygen_dir" gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 2048
+Name-Real: Test Agent
+Name-Email: test@ricon.family
+Expire-Date: 0
+%commit
+EOF
+
+  VALID_GPG_KEY=$(GNUPGHOME="$keygen_dir" gpg --armor --export-secret-keys test@ricon.family 2>/dev/null)
+  export VALID_GPG_KEY
+
+  # Clean up keygen dir — tests use their own GNUPGHOME
+  gpgconf --homedir "$keygen_dir" --kill gpg-agent 2>/dev/null || true
+  rm -rf "$keygen_dir"
+
+  # Set up a clean GNUPGHOME for the test itself (also short path)
+  TEST_GNUPGHOME="/tmp/bats-gpg-test-$$"
+  mkdir -p "$TEST_GNUPGHOME"
+  chmod 700 "$TEST_GNUPGHOME"
+  export GNUPGHOME="$TEST_GNUPGHOME"
+}
+
+# Wrap a value in literal double quotes (simulates the corruption).
+# Usage: quoted=$(quote_wrap "$value")
+quote_wrap() {
+  echo "\"$1\""
+}
+
+# Clean up gpg-agent and temp dirs.
+cleanup_test_gpg() {
+  gpgconf --homedir "${TEST_GNUPGHOME:-/nonexistent}" --kill gpg-agent 2>/dev/null || true
+  rm -rf "${TEST_GNUPGHOME:-}" 2>/dev/null || true
+}


### PR DESCRIPTION
## Problem

The Apr 13 secret rotation (run by c0da via `agent:sync-secrets`) stored GPG private keys wrapped in literal double quotes in fold's GitHub secrets. This caused `gpg: no valid OpenPGP data found` on every fold CI agent run — all 8 agents broken for ~1 day.

Root cause: the 1password CLI (or its shell interaction) wrapped multiline values in quotes. `sync-secrets` uploaded them verbatim. `gpg:setup` passed them to GPG verbatim. Nobody validated.

## Changes

### `lib/gpg.sh` (new)
- **`strip_wrapping_quotes`** — removes leading/trailing `"` if both present
- **`validate_gpg_key`** — dry-run GPG import with specific diagnostics:
  - Empty key
  - Key wrapped in quotes
  - Missing PGP armor header
  - GPG parse failure (truncated, corrupted)

### `agent/sync-secrets`
- Strips wrapping quotes from GPG key values before upload
- Validates GPG private keys via dry-run import; skips on failure instead of uploading corrupt data

### `gpg/setup`
- Strips wrapping quotes before importing
- Validates before importing, with actionable hint on failure

### `.mise/tasks/test`
- Updated to standard BATS test task pattern (codebase#4)
- Supports: `mise run test`, `mise run test gpg`, `mise run test file.bats`, `mise run test -- --filter 'pattern'`

### Tests (15 new)
- 7 tests for `strip_wrapping_quotes` (basic, edge cases, multiline PGP key)
- 5 tests for `validate_gpg_key` (valid, empty, quoted, garbage, truncated)
- 3 integration tests for `gpg:setup` (valid key, quoted key auto-fix, garbage rejection)

## How we fixed the immediate outage

Used a temporary CI workflow in fold to strip the quotes and re-upload all 8 agents' GPG keys in-place. Verified with a successful quick agent run. Workflow deleted after fix.