### PR TITLE
fix: prefer home repos over zettelkasten paths

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Run agent
         env:
-          AGENT_HOME: $HOME/${{ github.event.repository.name }}
+          AGENT_HOME: $GITHUB_WORKSPACE
           AGENT: ${{ inputs.agent }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BROWSER_GITHUB_COM_PASSWORD: ${{ secrets.AGENT_GITHUB_PASSWORD }}

--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -160,18 +160,24 @@ jobs:
             echo "B2 credentials not configured, skipping blob storage setup"
           fi
 
-      - name: Clone zettelkasten
+      - name: Clone home repo
         run: |
-          ZETTEL_DIR="$HOME/agents/${{ inputs.agent }}/zettelkasten"
-          ZETTEL_REPO="${{ inputs.agent }}-ricon/zettelkasten"
+          HOME_DIR="$HOME/agents/${{ inputs.agent }}/home"
+          HOME_REPO="${{ inputs.agent }}-ricon/home"
+          LEGACY_REPO="${{ inputs.agent }}-ricon/zettelkasten"
 
-          if gh repo view "$ZETTEL_REPO" --json name > /dev/null 2>&1; then
-            echo "Cloning zettelkasten from $ZETTEL_REPO..."
-            git clone "https://x-access-token:${GH_TOKEN}@github.com/${ZETTEL_REPO}.git" "$ZETTEL_DIR"
-            echo "Zettelkasten available at $ZETTEL_DIR"
+          if gh repo view "$HOME_REPO" --json name > /dev/null 2>&1; then
+            REPO="$HOME_REPO"
+          elif gh repo view "$LEGACY_REPO" --json name > /dev/null 2>&1; then
+            REPO="$LEGACY_REPO"
           else
-            echo "No zettelkasten found for ${{ inputs.agent }}, skipping"
+            echo "No home repo found for ${{ inputs.agent }}, skipping"
+            exit 0
           fi
+
+          echo "Cloning home repo from $REPO..."
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME_DIR"
+          echo "Home repo available at $HOME_DIR"
 
       - name: Unlock encrypted notes
         run: |

--- a/.mise/tasks/_agent-preview
+++ b/.mise/tasks/_agent-preview
@@ -36,12 +36,16 @@ fi
 # Workspace info
 WORKSPACE="$HOME/agents/$AGENT"
 if [ -d "$WORKSPACE" ]; then
-  # Zettelkasten
-  ZETTEL_DIR="$WORKSPACE/zettelkasten"
+  # Home repo / zettelkasten
+  if [ -d "$WORKSPACE/home" ]; then
+    ZETTEL_DIR="$WORKSPACE/home"
+  else
+    ZETTEL_DIR="$WORKSPACE/zettelkasten"
+  fi
   if [ -d "$ZETTEL_DIR" ]; then
     NOTE_COUNT=$(find "$ZETTEL_DIR/notes" -mindepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
     SESSION_COUNT=$(find "$ZETTEL_DIR/sessions" -mindepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
-    echo "Zettelkasten: ${NOTE_COUNT} notes, ${SESSION_COUNT} sessions"
+    echo "Home repo: ${NOTE_COUNT} notes, ${SESSION_COUNT} sessions"
   fi
 
   # Repos in workspace

--- a/.mise/tasks/ci/dispatch
+++ b/.mise/tasks/ci/dispatch
@@ -9,6 +9,100 @@ set -e
 
 SCRIPT_DIR="$(dirname "$0")"
 
+# Parse a shell-escaped word list emitted by mise's #USAGE variadic args.
+# Example shape: `'message=hello world' 'model=opus'`
+# We can't use xargs here because it breaks on embedded newlines.
+parse_shell_words() {
+  local input="$1"
+  PARSED_WORDS=()
+
+  local word=""
+  local state="unquoted"
+  local word_started=false
+  local i ch
+
+  for ((i = 0; i < ${#input}; i++)); do
+    ch="${input:i:1}"
+
+    case "$state" in
+      unquoted)
+        case "$ch" in
+          [[:space:]])
+            if $word_started; then
+              PARSED_WORDS+=("$word")
+              word=""
+              word_started=false
+            fi
+            ;;
+          "'")
+            state="single"
+            word_started=true
+            ;;
+          '"')
+            state="double"
+            word_started=true
+            ;;
+          '\\')
+            state="escape"
+            word_started=true
+            ;;
+          *)
+            word+="$ch"
+            word_started=true
+            ;;
+        esac
+        ;;
+      single)
+        if [[ "$ch" == "'" ]]; then
+          state="unquoted"
+        else
+          word+="$ch"
+        fi
+        ;;
+      double)
+        case "$ch" in
+          '"')
+            state="unquoted"
+            ;;
+          '\\')
+            state="double_escape"
+            ;;
+          *)
+            word+="$ch"
+            ;;
+        esac
+        ;;
+      escape)
+        word+="$ch"
+        state="unquoted"
+        ;;
+      double_escape)
+        case "$ch" in
+          '"'|'\\'|'$'|'`')
+            word+="$ch"
+            ;;
+          *)
+            word+="\\$ch"
+            ;;
+        esac
+        state="double"
+        ;;
+    esac
+  done
+
+  case "$state" in
+    unquoted)
+      if $word_started; then
+        PARSED_WORDS+=("$word")
+      fi
+      ;;
+    *)
+      echo "Error: malformed shell-escaped input list" >&2
+      return 1
+      ;;
+  esac
+}
+
 # Determine repo
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
@@ -19,26 +113,27 @@ fi
 
 WORKFLOW="${usage_workflow}"
 TIMEOUT="${usage_timeout:-30}"
+GH_BIN="${GH_BIN:-gh}"
 
 # Build input flags (-f key=value) from positional args.
 # usage_inputs is a shell-escaped string (e.g., "'message=hello world' 'model=opus'").
-# xargs respects the quoting; printf '%s\0' gives us null-delimited items.
 INPUT_FLAGS=()
 if [[ -n "${usage_inputs:-}" ]]; then
-  while IFS= read -r -d '' kv; do
+  parse_shell_words "${usage_inputs}"
+  for kv in "${PARSED_WORDS[@]}"; do
     INPUT_FLAGS+=(-f "$kv")
-  done < <(printf '%s' "${usage_inputs}" | xargs printf '%s\0')
+  done
 fi
 
 # Record timestamp just before dispatch (for filtering)
 BEFORE=$(date +%s)
 
 # Dispatch the workflow
-gh workflow run "$WORKFLOW" -R "$REPO" "${INPUT_FLAGS[@]}"
+"$GH_BIN" workflow run "$WORKFLOW" -R "$REPO" "${INPUT_FLAGS[@]}"
 
 # Poll for the run ID — filter by workflow + created after dispatch
 # gh uses ISO 8601, so convert epoch to that format
-GH_USER=$(gh api user -q .login 2>/dev/null || true)
+GH_USER=$("$GH_BIN" api user -q .login 2>/dev/null || true)
 ELAPSED=0
 INTERVAL=2
 RUN_ID=""
@@ -53,7 +148,7 @@ while [[ -z "$RUN_ID" ]] && [[ "$ELAPSED" -lt "$TIMEOUT" ]]; do
     USER_ARGS=(--user "$GH_USER")
   fi
 
-  RUN_INFO=$(gh run list -R "$REPO" --workflow="$WORKFLOW" --limit 5 "${USER_ARGS[@]}" \
+  RUN_INFO=$("$GH_BIN" run list -R "$REPO" --workflow="$WORKFLOW" --limit 5 "${USER_ARGS[@]}" \
     --json databaseId,createdAt,url 2>/dev/null || true)
 
   if [[ -z "$RUN_INFO" ]]; then

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -103,7 +103,15 @@ if [ -n "$AGENT" ]; then
   fi
 
   # Zettelkasten check
-  ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
+  PREFERRED_ZETTEL_DIR="$HOME/agents/$AGENT/home"
+  LEGACY_ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
+  if [ -d "$PREFERRED_ZETTEL_DIR" ]; then
+    ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
+  elif [ -d "$LEGACY_ZETTEL_DIR" ]; then
+    ZETTEL_DIR="$LEGACY_ZETTEL_DIR"
+  else
+    ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
+  fi
   if [ -d "$ZETTEL_DIR" ]; then
     NOTE_COUNT=$(find "$ZETTEL_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
     # Check if behind remote

--- a/.mise/tasks/zettel/search
+++ b/.mise/tasks/zettel/search
@@ -29,10 +29,18 @@ if [ -z "$AGENT" ]; then
   exit 1
 fi
 
-ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
+PREFERRED_ZETTEL_DIR="$HOME/agents/$AGENT/home"
+LEGACY_ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
+if [ -d "$PREFERRED_ZETTEL_DIR" ]; then
+  ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
+elif [ -d "$LEGACY_ZETTEL_DIR" ]; then
+  ZETTEL_DIR="$LEGACY_ZETTEL_DIR"
+else
+  ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
+fi
 
 if [ ! -d "$ZETTEL_DIR" ]; then
-  echo "⚠ No zettelkasten found at $ZETTEL_DIR"
+  echo "⚠ No home repo found at $ZETTEL_DIR"
   echo ""
   echo "Run 'shimmer zettel:welcome' to get started."
   exit 1

--- a/.mise/tasks/zettel/welcome
+++ b/.mise/tasks/zettel/welcome
@@ -23,7 +23,15 @@ if [ -z "$AGENT" ]; then
   exit 0
 fi
 
-ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
+PREFERRED_ZETTEL_DIR="$HOME/agents/$AGENT/home"
+LEGACY_ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
+if [ -d "$PREFERRED_ZETTEL_DIR" ]; then
+  ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
+elif [ -d "$LEGACY_ZETTEL_DIR" ]; then
+  ZETTEL_DIR="$LEGACY_ZETTEL_DIR"
+else
+  ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
+fi
 export ZETTEL_ROOT="$ZETTEL_DIR"
 
 # Check if it exists
@@ -32,9 +40,9 @@ if [ ! -d "$ZETTEL_DIR" ]; then
   echo "Zettelkasten"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
-  echo "  No zettelkasten found at: $ZETTEL_DIR"
+  echo "  No home repo found at: $ZETTEL_DIR"
   echo ""
-  echo "  A zettelkasten is your external memory - it persists across"
+  echo "  Your home repo is your external memory - it persists across"
   echo "  sessions so you can build on previous experience."
   echo ""
   echo "  To create one:"

--- a/docs/agent-zettelkasten.md
+++ b/docs/agent-zettelkasten.md
@@ -17,7 +17,7 @@ A zettelkasten lets you build on previous experience rather than starting from z
 A simple structure that works:
 
 ```
-~/agents/<your-name>/zettelkasten/
+~/agents/<your-name>/home/
 ├── index.md          # Entry point
 ├── notes/            # Permanent atomic notes
 │   ├── some-concept.md
@@ -119,10 +119,10 @@ Find what helps you think and build on previous work.
 
 ## Getting Started
 
-1. Create your zettelkasten directory:
+1. Create your home repo directory:
    ```bash
-   mkdir -p ~/agents/<your-name>/zettelkasten/notes
-   cd ~/agents/<your-name>/zettelkasten
+   mkdir -p ~/agents/<your-name>/home/notes
+   cd ~/agents/<your-name>/home
    git init
    ```
 
@@ -151,9 +151,9 @@ shimmer tasks            # Available capabilities
 
 ### Learn From Colleagues
 
-Check existing zettelkastens for patterns and insights:
+Check existing agent home repos for patterns and insights:
 ```bash
-find ~/agents -name "*.md" -path "*/zettelkasten/*" | head -50
+find ~/agents -name "*.md" -path "*/home/*" | head -50
 ```
 
 Look for notes about YOU - colleagues may have documented interactions with you.
@@ -194,9 +194,9 @@ cat ~/shimmer/workflows.yaml
 
 Consider creating a private repo to own your zettelkasten:
 ```bash
-cd ~/agents/<your-name>/zettelkasten
-gh repo create <your-github>/zettelkasten --private \
-  --description "<your-name>'s slip box" \
+cd ~/agents/<your-name>/home
+gh repo create <your-github>/home --private \
+  --description "<your-name>'s home repo" \
   --source . --push
 gh auth setup-git  # Enable pushing
 ```

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -155,3 +155,16 @@ setup() {
 
   grep -q "hello there" "$HARNESS_LOG"
 }
+
+@test "agent:dispatch preserves embedded newlines in message input" {
+  mock_gh 12345
+  mock_shimmer
+
+  message=$'line1\nline2'
+  run shimmer agent:dispatch --repo test/repo c0da "$message"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Woke c0da (run 12345)"* ]]
+
+  log=$(cat "$GH_LOG")
+  [[ "$log" == *$'message=line1\nline2'* ]]
+}

--- a/test/agent/helpers.bash
+++ b/test/agent/helpers.bash
@@ -5,6 +5,7 @@
 # without real session infrastructure.
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../ci" && pwd)/helpers.bash"
 
 # Set up minimal agent identity environment.
 # Usage: setup_agent [name]

--- a/test/ci/dispatch.bats
+++ b/test/ci/dispatch.bats
@@ -52,6 +52,19 @@ setup() {
   grep "workflow run" "$GH_LOG" | grep -q "message=hello world from CI"
 }
 
+@test "dispatch: preserves embedded newlines in input values" {
+  mock_gh 12345
+  mock_shimmer
+
+  message=$'line1\nline2'
+  run shimmer ci:dispatch test.yml "message=$message" model=opus --repo test/repo
+  [ "$status" -eq 0 ]
+
+  log=$(cat "$GH_LOG")
+  [[ "$log" == *$'message=line1\nline2'* ]]
+  [[ "$log" == *"model=opus"* ]]
+}
+
 @test "dispatch: shows human-friendly info on stderr" {
   mock_gh 12345
   mock_shimmer

--- a/test/ci/helpers.bash
+++ b/test/ci/helpers.bash
@@ -51,6 +51,7 @@ esac
 MOCK
   chmod +x "$MOCK_BIN/gh"
   export PATH="$MOCK_BIN:$PATH"
+  export GH_BIN="$MOCK_BIN/gh"
 }
 
 # Create a mock gh that never returns a run (for timeout testing)
@@ -76,4 +77,5 @@ esac
 MOCK
   chmod +x "$MOCK_BIN/gh"
   export PATH="$MOCK_BIN:$PATH"
+  export GH_BIN="$MOCK_BIN/gh"
 }


### PR DESCRIPTION
## Summary
- prefer `~/agents/<agent>/home` over legacy `~/agents/<agent>/zettelkasten` in agent startup tooling
- update the agent-run workflow template to clone `<agent>-ricon/home`, with fallback to the legacy repo name
- refresh zettelkasten docs/examples to use home-repo paths

## Testing
- `bash -n .mise/tasks/zettel/welcome .mise/tasks/zettel/search .mise/tasks/welcome .mise/tasks/_agent-preview`
- `mise -C ~/agents/quick/shimmer run -q zettel:welcome`
- `mise -C ~/agents/quick/shimmer run -q welcome`
