### PR TITLE
fix(welcome): drop Zettel and Blob rows

### DIFF
--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -103,10 +103,12 @@ if [ -n "$AGENT" ]; then
   fi
 
   # Note: Zettel and Blob rows removed from welcome (April 2026).
+  # See KnickKnackLabs/shimmer#726 for the full rationale and follow-ups.
   # - Zettel check was incorrect for the modern home-repo layout
   #   (only looked at $HOME/agents/$AGENT/home top-level, missing
   #   notes organised under Zettels/, Inbox/, etc.). Zettel status
-  #   belongs in each agent's home-repo `mise run welcome` task.
+  #   should live in each agent's own home-repo welcome task where
+  #   the layout is known.
   # - Blob check reported a feature still in flight. Planned to move
   #   to KnickKnackLabs/blobs; until that ships, the check just adds
   #   noise at orientation.

--- a/.mise/tasks/welcome
+++ b/.mise/tasks/welcome
@@ -102,58 +102,21 @@ if [ -n "$AGENT" ]; then
     print_status "GitHub" "$GH_CHECK" "$GH_USER" "$GH_HINT"
   fi
 
-  # Zettelkasten check
-  PREFERRED_ZETTEL_DIR="$HOME/agents/$AGENT/home"
-  LEGACY_ZETTEL_DIR="$HOME/agents/$AGENT/zettelkasten"
-  if [ -d "$PREFERRED_ZETTEL_DIR" ]; then
-    ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
-  elif [ -d "$LEGACY_ZETTEL_DIR" ]; then
-    ZETTEL_DIR="$LEGACY_ZETTEL_DIR"
-  else
-    ZETTEL_DIR="$PREFERRED_ZETTEL_DIR"
-  fi
-  if [ -d "$ZETTEL_DIR" ]; then
-    NOTE_COUNT=$(find "$ZETTEL_DIR" -maxdepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
-    # Check if behind remote
-    ZETTEL_BEHIND=0
-    if [ -d "$ZETTEL_DIR/.git" ]; then
-      ZETTEL_TRACKING=$(git -C "$ZETTEL_DIR" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo "")
-      if [ -n "$ZETTEL_TRACKING" ]; then
-        if timeout 5 git -C "$ZETTEL_DIR" fetch origin 2>/dev/null; then
-          ZETTEL_BEHIND=$(git -C "$ZETTEL_DIR" rev-list --count HEAD.."$ZETTEL_TRACKING" 2>/dev/null || echo 0)
-        fi
-      fi
-    fi
-    if [ "$ZETTEL_BEHIND" -gt 0 ]; then
-      print_status "Zettel" "⚠" "$NOTE_COUNT notes ($ZETTEL_BEHIND behind remote)" "cd $ZETTEL_DIR && git pull"
-    else
-      print_status "Zettel" "✓" "$NOTE_COUNT notes" "shimmer zettel:welcome"
-    fi
-  else
-    print_status "Zettel" "✗" "none yet" "shimmer zettel:welcome"
-  fi
-
-  # Blob storage check
-  if command -v mc &>/dev/null && mc alias list "$AGENT" 2>/dev/null | grep -q "$AGENT"; then
-    B2_BUCKET_VAL="${B2_BUCKET:-}"
-    if [ -z "$B2_BUCKET_VAL" ]; then
-      B2_BUCKET_VAL=$(secrets get "$AGENT/b2-bucket" 2>/dev/null) || B2_BUCKET_VAL=""
-    fi
-    if [ -n "$B2_BUCKET_VAL" ]; then
-      OBJ_COUNT=$(mc ls --recursive --json "${AGENT}/${B2_BUCKET_VAL}" 2>/dev/null | jq -s 'length' 2>/dev/null || echo "?")
-      print_status "Blob" "✓" "${OBJ_COUNT} objects" "shimmer blob:welcome"
-    else
-      print_status "Blob" "⚠" "alias set, no bucket" "secrets set $AGENT/b2-bucket"
-    fi
-  else
-    print_status "Blob" "✗" "not configured" "shimmer blob:setup $AGENT"
-  fi
+  # Note: Zettel and Blob rows removed from welcome (April 2026).
+  # - Zettel check was incorrect for the modern home-repo layout
+  #   (only looked at $HOME/agents/$AGENT/home top-level, missing
+  #   notes organised under Zettels/, Inbox/, etc.). Zettel status
+  #   belongs in each agent's home-repo `mise run welcome` task.
+  # - Blob check reported a feature still in flight. Planned to move
+  #   to KnickKnackLabs/blobs; until that ships, the check just adds
+  #   noise at orientation.
+  # The shimmer blob:* tasks themselves remain for agents already
+  # using Backblaze via `mc`.
 else
   print_status "GPG" "?" "set identity first"
   print_status "Email" "?" "set identity first"
   print_status "Matrix" "?" "set identity first"
   print_status "GitHub" "?" "set identity first"
-  print_status "Zettel" "?" "set identity first"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #726.

## What

Removes the Zettel and Blob rows from `.mise/tasks/welcome`.

## Why

Both rows created orientation noise without useful signal — see #726 for the longer argument. Summary:

- **Zettel was broken.** The check used `find $HOME/agents/$AGENT/home -maxdepth 1 -name "*.md"` — which only sees `CLAUDE.md`/`HUMAN.md` at top level and misses every note organised under `Zettels/`, `Inbox/`, `Index/`. Every agent with a structured home repo (which is every agent) was getting `✗ none yet` despite having 20–30+ notes. Zettel status belongs in each agent's home-repo `mise run welcome` task where the directory layout is known.

- **Blob was premature.** Reported `✗ not configured` for a feature that's still in flight. The plan is to move blob storage into `KnickKnackLabs/blobs` (on my work queue as of today's session); until that ships there's no onboarding path for the `✗` row to point users toward.

## Before / after

Before (live `shimmer welcome` for any agent with a home repo):

```
Identity   ✓ baby-joel@ricon.family
GPG        ✓ signing enabled                → shimmer gpg:status baby-joel
Email      ✗ timed out after 5s             → emails welcome
Matrix     ✗ not logged in                  → shimmer matrix:login baby-joel
GitHub     ⚠ baby-joel (expires in 4d)      → shimmer github:token:regenerate baby-joel
Zettel     ✗ none yet                       → shimmer zettel:welcome       ← false
Blob       ✗ not configured                 → shimmer blob:setup baby-joel  ← stale plan
```

After:

```
Identity   ✓ baby-joel@ricon.family
GPG        ✓ signing enabled                → shimmer gpg:status baby-joel
Email      ✗ timed out after 5s             → emails welcome
Matrix     ✗ not logged in                  → shimmer matrix:login baby-joel
GitHub     ⚠ baby-joel (expires in 4d)      → shimmer github:token:regenerate baby-joel
```

## Scope

- Only `.mise/tasks/welcome` is modified. The underlying `shimmer blob:*` and `shimmer zettel:*` task subtrees are untouched — agents currently using Backblaze via `mc` are unaffected.
- Also drops the `Zettel ? set identity first` placeholder from the no-identity branch for symmetry.

## Not in this PR

- Replacement "Home" row design (see #726 follow-up A).
- Deprecating `shimmer zettel:*` (#726 follow-up B).
- Building `KnickKnackLabs/blobs` (#726 follow-up C).

## Tests

120/120 pass — no existing coverage for the Zettel/Blob rows to break. Live smoke confirms the 5-row output above.

Surfaced in [baby-joel's Startup Improvement Ideas](https://github.com/baby-joel/home) #3.
