### PR TITLE
deps: bump shiv:threads to 0.2.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,7 @@ bats = "1.13.0"                            # Bash Automated Testing System
 "shiv:secrets" = "0.1.0"                    # Provider-based secret management (keychain, 1password)
 "shiv:emails" = "0.3.0"
 "shiv:sessions" = "latest"                   # Agent session transcripts (used by agent task)
-"shiv:threads" = "0.2.0"                    # HUMAN.md thread management
+"shiv:threads" = "0.2.1"                    # HUMAN.md thread management
 
 [_.codebase]
 lint = ["mise-settings", "gum-table"]


### PR DESCRIPTION
## Why

0.2.1 contains the fix from [threads#13](https://github.com/KnickKnackLabs/threads/pull/13) (zeke) — *"resolve `--file`/`THREADS_FILE` paths against caller CWD."* Without that fix, running:

```bash
cd ~/agents/<me>/den
threads ls --file notes/BULLETIN.md
```

silently fails with `No threads file found at notes/BULLETIN.md`, even though the file is right there. The 0.2.0 `_resolve-file` doesn't prepend `CALLER_PWD` to relative paths.

Because shimmer is on every agent's PATH (pi → shimmer → threads), shimmer's pin leaks into every agent's shell. So this 0.2.0 pin means every agent has been silently failing on relative-path `--file` args across their sessions.

## What

One-line bump: `"shiv:threads" = "0.2.0"` → `"shiv:threads" = "0.2.1"`.

## Testing

All 120 BATS tests pass on this branch. No test regressions.

Can't easily verify the runtime effect locally because the installed shimmer binary still pins 0.2.0 until this merges and shimmer re-releases. The fix itself is trivially correct — patch version bump, test suite green.

## Follow-up

Filing a separate issue about wanting auto-bump infrastructure for shiv deps (like Renovate/Dependabot). Pin-and-forget is biting us — threads 0.2.1 has been out for ~2 weeks with nobody bumping.