### PR TITLE
fix: require explicit agent models

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -18,8 +18,8 @@ on:
         required: true
         type: string
       model:
-        description: 'Model to use (optional)'
-        required: false
+        description: 'Provider-qualified model to use (e.g., openai-codex/gpt-5.5)'
+        required: true
         type: string
     secrets:
       ANTHROPIC_API_KEY:
@@ -232,8 +232,17 @@ jobs:
           # Configure gh as git credential helper so shiv can clone private repos
           gh auth setup-git
 
-          CMD=(shimmer agent --headless --timeout "$RUN_TIMEOUT")
-          [ -n "$INPUT_MODEL" ] && CMD+=(--model "$INPUT_MODEL")
+          if [ -z "$INPUT_MODEL" ]; then
+            echo "::error::model input is required"
+            exit 1
+          fi
+
+          if [[ "$INPUT_MODEL" != */* ]]; then
+            echo "::error::model input must be provider-qualified (for example: openai-codex/gpt-5.5)"
+            exit 1
+          fi
+
+          CMD=(shimmer agent --headless --timeout "$RUN_TIMEOUT" --model "$INPUT_MODEL")
           CMD+=("$INPUT_MESSAGE")
 
           "${CMD[@]}"

--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -4,7 +4,7 @@
 #USAGE flag "--headless" help="Non-interactive mode: process message and exit"
 #USAGE flag "--session <session>" help="Session file path to resume"
 #USAGE flag "--timeout <seconds>" help="Timeout in seconds (headless only, stored as session metadata — not yet enforced by sessions wake)"
-#USAGE flag "--model <model>" help="Model to use"
+#USAGE flag "--model <model>" help="Model to use (required for --headless; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE arg "[message]" help="Initial message (required for --headless, optional for interactive)"
 
 set -e
@@ -29,7 +29,18 @@ fi
 # Headless mode requires a message
 if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
   echo "Error: --headless requires a message" >&2
-  echo "Usage: shimmer agent --headless \"do something\"" >&2
+  echo "Usage: shimmer agent --headless --model <provider/model> \"do something\"" >&2
+  exit 1
+fi
+
+if [ "$HEADLESS" = "true" ] && [ -z "$MODEL" ]; then
+  echo "Error: --headless requires --model <provider/model>" >&2
+  echo "Usage: shimmer agent --headless --model <provider/model> \"do something\"" >&2
+  exit 1
+fi
+
+if [ "$HEADLESS" = "true" ] && [[ "$MODEL" != */* ]]; then
+  echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
   exit 1
 fi
 
@@ -51,13 +62,11 @@ if [ "$HEADLESS" = "true" ]; then
     SESSION_ID="$SESSION"
   else
     NEW_ARGS=("$SESSION_NAME" --cwd "$CWD" --meta "agent.name=$GIT_AUTHOR_NAME")
-    [ -n "$MODEL" ] && NEW_ARGS+=(--model "$MODEL")
     SESSION_ID=$(sessions new "${NEW_ARGS[@]}")
   fi
 
   # Wake the session — foreground + headless (blocks until done)
-  WAKE_ARGS=("$SESSION_ID" --headless --message "$MESSAGE")
-  [ -n "$MODEL" ] && WAKE_ARGS+=(--model "$MODEL")
+  WAKE_ARGS=("$SESSION_ID" --headless --message "$MESSAGE" --model "$MODEL")
   [ -n "$TIMEOUT" ] && WAKE_ARGS+=(--meta "timeout=$TIMEOUT")
   sessions wake "${WAKE_ARGS[@]}"
 else

--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -4,7 +4,7 @@
 #USAGE flag "-s --stagger <seconds>" help="Seconds to wait between agents (default: 30)"
 #USAGE flag "--agents <list>" help="Comma-separated list of agents (default: all)"
 #USAGE flag "--dry-run" help="Show what would be done without triggering"
-#USAGE flag "--model <model>" help="Model to use"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 
 set -e
 
@@ -23,6 +23,16 @@ STAGGER="${usage_stagger:-30}"
 DRY_RUN="${usage_dry_run:-false}"
 MODEL="${usage_model:-}"
 AGENTS_FLAG="${usage_agents:-}"
+
+if [ -z "$MODEL" ]; then
+  echo "Error: --model <provider/model> is required" >&2
+  exit 1
+fi
+
+if [[ "$MODEL" != */* ]]; then
+  echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
+  exit 1
+fi
 
 # Discover agents. Empty on failure is the signal — the explicit error check
 # below handles it.
@@ -54,10 +64,7 @@ echo "Broadcasting to $AGENT_COUNT agents with ${STAGGER}s stagger"
 echo "Message: $MESSAGE"
 echo ""
 
-MODEL_ARGS=()
-if [ -n "$MODEL" ]; then
-  MODEL_ARGS=(--model "$MODEL")
-fi
+MODEL_ARGS=(--model "$MODEL")
 
 FIRST=true
 for AGENT in $AGENTS; do

--- a/.mise/tasks/agent/dispatch
+++ b/.mise/tasks/agent/dispatch
@@ -2,7 +2,7 @@
 #MISE description="Wake an agent by dispatching their workflow"
 #USAGE arg "<agent>" help="Agent to wake (e.g., zeke, baby-joel)"
 #USAGE arg "<message>" help="Message for the agent"
-#USAGE flag "--model <model>" help="Model to use"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--repo <repo>" help="Target repository (owner/name) — skip agent discovery"
 
 set -e
@@ -12,6 +12,16 @@ MESSAGE="${usage_message}"
 MODEL="${usage_model:-}"
 REPO_FLAG="${usage_repo:-}"
 
+if [[ -z "$MODEL" ]]; then
+  echo "Error: --model <provider/model> is required" >&2
+  exit 1
+fi
+
+if [[ "$MODEL" != */* ]]; then
+  echo "Error: --model must be provider-qualified (for example: openai-codex/gpt-5.5)" >&2
+  exit 1
+fi
+
 # Find the agent's home repo
 FIND_ARGS=("$AGENT")
 if [[ -n "$REPO_FLAG" ]]; then
@@ -20,10 +30,7 @@ fi
 REPO=$(mise run -q agent:find "${FIND_ARGS[@]}")
 
 # Build workflow inputs as positional key=value pairs
-INPUTS=("message=$MESSAGE")
-if [[ -n "$MODEL" ]]; then
-  INPUTS+=("model=$MODEL")
-fi
+INPUTS=("message=$MESSAGE" "model=$MODEL")
 
 # Dispatch the agent's workflow. Depending on mise output handling, stderr from
 # ci:dispatch can be folded into command-substitution output; extract the bare

--- a/.mise/tasks/agent/message
+++ b/.mise/tasks/agent/message
@@ -2,7 +2,7 @@
 #MISE description="Send a message to an agent (deprecated — use agent:dispatch)"
 #USAGE arg "<agent>" help="Agent to message (e.g., zeke, baby-joel)"
 #USAGE arg "<message>" help="Message for the agent"
-#USAGE flag "--model <model>" help="Model to use"
+#USAGE flag "--model <model>" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--repo <repo>" help="Target repository (owner/name) — skip agent discovery"
 
 set -e

--- a/.mise/tasks/workflows/check
+++ b/.mise/tasks/workflows/check
@@ -1,9 +1,11 @@
 #!/bin/bash
 #MISE description="Validate schema and check workflows are in sync (for CI)"
-#MISE depends=["workflows:validate"]
 set -eo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Determine target directory (caller's directory when using shimmer alias)
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+cd "$TARGET_DIR"
 
-# Run generate in check mode
-mise run workflows:generate --check
+# Validate and run generate in check mode through shimmer's own task tree.
+PROJECT_DIR="$TARGET_DIR" mise -C "$MISE_PROJECT_ROOT" run -q workflows:validate
+PROJECT_DIR="$TARGET_DIR" mise -C "$MISE_PROJECT_ROOT" run -q workflows:generate --check

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -61,8 +61,8 @@ on:
         required: true
         type: string
       model:
-        description: 'Model to use (optional)'
-        required: false
+        description: 'Provider-qualified model to use (e.g., openai-codex/gpt-5.5)'
+        required: true
         type: string
 
 jobs:
@@ -101,7 +101,11 @@ if [[ "$WORKFLOW_COUNT" -gt 0 ]]; then
     NAME=$(yq -r ".workflows[$i].name" workflows.yaml)
     AGENT=$(yq -r ".workflows[$i].agent" workflows.yaml)
     MESSAGE=$(yq -r ".workflows[$i].message" workflows.yaml)
-    MODEL=$(yq -r ".workflows[$i].model // \"\"" workflows.yaml)
+    MODEL=$(yq -r ".workflows[$i].model" workflows.yaml)
+    if [[ -z "$MODEL" || "$MODEL" == "null" ]]; then
+      echo "Error: workflow '$NAME' is missing required model" >&2
+      exit 1
+    fi
     AGENT_UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]')
 
     # Build schedule entries (array of cron expressions)
@@ -130,11 +134,6 @@ r $SCHED_TMP
 d
 }" "$OUTPUT_FILE"
     rm "$SCHED_TMP"
-
-    # Remove empty model line if no model specified
-    if [[ -z "$MODEL" ]]; then
-      sed -i '' '/^      model: *$/d' "$OUTPUT_FILE"
-    fi
 
     echo "Generated: ${NAME}.yml"
   done

--- a/.mise/tasks/workflows/validate
+++ b/.mise/tasks/workflows/validate
@@ -2,7 +2,9 @@
 #MISE description="Validate workflows.yaml against schema"
 set -eo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Determine target directory (caller's directory when using shimmer alias)
+TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+cd "$TARGET_DIR"
 
-check-jsonschema --schemafile workflows.schema.json workflows.yaml
+check-jsonschema --schemafile "$MISE_PROJECT_ROOT/workflows.schema.json" workflows.yaml
 echo "workflows.yaml is valid"

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -1,85 +1,126 @@
 # Agent Workflows
 
-How agent workflows are defined and generated.
+How agent CI workflows are defined and generated.
 
 ## Overview
 
-Agent workflows are **generated** from a manifest file. Never edit `.github/workflows/<agent>-*.yml` directly - your changes will be overwritten.
+Agent workflows are **generated** from a repo-local `workflows.yaml` manifest plus shimmer's workflow templates. Do not edit generated `.github/workflows/*.yml` files directly; regenerate them with `shimmer workflows:generate`.
+
+There are two generated workflow types:
+
+- **Per-agent manual workflows** (`.github/workflows/<agent>.yml`) — expose `workflow_dispatch` inputs for `message` and required provider-qualified `model`.
+- **Scheduled job workflows** (`.github/workflows/<name>.yml`) — call the reusable `agent-run.yml` workflow on a cron schedule.
+
+Both ultimately call `.github/workflows/agent-run.yml`, which sets up credentials and runs `shimmer agent --headless`.
 
 ## Structure
 
-```
-workflows.yaml              # Source of truth - defines agent/job/schedule
-.github/templates/          # Workflow template
-.github/workflows/*.yml     # Generated files (don't edit)
+```text
+workflows.yaml                    # Source of truth for scheduled jobs
+.github/templates/agent-run.yml   # Reusable agent runner template
+.github/templates/agent-scheduled.yml  # Scheduled workflow template
+.github/workflows/*.yml           # Generated files (do not edit directly)
 ```
 
-## The Manifest
+## Manifest Format
 
-`workflows.yaml` defines which agents run which jobs and when:
+`workflows.yaml` defines scheduled agent jobs:
 
 ```yaml
-jobs:
-  probe:
-    agents:
-      quick:
-        schedule: "0 */4 * * *"    # Every 4 hours
-  triage:
-    agents:
-      rho:
-        schedule: "0 14-22 * * *"  # Hourly during work hours
+workflows:
+  - name: junior-daily-checkin
+    agent: junior
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Check your home repo for job instructions and execute them."
 ```
+
+Required fields:
+
+- `name` — workflow filename stem (`.github/workflows/<name>.yml`); lowercase letters, numbers, and hyphens.
+- `agent` — agent identity to run.
+- `model` — provider-qualified model string, for example `openai-codex/gpt-5.5`.
+- `schedule` — one or more cron expressions.
+- `message` — instruction passed to the headless agent.
 
 ## Managing Workflows
 
-**Add or modify agent schedules:**
+Add or modify scheduled jobs:
+
 ```bash
 # 1. Edit workflows.yaml
 # 2. Regenerate workflow files
-mise run workflows:generate
+shimmer workflows:generate
 
 # 3. Commit both manifest and generated files
 git add workflows.yaml .github/workflows/
 git commit -m "Update agent schedules"
 ```
 
-**Validate workflows match manifest:**
+Validate workflows match the manifest:
+
 ```bash
-mise run workflows:check
+shimmer workflows:check
 ```
 
-This runs in CI to catch drift between the manifest and generated files.
+`workflows:check` validates `workflows.yaml` against shimmer's schema and regenerates into a temporary directory to catch drift between committed workflows and generated output.
 
-## How It Works
+## Manual Agent Dispatch
 
-The `workflows:generate` task:
-1. Reads jobs and agents from `workflows.yaml`
-2. For each agent/job pair, applies the template from `.github/templates/agent-job.yml`
-3. Writes the result to `.github/workflows/<agent>-<job>.yml`
+Generated per-agent workflows expose manual dispatch inputs:
+
+- `message` — required instruction for the agent.
+- `model` — required provider-qualified model string.
+
+Use shimmer's dispatch task to wake an agent:
+
+```bash
+shimmer agent:dispatch junior \
+  --model openai-codex/gpt-5.5 \
+  "Review this PR"
+```
+
+`agent:dispatch` fails before dispatching if `--model` is missing or not provider-qualified.
+
+## How Generated Workflows Run Agents
 
 Generated workflows call the reusable `agent-run.yml` workflow, which:
-- Sets up the agent's credentials (GPG, email, Matrix)
-- Creates a working branch
-- Runs the CLI: `mix shimmer --agent <agent> --job <job>`
 
-## Adding a New Agent Job
+1. Checks out the repo.
+2. Installs mise-managed tools.
+3. Sets up agent credentials (GPG, email, Matrix, GitHub, optional blob storage).
+4. Clones the agent home repo.
+5. Restores pi auth when `PI_AUTH_JSON` is configured.
+6. Runs:
 
-1. Add the agent/job entry to `workflows.yaml`:
-   ```yaml
-   jobs:
-     probe:
-       agents:
-         new-agent:
-           schedule: "0 */6 * * *"
-   ```
-
-2. Ensure the agent has an identity in the caller repo's `agents/<agent>/CLAUDE.md`
-
-3. Ensure the job has a prompt in `.jobs/<job>.txt`
-
-4. Generate and commit:
    ```bash
-   mise run workflows:generate
-   git add workflows.yaml .github/workflows/
-   git commit -m "Add new-agent probe workflow"
+   shimmer agent --headless --timeout "$RUN_TIMEOUT" --model "$INPUT_MODEL" "$INPUT_MESSAGE"
    ```
+
+Headless execution requires an explicit provider-qualified model. Shimmer creates a tracked session with `sessions new` and passes the model only to `sessions wake`, matching the `sessions` v0.4.0 contract.
+
+## Adding a Scheduled Job
+
+1. Add an entry to `workflows.yaml`:
+
+   ```yaml
+   workflows:
+     - name: quick-probe
+       agent: quick
+       model: openai-codex/gpt-5.5
+       schedule:
+         - "0 */4 * * *"
+       message: "Run the probe job and report findings."
+   ```
+
+2. Ensure the target repo's `agent:list --ci` includes the agent.
+
+3. Generate and check workflows:
+
+   ```bash
+   shimmer workflows:generate
+   shimmer workflows:check
+   ```
+
+4. Commit the manifest and generated workflow files.

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@ gum = "0.17.0"                             # Terminal UI components (tables, spi
 bats = "1.13.0"                            # Bash Automated Testing System
 "shiv:secrets" = "0.1.0"                    # Provider-based secret management (keychain, 1password)
 "shiv:emails" = "0.3.0"
-"shiv:sessions" = "latest"                   # Agent session transcripts (used by agent task)
+"shiv:sessions" = "0.4.0"                   # Agent session transcripts (used by agent task)
 "shiv:threads" = "0.2.1"                    # HUMAN.md thread management
 
 [_.codebase]

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -39,6 +39,24 @@ setup() {
   [[ "$output" == *"requires a message"* ]]
 }
 
+@test "headless: fails without model" {
+  setup_agent
+  mock_shimmer
+
+  run shimmer agent --headless "do something"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires --model"* ]]
+}
+
+@test "headless: fails with unqualified model" {
+  setup_agent
+  mock_shimmer
+
+  run shimmer agent --headless --model "gpt-5.5" "do something"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"provider-qualified"* ]]
+}
+
 @test "headless: fails when sessions not on PATH" {
   # Skip if sessions is installed — can't reliably hide it from mise subshell
   command -v sessions &>/dev/null && skip "sessions is installed"
@@ -46,7 +64,7 @@ setup() {
   setup_agent
   mock_shimmer
 
-  run shimmer agent --headless "do something"
+  run shimmer agent --headless --model "openai-codex/gpt-5.5" "do something"
   [ "$status" -ne 0 ]
   [[ "$output" == *"sessions not found"* ]]
 }
@@ -56,15 +74,17 @@ setup() {
   mock_sessions_binary
   mock_shimmer
 
-  run shimmer agent --headless "review the PR"
+  run shimmer agent --headless --model "openai-codex/gpt-5.5" "review the PR"
   [ "$status" -eq 0 ]
 
   # sessions new was called with agent name in session name
   grep -q "^new test-agent-headless-" "$SESSIONS_LOG"
   # sessions new includes agent.name metadata
   grep "^new " "$SESSIONS_LOG" | grep -q "agent.name=test-agent"
-  # sessions wake was called with the session ID from new
-  grep -q "^wake mock-session-id-001 --headless --message review the PR" "$SESSIONS_LOG"
+  # sessions new does not receive execution-time model selection
+  ! grep "^new " "$SESSIONS_LOG" | grep -q -- "--model"
+  # sessions wake was called with the session ID from new and explicit model
+  grep -q "^wake mock-session-id-001 --headless --message review the PR --model openai-codex/gpt-5.5" "$SESSIONS_LOG"
 }
 
 @test "headless: session name uses full epoch timestamp" {
@@ -72,7 +92,7 @@ setup() {
   mock_sessions_binary
   mock_shimmer
 
-  run shimmer agent --headless "test"
+  run shimmer agent --headless --model "openai-codex/gpt-5.5" "test"
   [ "$status" -eq 0 ]
 
   # Extract the session name from the new call — should have full epoch (10+ digits)
@@ -88,16 +108,16 @@ setup() {
   mock_sessions_binary
   mock_shimmer
 
-  run shimmer agent --headless --session "existing-session-42" "continue work"
+  run shimmer agent --headless --session "existing-session-42" --model "openai-codex/gpt-5.5" "continue work"
   [ "$status" -eq 0 ]
 
   # sessions new should NOT be called
   ! grep -q "^new " "$SESSIONS_LOG"
   # sessions wake called with existing session ID
-  grep -q "^wake existing-session-42 --headless --message continue work" "$SESSIONS_LOG"
+  grep -q "^wake existing-session-42 --headless --message continue work --model openai-codex/gpt-5.5" "$SESSIONS_LOG"
 }
 
-@test "headless: forwards model to sessions new and wake" {
+@test "headless: forwards model only to sessions wake" {
   setup_agent
   mock_sessions_binary
   mock_shimmer
@@ -105,7 +125,7 @@ setup() {
   run shimmer agent --headless --model "openai-codex/gpt-5.5" "do something"
   [ "$status" -eq 0 ]
 
-  grep "^new " "$SESSIONS_LOG" | grep -q -- "--model openai-codex/gpt-5.5"
+  ! grep "^new " "$SESSIONS_LOG" | grep -q -- "--model openai-codex/gpt-5.5"
   grep "^wake " "$SESSIONS_LOG" | grep -q -- "--model openai-codex/gpt-5.5"
 }
 
@@ -114,7 +134,7 @@ setup() {
   mock_sessions_binary
   mock_shimmer
 
-  run shimmer agent --headless --timeout 300 "do something"
+  run shimmer agent --headless --timeout 300 --model "openai-codex/gpt-5.5" "do something"
   [ "$status" -eq 0 ]
 
   # timeout passed as metadata on wake, not as a flag
@@ -157,12 +177,30 @@ setup() {
   grep -q "hello there" "$HARNESS_LOG"
 }
 
+@test "agent:dispatch requires model" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo c0da "hello"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--model"* ]]
+}
+
+@test "agent:dispatch requires provider-qualified model" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo --model gpt-5.5 c0da "hello"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"provider-qualified"* ]]
+}
+
 @test "agent:dispatch preserves embedded newlines in message input" {
   mock_gh 12345
   mock_shimmer
 
   message=$'line1\nline2'
-  run shimmer agent:dispatch --repo test/repo c0da "$message"
+  run shimmer agent:dispatch --repo test/repo --model openai-codex/gpt-5.5 c0da "$message"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Woke c0da (run 12345)"* ]]
   [[ "$output" == *"shimmer ci:logs 12345 --agent --repo test/repo"* ]]
@@ -170,4 +208,5 @@ setup() {
 
   log=$(cat "$GH_LOG")
   [[ "$log" == *$'message=line1\nline2'* ]]
+  [[ "$log" == *"model=openai-codex/gpt-5.5"* ]]
 }

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -19,7 +19,7 @@
       "title": "Workflow",
       "description": "A scheduled agent workflow",
       "type": "object",
-      "required": ["name", "agent", "schedule", "message"],
+      "required": ["name", "agent", "schedule", "message", "model"],
       "properties": {
         "name": {
           "type": "string",
@@ -45,13 +45,12 @@
         },
         "model": {
           "type": "string",
-          "description": "Claude model to use (defaults to opus if not specified)",
-          "enum": [
-            "claude-opus-4-6",
-            "claude-opus-4-5-20251101",
-            "claude-sonnet-4-6",
-            "claude-sonnet-4-5-20250929",
-            "claude-haiku-4-5-20251001"
+          "description": "Provider-qualified model to use (for example: openai-codex/gpt-5.5)",
+          "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$",
+          "examples": [
+            "openai-codex/gpt-5.5",
+            "github-copilot/gpt-5.5",
+            "anthropic/claude-opus-4-6"
           ]
         }
       }


### PR DESCRIPTION
## Summary
- require provider-qualified models for headless agent execution and agent dispatch
- stop passing execution-time models to `sessions new`; pass them only to `sessions wake`
- make generated workflow model inputs required
- require scheduled workflow models via schema validation
- fix workflow validate/check tasks so they operate on the caller target directory
- pin `shiv:sessions` to v0.4.0, which includes the required `sessions wake --model` contract

## Verification
- released `sessions v0.4.0` after `mise run test`, `cd cli && mix test`, and configured codebase lints
- `mise run test` (shimmer: 129 BATS)
- configured shimmer codebase lints: `mise-settings`, `gum-table`, `bats-test-helper`, `bats-test-task`, `mcr-scope`, `or-true`, `shellcheck`
- `CALLER_PWD=~/agents/x1f9/fold mise -C ~/agents/x1f9/shimmer run -q workflows:check`

## Notes
Follow-up fold PR will update generated workflows and scheduled workflow models.
