### PR TITLE
chore: rollout codebase v0.2.0 lint rules + fix findings

### DIFF
--- a/.mise/tasks/agent/schedules
+++ b/.mise/tasks/agent/schedules
@@ -54,8 +54,9 @@ for i in $(seq 0 $((WORKFLOW_COUNT - 1))); do
     status="?"
   fi
 
-  ROWS+="${status}"$'\t'"${NAME}"$'\t'"${AGENT}"$'\t'"${SCHEDULE}"$'\t'"${MESSAGE}"$'\n'
+  ROWS+="${status}"$'\t'"${NAME}"$'\t'"${AGENT}"$'\t'"${SCHEDULE}"$'\t'"${MESSAGE}"
+  [ "$i" -lt $((WORKFLOW_COUNT - 1)) ] && ROWS+=$'\n'
 done
 
-printf '%s\n%s' "$HEADER" "$ROWS" | gum table --print --separator $'\t' --border rounded \
+printf '%s\n%s\n' "$HEADER" "$ROWS" | gum table --print --separator $'\t' --border rounded \
   --border.foreground 240 --header.foreground 81

--- a/.mise/tasks/agent/schedules
+++ b/.mise/tasks/agent/schedules
@@ -18,10 +18,7 @@ REPO=$(git remote get-url origin 2>/dev/null | sed 's/.*github.com[:/]//' | sed 
 workflow_data=$(gh api "repos/$REPO/actions/workflows" --jq '.workflows[] | "\(.path)\t\(.state)"' 2>/dev/null || true)
 
 echo "Agent Schedules"
-echo "==============="
 echo ""
-printf "%-8s %-12s %-10s %-24s %s\n" "STATUS" "NAME" "AGENT" "SCHEDULE" "MESSAGE"
-printf "%-8s %-12s %-10s %-24s %s\n" "------" "----" "-----" "--------" "-------"
 
 # Read workflows from yaml
 WORKFLOW_COUNT=$(yq -r '.workflows | length' workflows.yaml 2>/dev/null || echo "0")
@@ -31,6 +28,8 @@ if [ "$WORKFLOW_COUNT" -eq 0 ]; then
   exit 0
 fi
 
+HEADER=$'STATUS\tNAME\tAGENT\tSCHEDULE\tMESSAGE'
+ROWS=""
 for i in $(seq 0 $((WORKFLOW_COUNT - 1))); do
   NAME=$(yq -r ".workflows[$i].name" workflows.yaml)
   AGENT=$(yq -r ".workflows[$i].agent" workflows.yaml)
@@ -55,5 +54,8 @@ for i in $(seq 0 $((WORKFLOW_COUNT - 1))); do
     status="?"
   fi
 
-  printf "%-8s %-12s %-10s %-24s %s\n" "$status" "$NAME" "$AGENT" "$SCHEDULE" "$MESSAGE" # codebase:ignore
+  ROWS+="${status}"$'\t'"${NAME}"$'\t'"${AGENT}"$'\t'"${SCHEDULE}"$'\t'"${MESSAGE}"$'\n'
 done
+
+printf '%s\n%s' "$HEADER" "$ROWS" | gum table --print --separator $'\t' --border rounded \
+  --border.foreground 240 --header.foreground 81

--- a/.mise/tasks/code/init/welcome
+++ b/.mise/tasks/code/init/welcome
@@ -38,7 +38,7 @@ echo ""
 if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
   REPOS=$(gh repo list ricon-family --limit 20 --json name,description --jq '.[] | "  \(.name)\t\(.description // "-")"' 2>/dev/null || true)
   if [ -n "$REPOS" ]; then
-    echo "$REPOS" | column -t -s $'\t' # codebase:ignore
+    echo "$REPOS" | column -t -s $'\t' # codebase:ignore gum-table
   else
     echo "  (couldn't fetch repos - check gh auth)"
   fi

--- a/.mise/tasks/github/org/list
+++ b/.mise/tasks/github/org/list
@@ -31,7 +31,7 @@ while IFS= read -r org; do
   PRIVATE_REPOS=$(echo "$INFO" | jq -r '.total_private_repos // 0')
   REPO_COUNT=$((PUBLIC_REPOS + PRIVATE_REPOS))
 
-  printf "  %-24s %-8s %3d repos  %3d members" "$org" "$ROLE" "$REPO_COUNT" "$MEMBERS" # codebase:ignore
+  printf "  %-24s %-8s %3d repos  %3d members" "$org" "$ROLE" "$REPO_COUNT" "$MEMBERS" # codebase:ignore gum-table
   if [[ -n "$DESC" ]]; then
     echo "  $DESC"
   else

--- a/.mise/tasks/github/repo/list
+++ b/.mise/tasks/github/repo/list
@@ -70,7 +70,7 @@ list_repos() {
       suffix=" (archived)"
     fi
 
-    printf "  %-24s %-8s %-40s %s%s\n" "$name" "$visibility" "$nameWithOwner" "$age" "$suffix" # codebase:ignore
+    printf "  %-24s %-8s %-40s %s%s\n" "$name" "$visibility" "$nameWithOwner" "$age" "$suffix" # codebase:ignore gum-table
   done
 
   # Summary

--- a/.mise/tasks/metrics/activity
+++ b/.mise/tasks/metrics/activity
@@ -34,7 +34,7 @@ echo "$PR_DATA" | jq -r --arg days "$DAYS" '
   sort_by(-.total) |
   .[] |
   "\(.agent)\t\(.total) PRs (\(.merged) merged, \(.closed) closed, \(.open) open)"
-' 2>/dev/null | column -t -s $'\t' || echo "No agent PR data found" # codebase:ignore
+' 2>/dev/null | column -t -s $'\t' || echo "No agent PR data found" # codebase:ignore gum-table
 
 echo ""
 echo "=== Issues by Agent ==="
@@ -55,7 +55,7 @@ echo "$ISSUE_DATA" | jq -r --arg days "$DAYS" '
   sort_by(-.total) |
   .[] |
   "\(.agent)\t\(.total) issues (\(.open) open, \(.closed) closed)"
-' 2>/dev/null | column -t -s $'\t' || echo "No agent issue data found" # codebase:ignore
+' 2>/dev/null | column -t -s $'\t' || echo "No agent issue data found" # codebase:ignore gum-table
 
 echo ""
 echo "=== Merge Conflict Status ==="

--- a/.mise/tasks/metrics/usage
+++ b/.mise/tasks/metrics/usage
@@ -33,7 +33,7 @@ gh run list --limit 500 --json workflowName,createdAt,updatedAt,status,conclusio
   sort_by(-.total) |
   .[] |
   "\(.workflow)\t\(.total)\t\(.success) ok\t\(.failure) fail\t\(.skipped) skip"
-' | column -t -s $'\t' # codebase:ignore
+' | column -t -s $'\t' # codebase:ignore gum-table
 
 echo ""
 echo "=== Run Duration Estimates ==="
@@ -53,7 +53,7 @@ gh run list --limit 500 --status success --json workflowName,createdAt,updatedAt
   sort_by(-.total_min) |
   .[] |
   "\(.workflow)\t\(.count) runs\t~\(.avg_min)m avg\t\(.total_min)m total"
-' | column -t -s $'\t' # codebase:ignore
+' | column -t -s $'\t' # codebase:ignore gum-table
 
 echo ""
 echo "=== Totals ==="

--- a/.mise/tasks/pr/list
+++ b/.mise/tasks/pr/list
@@ -87,7 +87,7 @@ echo "$PRS" | while read -r pr; do
   # Format changes
   CHANGES="+${ADDITIONS}/-${DELETIONS}"
 
-  printf "  #%-4s  %-14s  %-12s  %4s  %s%s\n" "$NUMBER" "$STATUS" "$CHANGES" "$AGE" "$TITLE" "$STALE" # codebase:ignore
+  printf "  #%-4s  %-14s  %-12s  %4s  %s%s\n" "$NUMBER" "$STATUS" "$CHANGES" "$AGE" "$TITLE" "$STALE" # codebase:ignore gum-table
 done
 
 echo ""

--- a/.mise/tasks/telemetry/status
+++ b/.mise/tasks/telemetry/status
@@ -49,6 +49,9 @@ echo ""
 
 # Tools breakdown
 echo "  By tool:"
-jq -r '.tool' "$TELEMETRY_FILE" 2>/dev/null | sort | uniq -c | sort -rn | while read -r count tool; do
-  printf "    %-20s %s\n" "$tool" "$count"
-done
+HEADER=$'tool\tcount'
+TABLE=$(jq -r '.tool' "$TELEMETRY_FILE" 2>/dev/null | sort | uniq -c | sort -rn | awk '{tool=$2; count=$1; printf "%s\t%s\n", tool, count}')
+if [ -n "$TABLE" ]; then
+  printf '%s\n%s\n' "$HEADER" "$TABLE" | gum table --print --separator $'\t' --border rounded \
+    --border.foreground 240 --header.foreground 81
+fi

--- a/.mise/tasks/zettel/welcome
+++ b/.mise/tasks/zettel/welcome
@@ -174,27 +174,30 @@ for dir in inbox 00_Inbox; do
 done
 
 # Structure - always show to teach the convention
+# These printf lines are decorative "count → dir/" pairs, not a table;
+# using gum table here would add a box border around prose. Annotated
+# so lint:gum-table doesn't flag them.
 echo "  Structure:"
 
 # Inbox first - encourages processing pending items
 if [ -n "$INBOX_DIR" ]; then
-  printf "    %-12s → %s/\n" "$INBOX_COUNT pending" "$INBOX_DIR"
+  printf "    %-12s → %s/\n" "$INBOX_COUNT pending" "$INBOX_DIR" # codebase:ignore gum-table
 else
-  printf "    %-12s → %s/\n" "0 pending" "inbox"
+  printf "    %-12s → %s/\n" "0 pending" "inbox" # codebase:ignore gum-table
 fi
 
 # Sessions (more likely to be reviewed than notes)
 if [ -n "$SESSIONS_DIR" ]; then
-  printf "    %-12s → %s/\n" "$SESSIONS_COUNT sessions" "$SESSIONS_DIR"
+  printf "    %-12s → %s/\n" "$SESSIONS_COUNT sessions" "$SESSIONS_DIR" # codebase:ignore gum-table
 else
-  printf "    %-12s → %s/\n" "0 sessions" "sessions"
+  printf "    %-12s → %s/\n" "0 sessions" "sessions" # codebase:ignore gum-table
 fi
 
 # Notes (permanent atomic notes)
 if [ -n "$NOTES_DIR" ]; then
-  printf "    %-12s → %s/\n" "$NOTES_COUNT notes" "$NOTES_DIR"
+  printf "    %-12s → %s/\n" "$NOTES_COUNT notes" "$NOTES_DIR" # codebase:ignore gum-table
 else
-  printf "    %-12s → %s/\n" "0 notes" "notes"
+  printf "    %-12s → %s/\n" "0 notes" "notes" # codebase:ignore gum-table
 fi
 
 # Uncategorized (files not in standard dirs, excluding README.md)
@@ -203,7 +206,7 @@ CATEGORIZED=$((NOTES_COUNT + SESSIONS_COUNT + INBOX_COUNT))
 [ "$HAS_README" = true ] && CATEGORIZED=$((CATEGORIZED + 1))
 UNCATEGORIZED=$((TOTAL_COUNT - CATEGORIZED))
 if [ "$UNCATEGORIZED" -gt 0 ]; then
-  printf "    %-12s %s\n" "$UNCATEGORIZED other" "(in root or other dirs)"
+  printf "    %-12s %s\n" "$UNCATEGORIZED other" "(in root or other dirs)" # codebase:ignore gum-table
 fi
 
 echo ""

--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ experimental = true
 shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 
 [tools]
-"shiv:codebase" = "0.1.0"                 # Codebase linting + migrations
+"shiv:codebase" = "0.2.0"                 # Codebase linting + migrations
 node = "22"                               # LTS
 "github:pimalaya/himalaya" = "1.2.0"      # Email CLI for agents
 "1password-cli" = "2.32.0"                # Credential management
@@ -24,7 +24,7 @@ bats = "1.13.0"                            # Bash Automated Testing System
 "shiv:threads" = "0.2.0"                    # HUMAN.md thread management
 
 [_.codebase]
-lint = ["mise-settings", "gum-table"]
+lint = ["mise-settings", "gum-table", "bats-test-helper", "bats-test-task", "mcr-scope"]
 
 [_.codebase.scope]
 gum-table = ".mise/tasks"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -10,8 +10,8 @@
 # invoked via `mise run test` or directly with `bats test/...`. We can't
 # rely on $MISE_CONFIG_ROOT: it's unset when bats is invoked directly,
 # and even under `mise run test` it points at the nearest mise.toml,
-# which may be an overlay rather than the real shimmer root. See
-# fold/notes/mise-gotchas.md and codebase's lint:mcr-scope rule.
+# which may be an overlay rather than the real shimmer root. The
+# codebase tool's lint:mcr-scope rule enforces this pattern.
 SHIMMER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Create a mock task file. Call this before mock_shimmer.

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -6,12 +6,13 @@
 #
 # Usage: source this from suite-specific helpers.bash files.
 
-# Project root — set by mise when running tasks
-if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
-  echo "MISE_CONFIG_ROOT not set — run tests via: mise run test" >&2
-  exit 1
-fi
-SHIMMER_DIR="$MISE_CONFIG_ROOT"
+# Project root — derived from this file's location so tests work whether
+# invoked via `mise run test` or directly with `bats test/...`. We can't
+# rely on $MISE_CONFIG_ROOT: it's unset when bats is invoked directly,
+# and even under `mise run test` it points at the nearest mise.toml,
+# which may be an overlay rather than the real shimmer root. See
+# fold/notes/mise-gotchas.md and codebase's lint:mcr-scope rule.
+SHIMMER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Create a mock task file. Call this before mock_shimmer.
 # Usage: mock_task "email/quota" 'echo "Usage: 50%"'

--- a/test/web-fetch/web-fetch.bats
+++ b/test/web-fetch/web-fetch.bats
@@ -1,5 +1,16 @@
 #!/usr/bin/env bats
 # Tests for shimmer web:fetch
+#
+# Standalone by design: doesn't source test/helpers.bash because these
+# tests don't need the mock-first overlay machinery — they only need a
+# PATH-level mock of `curl`. The web:* tasks are slated for extraction
+# into a separate `web` codebase (KnickKnackLabs/web), at which point
+# these tests move with them, so tying into shimmer's shared helpers
+# would be wasted work.
+#
+# Hazard: the PATH-level curl mock relies on shimmer's mise.toml not
+# pinning `curl` as a tool. If it ever does, mise's prepended shim dir
+# would shadow $MOCK_BIN and silently break the mock.
 
 setup() {
   SHIMMER_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"

--- a/test/web-fetch/web-fetch.bats
+++ b/test/web-fetch/web-fetch.bats
@@ -3,7 +3,6 @@
 
 setup() {
   SHIMMER_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-  TASK="$SHIMMER_DIR/.mise/tasks/web/fetch"
 
   # Create a mock curl
   MOCK_BIN="$BATS_TEST_TMPDIR/bin"
@@ -24,24 +23,9 @@ MOCK
   chmod +x "$MOCK_BIN/curl"
 }
 
-# Helper: run the task with usage_ vars set
+# Helper: run the task through mise, so USAGE parses flags like real usage.
 run_fetch() {
-  local url=""
-  local quiet="false"
-  local header=""
-
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -q|--quiet) quiet="true"; shift ;;
-      -H|--header) header="$2"; shift 2 ;;
-      *) url="$1"; shift ;;
-    esac
-  done
-
-  usage_url="$url" \
-  usage_quiet="$quiet" \
-  usage_header="${header:-}" \
-  bash "$TASK"
+  mise -C "$SHIMMER_DIR" run -q web:fetch "$@"
 }
 
 # ============================================================================

--- a/test/web-search/brave.bats
+++ b/test/web-search/brave.bats
@@ -1,5 +1,16 @@
 #!/usr/bin/env bats
 # Tests for shimmer web:search:brave
+#
+# Standalone by design: doesn't source test/helpers.bash because these
+# tests don't need the mock-first overlay machinery — they only need a
+# PATH-level mock of `curl`. The web:* tasks are slated for extraction
+# into a separate `web` codebase (KnickKnackLabs/web), at which point
+# these tests move with them, so tying into shimmer's shared helpers
+# would be wasted work.
+#
+# Hazard: the PATH-level curl mock relies on shimmer's mise.toml not
+# pinning `curl` as a tool. If it ever does, mise's prepended shim dir
+# would shadow $MOCK_BIN and silently break the mock.
 
 setup() {
   SHIMMER_DIR="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"

--- a/test/web-search/brave.bats
+++ b/test/web-search/brave.bats
@@ -14,8 +14,6 @@ setup() {
 
   export PATH="$MOCK_BIN:$PATH"
   export BRAVE_SEARCH_API_KEY="test-key-123"
-
-  TASK="$SHIMMER_DIR/.mise/tasks/web/search/brave"
 }
 
 # Helper: set up curl mock to return a specific fixture
@@ -28,28 +26,24 @@ MOCK
   chmod +x "$MOCK_BIN/curl"
 }
 
-# Helper: run the task with usage_ vars set (simulating mise's USAGE parsing)
+# Helper: run the task through mise, so USAGE parses flags like real usage.
+# Multi-word queries (`run_brave test query`) are joined into a single
+# positional arg because the task's USAGE spec takes one `<query>`.
 run_brave() {
-  local json="false"
-  local count="5"
-  local offset="0"
+  local args=()
   local query=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --json) json="true"; shift ;;
-      -n) count="$2"; shift 2 ;;
-      --offset) offset="$2"; shift 2 ;;
-      *) query="$query $1"; shift ;;
+      --json)   args+=(--json); shift ;;
+      -n)       args+=(-n "$2"); shift 2 ;;
+      --offset) args+=(--offset "$2"); shift 2 ;;
+      *)        query="$query $1"; shift ;;
     esac
   done
   query="${query# }"  # trim leading space
 
-  usage_query="$query" \
-  usage_json="$json" \
-  usage_count="$count" \
-  usage_offset="$offset" \
-  bash "$TASK"
+  mise -C "$SHIMMER_DIR" run -q web:search:brave ${args[@]+"${args[@]}"} "$query"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

First PR in the rollout sweep for codebase v0.2.0's new lint rules (codebase#4). Bumps shimmer's shiv:codebase pin to v0.2.0 and enables `bats-test-helper`, `bats-test-task`, and `mcr-scope` in the lint list.

## Findings fixed

**bats-test-helper** (2 hits, `test/web-fetch/web-fetch.bats:44`, `test/web-search/brave.bats:52`):

Tests were invoking `bash "$TASK"` directly on the script, bypassing mise's USAGE parser and passing args as pre-set `usage_*` env vars. Now they go through `mise -C "$SHIMMER_DIR" run -q web:fetch` / `web:search:brave`, so flags are parsed like real usage.

**mcr-scope** (2 hits, `test/helpers.bash:10,14`):

`SHIMMER_DIR` was derived from `$MISE_CONFIG_ROOT`. Now derived from `$BATS_TEST_DIRNAME` via `${BASH_SOURCE[0]}` — works whether invoked via `mise run test` or direct `bats test/...`.

## Side effect: gum-table findings surfaced

v0.1.0 of `lint:gum-table` had a `local -n` bug (bash 4 only) that silently errored on bash 3.2 Macs, so the rule was effectively a no-op. v0.2.0 fixed the compat bug, which surfaced 8 pre-existing findings:

- **`.mise/tasks/telemetry/status`** — `[loop-table]` WARN → converted to `gum table`, matching the existing pattern in `telemetry/list`.
- **`.mise/tasks/agent/schedules`** — real 5-column table → converted to `gum table`.
- **`.mise/tasks/zettel/welcome`** — 7 `[padding]` INFO hits. These are decorative `count → dir/` key-value pairs, not tabular data — annotated with `# codebase:ignore gum-table` and a block comment explaining the rationale.

## Hygiene: migrate bare `# codebase:ignore` to rule-specific

7 pre-existing `# codebase:ignore` sites across 6 files didn't specify which rule they were suppressing. Migrated all of them to explicit `# codebase:ignore gum-table`, so future readers don't have to guess what's being suppressed and a new rule wouldn't be silently masked. See codebase#20 for the proposal to formalize this syntax.

## Deferred from this PR

codebase v0.2.0 also ships `lint:or-true` and `lint:shellcheck`. Both have substantial findings in shimmer that mix mechanical fixes with judgment calls (which `|| true` patterns are intentional, which shellcheck style warnings to suppress). Rolled out as separate PRs to keep review scope focused:

- #732 — enable `lint:or-true` + clean up ~22 findings
- #733 — enable `lint:shellcheck` + clean up shellcheck findings

## Verification

- `codebase pre-commit` hook green on all 5 enabled rules
- BATS suite: **120/120** passing
- Peer-reviewed locally by ikma and zeke (via `peer-review-via-sessions` pattern, CI-less). Both approve with suggestions. Round 2 commit (74f6556) addresses their findings: printf pattern inconsistency between `agent/schedules` and `telemetry/status`, opaque `fold/notes/` cross-ref in `test/helpers.bash`, and top-of-file comments on the standalone `web-*` test suites explaining the pending `web/` extraction + the PATH-level curl-mock hazard.

## Follow-ups

- codebase#20: structured inline ignore format (`codebase:ignore=<rule>[,<rule>]  <rationale>`) + `lint:ignore-justification` meta-rule.
- shimmer#732 + #733: remaining two rules.
- Rest of the sweep: sessions, notes, chat (bats-test-task non-canonical shape, mcr-scope, etc.).
- `den/notes/shim-version-desync.md` — unverified investigation note on the recurring "wrong tool version resolves after mise install" bug; surfaced during this PR's version bump.