### PR TITLE
fix: scrub caller context before agent launch

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -255,7 +255,6 @@ jobs:
           echo "### AGENT SESSION START ###"
 
           cd "$HOME/$REPO_NAME"
-          export CALLER_PWD="$HOME/$REPO_NAME"
 
           # shimmer as sets identity env vars (AGENT_IDENTITY, GIT_AUTHOR_*, GH_TOKEN, etc.)
           # shimmer agent --headless delegates to sessions run for execution

--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -53,8 +53,13 @@ if [ "$HEADLESS" = "true" ]; then
     exit 1
   fi
 
-  CWD="${CALLER_PWD:-.}"
+  CWD="${SHIV_CALLER_PWD:-${CALLER_PWD:-.}}"
   SESSION_NAME="${GIT_AUTHOR_NAME}-headless-$(date +%s)"
+
+  # Caller-context variables describe this immediate shim invocation. Do not
+  # leak them into long-lived session processes, where they can become stale
+  # ambient state and redirect later tooling to the wrong repository.
+  unset CALLER_PWD SHIV_CALLER_PWD
 
   # Create a tracked session (or resume an existing one)
   if [ -n "$SESSION" ]; then
@@ -71,7 +76,9 @@ if [ "$HEADLESS" = "true" ]; then
   sessions wake "${WAKE_ARGS[@]}"
 else
   # Interactive mode calls the agent harness directly.
-  cd "${CALLER_PWD:-.}"
+  CWD="${SHIV_CALLER_PWD:-${CALLER_PWD:-.}}"
+  cd "$CWD"
+  unset CALLER_PWD SHIV_CALLER_PWD
   HARNESS="${AGENT_HARNESS:-pi}"
   if ! command -v "$HARNESS" &>/dev/null; then
     echo "$HARNESS not found on PATH." >&2

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -87,6 +87,34 @@ setup() {
   grep -q "^wake mock-session-id-001 --headless --message review the PR --model openai-codex/gpt-5.5" "$SESSIONS_LOG"
 }
 
+@test "headless: uses SHIV_CALLER_PWD as session cwd before scrubbing" {
+  setup_agent
+  local caller_dir="$BATS_TEST_TMPDIR/shiv-caller"
+  mkdir -p "$caller_dir"
+  unset CALLER_PWD
+  export SHIV_CALLER_PWD="$caller_dir"
+  mock_sessions_binary
+  mock_shimmer
+
+  run shimmer agent --headless --model "openai-codex/gpt-5.5" "review the PR"
+  [ "$status" -eq 0 ]
+
+  grep "^new " "$SESSIONS_LOG" | grep -q -- "--cwd $caller_dir"
+}
+
+@test "headless: scrubs caller context before invoking sessions" {
+  setup_agent
+  export SHIV_CALLER_PWD="/stale/shiv/caller"
+  mock_sessions_binary
+  mock_shimmer
+
+  run shimmer agent --headless --model "openai-codex/gpt-5.5" "review the PR"
+  [ "$status" -eq 0 ]
+
+  grep -q '^CALLER_PWD=$' "$SESSIONS_ENV_LOG"
+  grep -q '^SHIV_CALLER_PWD=$' "$SESSIONS_ENV_LOG"
+}
+
 @test "headless: session name uses full epoch timestamp" {
   setup_agent
   mock_sessions_binary
@@ -153,6 +181,36 @@ setup() {
 
   # harness was called with --append-system-prompt
   grep -q -- "--append-system-prompt" "$HARNESS_LOG"
+}
+
+@test "interactive: uses SHIV_CALLER_PWD as harness cwd before scrubbing" {
+  setup_agent
+  local caller_dir="$BATS_TEST_TMPDIR/shiv-caller"
+  mkdir -p "$caller_dir"
+  unset CALLER_PWD
+  export SHIV_CALLER_PWD="$caller_dir"
+  mock_harness
+  mock_shimmer
+
+  run shimmer agent
+  [ "$status" -eq 0 ]
+
+  grep -q "^PWD=$caller_dir$" "$HARNESS_ENV_LOG"
+}
+
+@test "interactive: scrubs caller context before invoking harness" {
+  setup_agent
+  local caller_dir="$BATS_TEST_TMPDIR/scrub-caller"
+  mkdir -p "$caller_dir"
+  export SHIV_CALLER_PWD="$caller_dir"
+  mock_harness
+  mock_shimmer
+
+  run shimmer agent
+  [ "$status" -eq 0 ]
+
+  grep -q '^CALLER_PWD=$' "$HARNESS_ENV_LOG"
+  grep -q '^SHIV_CALLER_PWD=$' "$HARNESS_ENV_LOG"
 }
 
 @test "interactive: forwards session flag to harness" {

--- a/test/agent/helpers.bash
+++ b/test/agent/helpers.bash
@@ -24,11 +24,16 @@ mock_sessions_binary() {
   MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin-$$"
   mkdir -p "$MOCK_BIN"
   SESSIONS_LOG="$BATS_TEST_TMPDIR/sessions-log-$$"
-  export SESSIONS_LOG
+  SESSIONS_ENV_LOG="$BATS_TEST_TMPDIR/sessions-env-log-$$"
+  export SESSIONS_LOG SESSIONS_ENV_LOG
 
   cat > "$MOCK_BIN/sessions" <<'MOCK'
 #!/usr/bin/env bash
 echo "$@" >> "$SESSIONS_LOG"
+{
+  printf 'CALLER_PWD=%s\n' "${CALLER_PWD-}"
+  printf 'SHIV_CALLER_PWD=%s\n' "${SHIV_CALLER_PWD-}"
+} >> "${SESSIONS_ENV_LOG:-$SESSIONS_LOG.env}"
 case "$1" in
   new) echo "mock-session-id-001" ;;
   wake) ;;
@@ -46,11 +51,17 @@ mock_harness() {
   MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin-$$"
   mkdir -p "$MOCK_BIN"
   HARNESS_LOG="$BATS_TEST_TMPDIR/harness-log-$$"
-  export HARNESS_LOG
+  HARNESS_ENV_LOG="$BATS_TEST_TMPDIR/harness-env-log-$$"
+  export HARNESS_LOG HARNESS_ENV_LOG
 
   cat > "$MOCK_BIN/mock-harness" <<'MOCK'
 #!/usr/bin/env bash
 echo "$@" >> "$HARNESS_LOG"
+{
+  printf 'PWD=%s\n' "$PWD"
+  printf 'CALLER_PWD=%s\n' "${CALLER_PWD-}"
+  printf 'SHIV_CALLER_PWD=%s\n' "${SHIV_CALLER_PWD-}"
+} >> "${HARNESS_ENV_LOG:-$HARNESS_LOG.env}"
 MOCK
   chmod +x "$MOCK_BIN/mock-harness"
   export PATH="$MOCK_BIN:$PATH"


### PR DESCRIPTION
## Summary
- Unset `CALLER_PWD` and `SHIV_CALLER_PWD` before `shimmer agent` launches long-lived child processes
- Keep using caller cwd to choose the agent/session cwd before scrubbing
- Stop generated agent workflows from exporting `CALLER_PWD`
- Add regressions for headless sessions and interactive harness launch

Part of KnickKnackLabs/shiv#104. This intentionally does not rename the shiv caller-cwd contract yet; it fixes the stale ambient-context leak first.

## Verification
- `mise run test agent`
- `mise run test`
- `mise exec -- codebase lint:mise-settings "$PWD"`
- `mise exec -- codebase lint:gum-table "$PWD"`
- `mise exec -- codebase lint:shellcheck "$PWD"`
