### PR TITLE
test: tighten Prepare home repo regression test (yq-based)

### DIFF
--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -13,10 +13,13 @@ setup() {
 
   # Parse the YAML structurally so we assert on the step's run: body, not on
   # incidental matches in comments or neighbouring steps.
-  run_block=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run' "$template")
+  # `// ""` collapses a missing or null .run (e.g. a step that uses `uses:`
+  # instead of `run:`) to the empty string so the guard below catches it
+  # explicitly rather than asserting against the literal string "null".
+  run_block=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run // ""' "$template")
 
   [ -n "$run_block" ] || {
-    echo "could not locate 'Prepare home repo' step in $template" >&2
+    echo "could not locate 'Prepare home repo' step's run: block in $template" >&2
     return 1
   }
 

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -10,16 +10,20 @@ setup() {
 
 @test "workflow: home preparation delegates to home agent:prepare task" {
   template="$SHIMMER_DIR/.github/templates/agent-run.yml"
-  prepare_block=$(awk '
-    /- name: Prepare home repo/ { show = 1 }
-    /- name: Unlock caller repo notes/ { show = 0 }
-    show { print }
-  ' "$template")
 
-  [[ "$prepare_block" == *"mise run agent:prepare"* ]] || return 1
-  [[ "$prepare_block" != *"rudi install"* ]] || return 1
-  [[ "$prepare_block" != *"notes unlock"* ]] || return 1
-  [[ "$prepare_block" != *"modules init"* ]] || return 1
+  # Parse the YAML structurally so we assert on the step's run: body, not on
+  # incidental matches in comments or neighbouring steps.
+  run_block=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run' "$template")
+
+  [ -n "$run_block" ] || {
+    echo "could not locate 'Prepare home repo' step in $template" >&2
+    return 1
+  }
+
+  echo "$run_block" | grep -qF 'mise run agent:prepare'
+  ! echo "$run_block" | grep -qF 'rudi install'
+  ! echo "$run_block" | grep -qF 'notes unlock'
+  ! echo "$run_block" | grep -qF 'modules init'
 }
 
 # --- Identity checks ---


### PR DESCRIPTION
Fix-it PR against `johnson/home-agent-prepare-hook` (#747) per den's *Reviews ship with fixes* rule.

## What this changes

Rewrites the new `workflow: home preparation delegates to home agent:prepare task` test in `test/agent/agent.bats` to:

- Parse the workflow template structurally with `yq` and select the `Prepare home repo` step's `run:` block, instead of awk-extracting a span between two step-name lines.
- Use `grep -qF` (fixed-string) instead of `[[ $x == *...* ]]` glob comparisons.
- Fail explicitly with a useful message when the step can't be located (rename / removal), instead of silently producing an empty span where the negative `grep -qF` assertions would all spuriously succeed.

## Why

Two failure modes the original test wouldn't catch:

1. A YAML comment elsewhere in the span containing the literal string `rudi install` (or similar) would fail one of the negative assertions even though the runtime command list is fine.
2. If the boundary step `Unlock caller repo notes` is ever renamed, the awk extractor returns an empty block. The negative assertions (`!= *rudi install*`) all succeed against an empty string, masking real regressions.

## Verification

```
$ mise run test test/agent/agent.bats -f workflow
1..1
ok 1 workflow: home preparation delegates to home agent:prepare task

$ mise run test test/agent/agent.bats
... 22/22 ok
```

`yq` is already pinned in shimmer's `mise.toml` (`yq = "4.50.1"`).