### PR TITLE
Delegate home preparation to agent homes

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -211,15 +211,10 @@ jobs:
           mise trust
           mise install
 
-          if [ -d ".git-crypt" ] || [ -d "notes" ]; then
-            rudi install
-            notes unlock
-            notes install-hooks
-          fi
-
-          if [ -f ".modules/config" ]; then
-            modules install-hooks
-            modules init
+          if mise tasks --json | jq -e 'any(.[]; .name == "agent:prepare")' >/dev/null; then
+            mise run agent:prepare
+          else
+            echo "No agent:prepare task found in home repo; skipping home-specific preparation"
           fi
 
       - name: Unlock caller repo notes

--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -211,10 +211,10 @@ jobs:
           mise trust
           mise install
 
-          if mise tasks --json | jq -e 'any(.[]; .name == "agent:prepare")' >/dev/null; then
+          if mise tasks info agent:prepare >/dev/null 2>&1; then
             mise run agent:prepare
           else
-            echo "No agent:prepare task found in home repo; skipping home-specific preparation"
+            echo "::warning::No agent:prepare task found in home repo; skipping home-specific preparation. Add an agent:prepare task to silence this warning."
           fi
 
       - name: Unlock caller repo notes

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -91,14 +91,33 @@ Generated workflows call the reusable `agent-run.yml` workflow, which:
 2. Installs mise-managed tools.
 3. Sets up agent credentials (GPG, email, Matrix, GitHub, optional blob storage).
 4. Clones the agent home repo.
-5. Restores pi auth when `PI_AUTH_JSON` is configured.
-6. Runs:
+5. Prepares the home repo via the `agent:prepare` hook (see below).
+6. Restores pi auth when `PI_AUTH_JSON` is configured.
+7. Runs:
 
    ```bash
    shimmer agent --headless --timeout "$RUN_TIMEOUT" --model "$INPUT_MODEL" "$INPUT_MESSAGE"
    ```
 
 Headless execution requires an explicit provider-qualified model. Shimmer creates a tracked session with `sessions new` and passes the model only to `sessions wake`, matching the `sessions` v0.4.0 contract.
+
+### Home repo `agent:prepare` hook
+
+The `Prepare home repo` step is owned by the agent's home repo. After `mise trust && mise install` in the home, the workflow runs:
+
+```bash
+if mise tasks info agent:prepare >/dev/null 2>&1; then
+  mise run agent:prepare
+else
+  echo "::warning::No agent:prepare task found in home repo; skipping home-specific preparation. ..."
+fi
+```
+
+If the home declares an `agent:prepare` mise task, it runs. Otherwise the step emits a GitHub Actions `::warning::` annotation and continues — a missing hook does not fail the run.
+
+**What `agent:prepare` should do:** anything home-specific that needs to happen before every headless session — typically `notes unlock`, `notes install-hooks`, `modules install-hooks`, `modules init`, `rudi install`, plus anything else that home owns. It must be idempotent and safe to run on every dispatch (CI re-runs it from scratch each time; locally agents may also invoke it during interactive sessions).
+
+**Why it's a delegation hook, not a hardcoded block:** the workflow template used to assume every home spoke den/fold's tooling stack (notes/rudi/modules). Agent homes vary — some may use only a subset, some may need additional setup (cache warming, secret pre-fetch). The hook hands ownership of that decision to each home repo's `mise.toml`.
 
 ## Adding a Scheduled Job
 

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -6,6 +6,22 @@ setup() {
   load helpers
 }
 
+# --- Workflow template ---
+
+@test "workflow: home preparation delegates to home agent:prepare task" {
+  template="$SHIMMER_DIR/.github/templates/agent-run.yml"
+  prepare_block=$(awk '
+    /- name: Prepare home repo/ { show = 1 }
+    /- name: Unlock caller repo notes/ { show = 0 }
+    show { print }
+  ' "$template")
+
+  [[ "$prepare_block" == *"mise run agent:prepare"* ]] || return 1
+  [[ "$prepare_block" != *"rudi install"* ]] || return 1
+  [[ "$prepare_block" != *"notes unlock"* ]] || return 1
+  [[ "$prepare_block" != *"modules init"* ]] || return 1
+}
+
 # --- Identity checks ---
 
 @test "headless: fails without GIT_AUTHOR_NAME" {

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -13,10 +13,13 @@ setup() {
 
   # Parse the YAML structurally so we assert on the step's run: body, not on
   # incidental matches in comments or neighbouring steps.
-  run_block=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run' "$template")
+  # `// ""` collapses a missing or null .run (e.g. a step that uses `uses:`
+  # instead of `run:`) to the empty string so the guard below catches it
+  # explicitly rather than asserting against the literal string "null".
+  run_block=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run // ""' "$template")
 
   [ -n "$run_block" ] || {
-    echo "could not locate 'Prepare home repo' step in $template" >&2
+    echo "could not locate 'Prepare home repo' step's run: block in $template" >&2
     return 1
   }
 

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -10,16 +10,20 @@ setup() {
 
 @test "workflow: home preparation delegates to home agent:prepare task" {
   template="$SHIMMER_DIR/.github/templates/agent-run.yml"
-  prepare_block=$(awk '
-    /- name: Prepare home repo/ { show = 1 }
-    /- name: Unlock caller repo notes/ { show = 0 }
-    show { print }
-  ' "$template")
 
-  [[ "$prepare_block" == *"mise run agent:prepare"* ]] || return 1
-  [[ "$prepare_block" != *"rudi install"* ]] || return 1
-  [[ "$prepare_block" != *"notes unlock"* ]] || return 1
-  [[ "$prepare_block" != *"modules init"* ]] || return 1
+  # Parse the YAML structurally so we assert on the step's run: body, not on
+  # incidental matches in comments or neighbouring steps.
+  run_block=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run' "$template")
+
+  [ -n "$run_block" ] || {
+    echo "could not locate 'Prepare home repo' step in $template" >&2
+    return 1
+  }
+
+  echo "$run_block" | grep -qF 'mise run agent:prepare'
+  ! echo "$run_block" | grep -qF 'rudi install'
+  ! echo "$run_block" | grep -qF 'notes unlock'
+  ! echo "$run_block" | grep -qF 'modules init'
 }
 
 # --- Identity checks ---


### PR DESCRIPTION
## Summary
- Replace hardcoded home-repo notes/rudi/modules preparation in the agent workflow template with an optional home-owned `agent:prepare` task
- Keep cloning/trusting/installing the home repo in the reusable workflow, then let the home repo define its own per-run preparation
- Add a regression test that the home preparation block calls `agent:prepare` instead of hardcoding optional home systems

## Rationale
Agent homes should own their own setup dependencies and optional systems. The workflow should not assume every home uses notes, rudi, or modules.

## Tests
- `mise run test test/agent/agent.bats -f workflow`
- `mise run test` (134/134)
- `git diff --check`
- YAML parse of `.github/templates/agent-run.yml` and `.github/workflows/pr-check.yml`

Follow-up PRs regenerate fold and den workflows/docs from this template.