### PR TITLE
Fix apostrophe quoting in shimmer as output

### DIFF
--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -79,7 +79,8 @@ EMAIL="${AGENT}@ricon.family"
 
 shell_quote() {
   local value="$1"
-  printf "'%s'" "$(printf '%s' "$value" | sed "s/'/'\\''/g")"
+  local escaped=${value//\'/\'\\\'\'}
+  printf "'%s'" "$escaped"
 }
 
 ansi_c_quote() {

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -77,6 +77,25 @@ fi
 
 EMAIL="${AGENT}@ricon.family"
 
+shell_quote() {
+  local value="$1"
+  printf "'%s'" "$(printf '%s' "$value" | sed "s/'/'\\''/g")"
+}
+
+ansi_c_quote() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  value=${value//\'/\\\'}
+  printf "\$'%s'" "$value"
+}
+
+emit() {
+  printf '%s;\n' "$1"
+}
+
 # Validate agent against the authoritative home-provided agent list.
 if ! echo "$AGENTS" | grep -qx "$AGENT"; then
   echo "Unknown agent: $AGENT" >&2
@@ -88,10 +107,10 @@ fi
 # `shimmer as` from leaking through if any resolution step below fails.
 # This must come before PAT resolution — if secrets lookup exits early,
 # eval still clears the previous session's vars.
-echo "unset AGENT_IDENTITY B2_BUCKET"
-echo "unset GH_HOST GH_TOKEN"
-echo "unset GIT_AUTHOR_EMAIL GIT_COMMITTER_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_NAME"
-echo "unset AGENT_HOME"
+emit "unset AGENT_IDENTITY B2_BUCKET"
+emit "unset GH_HOST GH_TOKEN"
+emit "unset GIT_AUTHOR_EMAIL GIT_COMMITTER_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_NAME"
+emit "unset AGENT_HOME"
 
 # Fetch GitHub PAT via secrets tool
 PAT=$(secrets get "$AGENT/github-pat") || {
@@ -104,19 +123,19 @@ PAT=$(secrets get "$AGENT/github-pat") || {
 # NOTE: GH_HOST is hardcoded to github.com — all shimmer agents currently target
 # github.com. If an agent ever needs to target a GHE instance, this should become
 # configurable (e.g., per-agent config or secret store field).
-echo "export GH_HOST='github.com'"
-echo "export GH_TOKEN='$PAT'"
-echo "export GIT_AUTHOR_EMAIL='$EMAIL'"
-echo "export GIT_COMMITTER_EMAIL='$EMAIL'"
-echo "export GIT_AUTHOR_NAME='$AGENT'"
-echo "export GIT_COMMITTER_NAME='$AGENT'"
-echo "export AGENT_HOME='$AGENT_HOME_DIR'"
+emit "export GH_HOST=$(shell_quote 'github.com')"
+emit "export GH_TOKEN=$(shell_quote "$PAT")"
+emit "export GIT_AUTHOR_EMAIL=$(shell_quote "$EMAIL")"
+emit "export GIT_COMMITTER_EMAIL=$(shell_quote "$EMAIL")"
+emit "export GIT_AUTHOR_NAME=$(shell_quote "$AGENT")"
+emit "export GIT_COMMITTER_NAME=$(shell_quote "$AGENT")"
+emit "export AGENT_HOME=$(shell_quote "$AGENT_HOME_DIR")"
 
 # Optional: B2 blob storage bucket (don't fail if not configured).
 # Empty on missing or provider failure; conditional export below handles it.
 B2_BUCKET=$(secrets get "$AGENT/b2-bucket" 2>/dev/null) || B2_BUCKET=""
 if [ -n "$B2_BUCKET" ]; then
-  echo "export B2_BUCKET='$B2_BUCKET'"
+  emit "export B2_BUCKET=$(shell_quote "$B2_BUCKET")"
 fi
 
 # Resolve agent identity content via the home's agent:identity task.
@@ -124,9 +143,10 @@ fi
 # prints a notice in that case.
 IDENTITY=$(mise -C "$AGENT_HOME_DIR" run -q agent:identity "$AGENT" 2>/dev/null) || IDENTITY=""
 if [ -n "$IDENTITY" ]; then
-  # Export as multi-line env var using $'...' quoting
-  ESCAPED=$(printf '%s' "$IDENTITY" | sed "s/'/'\\\\''/g")
-  echo "export AGENT_IDENTITY='$ESCAPED'"
+  # Export as encoded ANSI-C quoting so unquoted command substitution
+  # (`eval $(shimmer as agent)`) cannot collapse literal newlines inside
+  # AGENT_IDENTITY before eval sees the command stream.
+  emit "export AGENT_IDENTITY=$(ansi_c_quote "$IDENTITY")"
 else
   echo "# Note: agent home has no agent:identity task — AGENT_IDENTITY not set" >&2
   echo "# (was cleared above to prevent stale values)" >&2

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `shimme
 
 Example:
 ```bash
-eval $(shimmer as quick)
+eval "$(shimmer as quick)"
 shimmer whoami
 ```
 

--- a/docs/agent-local.md
+++ b/docs/agent-local.md
@@ -66,7 +66,7 @@ This allows multiple agents to work on the same repository simultaneously withou
 Each terminal session needs the agent's identity configured:
 
 ```bash
-eval $(mise run as <agent>)
+eval "$(mise run as <agent>)"
 ```
 
 This sets:
@@ -98,7 +98,7 @@ GitHub identity:
 |------|-----------|---------|
 | Import GPG key | Once per machine | `mise run gpg:setup <agent>` |
 | Setup email | Once per machine | `emails setup <agent>` |
-| Set identity | Each session | `eval $(mise run as <agent>)` |
+| Set identity | Each session | `eval "$(mise run as <agent>)"` |
 | Verify setup | As needed | `mise run whoami` |
 
 ## Troubleshooting

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -85,6 +85,17 @@ teardown() {
   echo "$output" | grep -q "export GH_TOKEN='ghp_bob_token'"
 }
 
+@test "as: shell-quotes secrets with apostrophes" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake'quoted" "alice/b2-bucket=bucket'quoted"
+  mock_shimmer
+
+  eval "$(shimmer as alice 2>/dev/null)"
+
+  [ "$GH_TOKEN" = "ghp_fake'quoted" ]
+  [ "$B2_BUCKET" = "bucket'quoted" ]
+}
+
 @test "as: exports B2_BUCKET when available" {
   setup_test_home "alice"
   mock_secrets_binary "alice/github-pat=ghp_fake" "alice/b2-bucket=my-bucket"

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -174,6 +174,29 @@ teardown() {
   [ -z "${B2_BUCKET:-}" ]
 }
 
+@test "as: unquoted eval works in bash" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  run bash -c 'eval $(CALLER_PWD="$1" mise -C "$2" run -q as alice 2>/dev/null); printf "%s|%s|%s\n" "$GIT_AUTHOR_NAME" "$GH_HOST" "$AGENT_IDENTITY"' _ "$TEST_HOME" "$OVERLAY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alice|github.com|"* ]]
+  [[ "$output" == *"You are alice."* ]]
+}
+
+@test "as: unquoted eval works in zsh" {
+  command -v zsh >/dev/null 2>&1 || skip "zsh not installed"
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  run zsh -fc 'eval $(CALLER_PWD="$1" mise -C "$2" run -q as alice 2>/dev/null); print -r -- "$GIT_AUTHOR_NAME|$GH_HOST|$AGENT_IDENTITY"' _ "$TEST_HOME" "$OVERLAY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alice|github.com|"* ]]
+  [[ "$output" == *"You are alice."* ]]
+}
+
 # ============ Validation (no mocks — fails before secrets) ============
 
 @test "as: rejects unknown agent" {


### PR DESCRIPTION
## Summary
- fix shell_quote so apostrophes emit as POSIX-safe '\'' sequences
- add a regression covering GH_TOKEN and B2_BUCKET values containing apostrophes

## Tests
- mise run test test/as/as.bats

Note: full 1..136
ok 1 headless: fails without GIT_AUTHOR_NAME
ok 2 headless: fails without AGENT_IDENTITY
not ok 3 headless: fails without message
# (in test file test/agent/agent.bats, line 39)
#   `[[ "$output" == *"requires a message"* ]]' failed
not ok 4 headless: fails without model
# (in test file test/agent/agent.bats, line 48)
#   `[[ "$output" == *"requires --model"* ]]' failed
ok 5 headless: fails with unqualified model
ok 6 headless: fails when sessions not on PATH # skip sessions is installed
not ok 7 headless: calls sessions new + wake
# (in test file test/agent/agent.bats, line 81)
#   `grep -q "^new test-agent-headless-" "$SESSIONS_LOG"' failed
not ok 8 headless: uses SHIV_CALLER_PWD as session cwd before scrubbing
# (in test file test/agent/agent.bats, line 102)
#   `grep "^new " "$SESSIONS_LOG" | grep -q -- "--cwd $caller_dir"' failed
ok 9 headless: scrubs caller context before invoking sessions
not ok 10 headless: session name uses full epoch timestamp
# (in test file test/agent/agent.bats, line 131)
#   `[ "${#timestamp}" -ge 10 ]' failed
ok 11 headless: resumes existing session (skips sessions new)
ok 12 headless: forwards model only to sessions wake
ok 13 headless: timeout stored as metadata (not enforced)
not ok 14 interactive: calls harness with agent identity
# (in test file test/agent/agent.bats, line 180)
#   `[ "$status" -eq 0 ]' failed
not ok 15 interactive: uses SHIV_CALLER_PWD as harness cwd before scrubbing
# (in test file test/agent/agent.bats, line 196)
#   `[ "$status" -eq 0 ]' failed
not ok 16 interactive: scrubs caller context before invoking harness
# (in test file test/agent/agent.bats, line 210)
#   `[ "$status" -eq 0 ]' failed
not ok 17 interactive: forwards session flag to harness
# (in test file test/agent/agent.bats, line 222)
#   `[ "$status" -eq 0 ]' failed
not ok 18 interactive: forwards message to harness
# (in test file test/agent/agent.bats, line 233)
#   `[ "$status" -eq 0 ]' failed
not ok 19 agent:dispatch requires model
# (in test file test/agent/agent.bats, line 243)
#   `[ "$status" -ne 0 ]' failed
ok 20 agent:dispatch requires provider-qualified model
ok 21 agent:dispatch preserves embedded newlines in message input
ok 22 discovery: lists agents from home's agent:list task
ok 23 discovery: agent:identity returns content, not path
ok 24 as: outputs export statements for valid agent
ok 25 as: sets AGENT_HOME to the home directory
ok 26 as: AGENT_IDENTITY contains identity content
ok 27 as: works for each agent independently
ok 28 as: uses agent-specific PAT from secrets
ok 29 as: shell-quotes secrets with apostrophes
ok 30 as: exports B2_BUCKET when available
ok 31 as: succeeds without B2_BUCKET
ok 32 as: bridges SHIMMER_SECRETS_PROVIDER to SECRETS_PROVIDER
ok 33 as: clears previous identity vars before setting new ones
ok 34 as: eval clears stale AGENT_IDENTITY from previous session
ok 35 as: eval clears stale B2_BUCKET when new agent has none
ok 36 as: unquoted eval works in bash
ok 37 as: unquoted eval works in zsh # skip zsh not installed
ok 38 as: rejects unknown agent
ok 39 as: shows available agents on rejection
ok 40 as: fails when agent:list fails even if identity resolves
ok 41 as: rejects agent omitted from list even if identity file exists
ok 42 as: fails gracefully when home has no agent:list
ok 43 dispatch: triggers workflow and returns run ID
ok 44 dispatch: calls gh workflow run with correct args
ok 45 dispatch: passes input flags to gh workflow run
ok 46 dispatch: preserves spaces in input values
ok 47 dispatch: preserves embedded newlines in input values
ok 48 dispatch: shows human-friendly info on stderr
ok 49 dispatch: polls immediately when run is already indexed
ok 50 dispatch: polls until run appears
ok 51 dispatch: times out when run never appears
ok 52 dispatch: timeout error includes workflow URL
ok 53 dispatch: does not filter by actor
ok 54 dispatch: accepts run created slightly before local dispatch timestamp
ok 55 dispatch: rejects run older than createdAt grace window
ok 56 strip_wrapping_quotes: removes wrapping double quotes
ok 57 strip_wrapping_quotes: leaves unquoted strings unchanged
ok 58 strip_wrapping_quotes: leaves strings with only leading quote unchanged
ok 59 strip_wrapping_quotes: leaves strings with only trailing quote unchanged
ok 60 strip_wrapping_quotes: handles empty string
ok 61 strip_wrapping_quotes: preserves internal quotes
ok 62 strip_wrapping_quotes: handles multiline PGP key with quotes
ok 63 validate_gpg_key: accepts a valid GPG private key
ok 64 validate_gpg_key: rejects empty input
ok 65 validate_gpg_key: rejects key wrapped in quotes
ok 66 validate_gpg_key: rejects garbage data
ok 67 validate_gpg_key: rejects truncated key with valid header
ok 68 gpg:setup: imports a valid key from env
ok 69 gpg:setup: imports a quoted key from env (auto-strips quotes)
ok 70 gpg:setup: rejects garbage key with helpful error
ok 71 extracts token from clean single-line output
ok 72 extracts token split across two lines
ok 73 strips ANSI CSI sequences
ok 74 strips OSC 8 hyperlink sequences
ok 75 strips terminal mode switch sequences
ok 76 strips Unicode block art characters
ok 77 extracts token from realistic claude setup-token output
ok 78 fails when no token in output
ok 79 handles carriage returns in output
ok 80 emit appends event to TELEMETRY_FILE
ok 81 emit auto-populates ts when missing
ok 82 emit preserves ts when provided
ok 83 emit orders fields: ts, tool, cmd first
ok 84 emit appends multiple events
ok 85 emit is a no-op when TELEMETRY_FILE is unset
ok 86 emit rejects invalid JSON
ok 87 emit rejects event missing tool field
ok 88 emit rejects event missing cmd field
ok 89 emit pipes event through TELEMETRY_HOOK
ok 90 emit drops event when hook returns nothing
ok 91 emit fails when TELEMETRY_HOOK is not executable
ok 92 emit creates parent directories for TELEMETRY_FILE
ok 93 list --json outputs all events as JSONL
ok 94 list --json outputs valid JSON per line
ok 95 list --tool filters by tool name
ok 96 list --cmd filters by command name
ok 97 list --since filters by date
ok 98 list --tool and --cmd compose
ok 99 list --limit restricts output
ok 100 list default limit is 20
ok 101 list renders a table by default
ok 102 list with no matching filter shows message
ok 103 list fails when TELEMETRY_FILE not set
ok 104 status shows file path when configured
ok 105 status shows telemetry is off when TELEMETRY_FILE unset
ok 106 status shows no events when file doesn't exist
ok 107 status shows event count
ok 108 status shows tool breakdown
ok 109 status shows hook path when configured
ok 110 fetch: returns content from URL
ok 111 fetch: shows fetching message on stderr by default
ok 112 fetch: quiet mode suppresses fetching message
ok 113 fetch: returns raw HTML unchanged
ok 114 fetch: follows redirects
ok 115 fetch: passes custom headers
ok 116 fetch: fails on curl error
ok 117 json: returns web results array
ok 118 json: preserves all fields
ok 119 json: empty results returns empty array
ok 120 format: shows numbered results
ok 121 format: shows URLs
ok 122 format: strips HTML tags from descriptions
ok 123 format: decodes HTML entities
ok 124 format: handles missing description
ok 125 format: empty results shows message
ok 126 error: missing API key
ok 127 error: API error response
ok 128 error: non-JSON response (HTML proxy page, 502, etc.)
ok 129 offset: passes through to curl
ok 130 email: not configured when no himalaya config
ok 131 email: timed out after 5s when server unreachable
ok 132 email: check failed on non-timeout error
ok 133 email: success with unread and low quota
ok 134 email: success with zero unread
ok 135 email: warning when quota >= 80%
ok 136 email: critical when quota >= 95% still fails in existing agent tests unrelated to this change (headless/interactive agent dispatch expectations).