### PR TITLE
Fix shimmer as output for unquoted eval

### DIFF
--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -77,6 +77,26 @@ fi
 
 EMAIL="${AGENT}@ricon.family"
 
+shell_quote() {
+  local value="$1"
+  value=${value//\'/\'\\\'\'}
+  printf "'%s'" "$value"
+}
+
+ansi_c_quote() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  value=${value//\'/\\\'}
+  printf "\$'%s'" "$value"
+}
+
+emit() {
+  printf '%s;\n' "$1"
+}
+
 # Validate agent against the authoritative home-provided agent list.
 if ! echo "$AGENTS" | grep -qx "$AGENT"; then
   echo "Unknown agent: $AGENT" >&2
@@ -88,10 +108,10 @@ fi
 # `shimmer as` from leaking through if any resolution step below fails.
 # This must come before PAT resolution — if secrets lookup exits early,
 # eval still clears the previous session's vars.
-echo "unset AGENT_IDENTITY B2_BUCKET"
-echo "unset GH_HOST GH_TOKEN"
-echo "unset GIT_AUTHOR_EMAIL GIT_COMMITTER_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_NAME"
-echo "unset AGENT_HOME"
+emit "unset AGENT_IDENTITY B2_BUCKET"
+emit "unset GH_HOST GH_TOKEN"
+emit "unset GIT_AUTHOR_EMAIL GIT_COMMITTER_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_NAME"
+emit "unset AGENT_HOME"
 
 # Fetch GitHub PAT via secrets tool
 PAT=$(secrets get "$AGENT/github-pat") || {
@@ -104,19 +124,19 @@ PAT=$(secrets get "$AGENT/github-pat") || {
 # NOTE: GH_HOST is hardcoded to github.com — all shimmer agents currently target
 # github.com. If an agent ever needs to target a GHE instance, this should become
 # configurable (e.g., per-agent config or secret store field).
-echo "export GH_HOST='github.com'"
-echo "export GH_TOKEN='$PAT'"
-echo "export GIT_AUTHOR_EMAIL='$EMAIL'"
-echo "export GIT_COMMITTER_EMAIL='$EMAIL'"
-echo "export GIT_AUTHOR_NAME='$AGENT'"
-echo "export GIT_COMMITTER_NAME='$AGENT'"
-echo "export AGENT_HOME='$AGENT_HOME_DIR'"
+emit "export GH_HOST=$(shell_quote 'github.com')"
+emit "export GH_TOKEN=$(shell_quote "$PAT")"
+emit "export GIT_AUTHOR_EMAIL=$(shell_quote "$EMAIL")"
+emit "export GIT_COMMITTER_EMAIL=$(shell_quote "$EMAIL")"
+emit "export GIT_AUTHOR_NAME=$(shell_quote "$AGENT")"
+emit "export GIT_COMMITTER_NAME=$(shell_quote "$AGENT")"
+emit "export AGENT_HOME=$(shell_quote "$AGENT_HOME_DIR")"
 
 # Optional: B2 blob storage bucket (don't fail if not configured).
 # Empty on missing or provider failure; conditional export below handles it.
 B2_BUCKET=$(secrets get "$AGENT/b2-bucket" 2>/dev/null) || B2_BUCKET=""
 if [ -n "$B2_BUCKET" ]; then
-  echo "export B2_BUCKET='$B2_BUCKET'"
+  emit "export B2_BUCKET=$(shell_quote "$B2_BUCKET")"
 fi
 
 # Resolve agent identity content via the home's agent:identity task.
@@ -124,9 +144,10 @@ fi
 # prints a notice in that case.
 IDENTITY=$(mise -C "$AGENT_HOME_DIR" run -q agent:identity "$AGENT" 2>/dev/null) || IDENTITY=""
 if [ -n "$IDENTITY" ]; then
-  # Export as multi-line env var using $'...' quoting
-  ESCAPED=$(printf '%s' "$IDENTITY" | sed "s/'/'\\\\''/g")
-  echo "export AGENT_IDENTITY='$ESCAPED'"
+  # Export as encoded ANSI-C quoting so unquoted command substitution
+  # (`eval $(shimmer as agent)`) cannot collapse literal newlines inside
+  # AGENT_IDENTITY before eval sees the command stream.
+  emit "export AGENT_IDENTITY=$(ansi_c_quote "$IDENTITY")"
 else
   echo "# Note: agent home has no agent:identity task — AGENT_IDENTITY not set" >&2
   echo "# (was cleared above to prevent stale values)" >&2

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `shimme
 
 Example:
 ```bash
-eval $(shimmer as quick)
+eval "$(shimmer as quick)"
 shimmer whoami
 ```
 

--- a/docs/agent-local.md
+++ b/docs/agent-local.md
@@ -66,7 +66,7 @@ This allows multiple agents to work on the same repository simultaneously withou
 Each terminal session needs the agent's identity configured:
 
 ```bash
-eval $(mise run as <agent>)
+eval "$(mise run as <agent>)"
 ```
 
 This sets:
@@ -98,7 +98,7 @@ GitHub identity:
 |------|-----------|---------|
 | Import GPG key | Once per machine | `mise run gpg:setup <agent>` |
 | Setup email | Once per machine | `emails setup <agent>` |
-| Set identity | Each session | `eval $(mise run as <agent>)` |
+| Set identity | Each session | `eval "$(mise run as <agent>)"` |
 | Verify setup | As needed | `mise run whoami` |
 
 ## Troubleshooting

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -85,6 +85,43 @@ teardown() {
   echo "$output" | grep -q "export GH_TOKEN='ghp_bob_token'"
 }
 
+@test "as: eval preserves apostrophes in exported values" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake'quoted" "alice/b2-bucket=bucket'quoted"
+  mock_shimmer
+
+  eval "$(shimmer as alice 2>/dev/null)"
+
+  [ "$GH_TOKEN" = "ghp_fake'quoted" ]
+  [ "$B2_BUCKET" = "bucket'quoted" ]
+}
+
+@test "as: unquoted eval preserves apostrophes in exported values" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake'quoted" "alice/b2-bucket=bucket'quoted"
+  mock_shimmer
+
+  local script="$BATS_TEST_TMPDIR/unquoted-eval-apostrophe.sh"
+  cat > "$script" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+home="$1"
+overlay="$2"
+
+eval $(CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
+
+printf 'token=%s\n' "$GH_TOKEN"
+printf 'bucket=%s\n' "$B2_BUCKET"
+SCRIPT
+  chmod +x "$script"
+
+  run "$script" "$TEST_HOME" "$OVERLAY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"token=ghp_fake'quoted"* ]]
+  [[ "$output" == *"bucket=bucket'quoted"* ]]
+}
+
 @test "as: exports B2_BUCKET when available" {
   setup_test_home "alice"
   mock_secrets_binary "alice/github-pat=ghp_fake" "alice/b2-bucket=my-bucket"
@@ -172,6 +209,65 @@ teardown() {
 
   # B2_BUCKET should be cleared since alice has no bucket configured
   [ -z "${B2_BUCKET:-}" ]
+}
+
+@test "as: unquoted eval works in bash" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  local script="$BATS_TEST_TMPDIR/unquoted-eval-bash.sh"
+  cat > "$script" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+home="$1"
+overlay="$2"
+
+# Intentionally unquoted: this preserves compatibility with the historical
+# documented form, `eval $(shimmer as <agent>)`.
+eval $(CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
+
+printf 'name=%s\n' "$GIT_AUTHOR_NAME"
+printf 'host=%s\n' "$GH_HOST"
+printf 'identity=%s\n' "$AGENT_IDENTITY"
+SCRIPT
+  chmod +x "$script"
+
+  run "$script" "$TEST_HOME" "$OVERLAY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"name=alice"* ]]
+  [[ "$output" == *"host=github.com"* ]]
+  [[ "$output" == *"You are alice."* ]]
+}
+
+@test "as: unquoted eval works in zsh" {
+  command -v zsh >/dev/null 2>&1 || skip "zsh not installed"
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  local script="$BATS_TEST_TMPDIR/unquoted-eval-zsh.zsh"
+  cat > "$script" <<'SCRIPT'
+set -euo pipefail
+
+home="$1"
+overlay="$2"
+
+# Intentionally unquoted: this preserves compatibility with the historical
+# documented form, `eval $(shimmer as <agent>)`.
+eval $(CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
+
+print -r -- "name=$GIT_AUTHOR_NAME"
+print -r -- "host=$GH_HOST"
+print -r -- "identity=$AGENT_IDENTITY"
+SCRIPT
+
+  run zsh "$script" "$TEST_HOME" "$OVERLAY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"name=alice"* ]]
+  [[ "$output" == *"host=github.com"* ]]
+  [[ "$output" == *"You are alice."* ]]
 }
 
 # ============ Validation (no mocks — fails before secrets) ============


### PR DESCRIPTION
## Summary
- terminate every emitted shell command with semicolons so collapsed command substitution remains eval-safe
- encode multiline AGENT_IDENTITY with ANSI-C quoting instead of literal newlines
- add bash and zsh regression tests for unquoted eval
- update docs to recommend quoted eval

## Tests
- mise run test test/as/as.bats
- mise run test
- git diff --check