### PR TITLE
Use shimmer-specific caller cwd

### DIFF
--- a/.mise/tasks/_get-agents-dir
+++ b/.mise/tasks/_get-agents-dir
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 TASK_DIR="$MISE_CONFIG_ROOT/.mise/tasks"
-TARGET_DIR="${1:-${CALLER_PWD:-.}}"
+TARGET_DIR="${1:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 
 # Check target directory first
 if [ -d "$TARGET_DIR/agents" ]; then

--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -15,6 +15,15 @@ TIMEOUT="${usage_timeout:-}"
 MODEL="${usage_model:-}"
 MESSAGE="${usage_message:-}"
 
+scrub_caller_pwd_env() {
+  local name
+  while IFS= read -r name; do
+    case "$name" in
+      CALLER_PWD|*_CALLER_PWD) unset "$name" ;;
+    esac
+  done < <(compgen -e)
+}
+
 # Derive agent name from environment (set by `shimmer as`)
 if [ -z "$GIT_AUTHOR_NAME" ]; then
   echo "No agent identity detected. Run: eval \$(shimmer as <agent>)" >&2
@@ -53,13 +62,13 @@ if [ "$HEADLESS" = "true" ]; then
     exit 1
   fi
 
-  CWD="${SHIV_CALLER_PWD:-${CALLER_PWD:-.}}"
+  CWD="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}"
   SESSION_NAME="${GIT_AUTHOR_NAME}-headless-$(date +%s)"
 
   # Caller-context variables describe this immediate shim invocation. Do not
   # leak them into long-lived session processes, where they can become stale
   # ambient state and redirect later tooling to the wrong repository.
-  unset CALLER_PWD SHIV_CALLER_PWD
+  scrub_caller_pwd_env
 
   # Create a tracked session (or resume an existing one)
   if [ -n "$SESSION" ]; then
@@ -76,9 +85,9 @@ if [ "$HEADLESS" = "true" ]; then
   sessions wake "${WAKE_ARGS[@]}"
 else
   # Interactive mode calls the agent harness directly.
-  CWD="${SHIV_CALLER_PWD:-${CALLER_PWD:-.}}"
+  CWD="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}"
   cd "$CWD"
-  unset CALLER_PWD SHIV_CALLER_PWD
+  scrub_caller_pwd_env
   HARNESS="${AGENT_HARNESS:-pi}"
   if ! command -v "$HARNESS" &>/dev/null; then
     echo "$HARNESS not found on PATH." >&2

--- a/.mise/tasks/agent/broadcast
+++ b/.mise/tasks/agent/broadcast
@@ -8,7 +8,7 @@
 
 set -e
 
-CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-$(pwd)}}"
 
 # Resolve the agent home
 AGENT_HOME_DIR="${AGENT_HOME:-$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")}"

--- a/.mise/tasks/agent/find
+++ b/.mise/tasks/agent/find
@@ -5,7 +5,7 @@
 
 set -e
 
-CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-$(pwd)}}"
 AGENT="${usage_agent}"
 
 if [[ -n "${usage_repo:-}" ]]; then

--- a/.mise/tasks/agent/onboard
+++ b/.mise/tasks/agent/onboard
@@ -13,7 +13,7 @@ AGENT_UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 EMAIL="${AGENT}@ricon.family"
 
 # Target caller's repo for GitHub secrets (not shimmer's)
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 cd "$TARGET_DIR"
 
 # After cd, bare `mise run` resolves tasks from cwd (the caller's repo).

--- a/.mise/tasks/agent/provision
+++ b/.mise/tasks/agent/provision
@@ -17,7 +17,7 @@ EMAIL="${AGENT}@ricon.family"
 UPPER=$(echo "$AGENT" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 
 # Target caller's repo for GitHub secrets (not shimmer's)
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 cd "$TARGET_DIR"
 
 # After cd, bare `mise run` resolves tasks from cwd (the caller's repo).

--- a/.mise/tasks/agent/refresh-token
+++ b/.mise/tasks/agent/refresh-token
@@ -13,7 +13,7 @@ set -e
 if [ -n "${usage_repo:-}" ]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   cd "$TARGET_DIR"
   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 fi

--- a/.mise/tasks/agent/schedules
+++ b/.mise/tasks/agent/schedules
@@ -4,7 +4,7 @@
 set -e
 
 # Get the caller's directory (where shimmer was invoked from)
-CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-$(pwd)}}"
 cd "$CALLER_DIR"
 
 # Check for workflows.yaml

--- a/.mise/tasks/agent/sync-secrets
+++ b/.mise/tasks/agent/sync-secrets
@@ -10,7 +10,7 @@ set -e
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/lib/gpg.sh"
 
 # Determine target directory (caller's directory when using shimmer alias)
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 cd "$TARGET_DIR"
 
 AGENT="${usage_agent:-}"

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -7,7 +7,7 @@ set -e
 # Bridge env var during migration: shimmer callers may still set SHIMMER_SECRETS_PROVIDER
 export SECRETS_PROVIDER="${SECRETS_PROVIDER:-${SHIMMER_SECRETS_PROVIDER:-}}"
 
-CALLER_DIR="${CALLER_PWD:-$(pwd)}"
+CALLER_DIR="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-$(pwd)}}"
 
 # Resolve the agent home (the repo the user is calling from)
 AGENT_HOME_DIR=$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")

--- a/.mise/tasks/ci/dispatch
+++ b/.mise/tasks/ci/dispatch
@@ -107,7 +107,7 @@ parse_shell_words() {
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi
 

--- a/.mise/tasks/ci/logs
+++ b/.mise/tasks/ci/logs
@@ -16,7 +16,7 @@ set -e
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/ci/wait
+++ b/.mise/tasks/ci/wait
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(dirname "$0")"
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi
 

--- a/.mise/tasks/ci/wait-for-checks
+++ b/.mise/tasks/ci/wait-for-checks
@@ -5,7 +5,7 @@
 set -e
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/ci/watch
+++ b/.mise/tasks/ci/watch
@@ -8,7 +8,7 @@ set -e
 # Delegate agent discovery to the home's agent:list task
 get_agents() {
   local home_dir
-  home_dir=$(git -C "${CALLER_PWD:-.}" rev-parse --show-toplevel 2>/dev/null || echo "${CALLER_PWD:-.}")
+  home_dir=$(git -C "${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}" rev-parse --show-toplevel 2>/dev/null || echo "${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}")
   mise -C "$home_dir" run -q agent:list 2>/dev/null
 }
 

--- a/.mise/tasks/discussion/comment
+++ b/.mise/tasks/discussion/comment
@@ -26,7 +26,7 @@ if [[ -z "$BODY" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/discussion/create
+++ b/.mise/tasks/discussion/create
@@ -31,7 +31,7 @@ if [[ -z "$BODY" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/discussion/list
+++ b/.mise/tasks/discussion/list
@@ -5,7 +5,7 @@
 set -eo pipefail
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/discussion/view
+++ b/.mise/tasks/discussion/view
@@ -11,7 +11,7 @@ if [[ -z "$NUMBER" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/issue/claim
+++ b/.mise/tasks/issue/claim
@@ -12,7 +12,7 @@ if [[ -z "$ISSUE_NUM" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/issue/list
+++ b/.mise/tasks/issue/list
@@ -8,7 +8,7 @@ set -eo pipefail
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/issue/propose
+++ b/.mise/tasks/issue/propose
@@ -11,7 +11,7 @@ set -eo pipefail
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/issue/sub-add
+++ b/.mise/tasks/issue/sub-add
@@ -13,7 +13,7 @@ if [[ -z "$PARENT" ]] || [[ -z "$CHILD" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/issue/sub-create
+++ b/.mise/tasks/issue/sub-create
@@ -19,7 +19,7 @@ if [[ -z "$PARENT" ]] || [[ -z "$TITLE" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/issue/sub-list
+++ b/.mise/tasks/issue/sub-list
@@ -11,7 +11,7 @@ if [[ -z "$PARENT" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/issue/view
+++ b/.mise/tasks/issue/view
@@ -15,7 +15,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pm/edit-issue
+++ b/.mise/tasks/pm/edit-issue
@@ -19,7 +19,7 @@ if [[ -z "$ISSUE_NUM" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/pm/field-options
+++ b/.mise/tasks/pm/field-options
@@ -22,7 +22,7 @@ if [[ -z "$FIELD_NAME" ]] || [[ -z "$OPTIONS" ]]; then
 fi
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/pm/init
+++ b/.mise/tasks/pm/init
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/pm/list-issues
+++ b/.mise/tasks/pm/list-issues
@@ -5,7 +5,7 @@ set -eo pipefail
 export GH_PAGER=""
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 # Repo detection is optional: on failure we fall back to an unscoped issue list.
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR" 2>/dev/null) || REPO=""

--- a/.mise/tasks/pm/wip
+++ b/.mise/tasks/pm/wip
@@ -6,7 +6,7 @@ set -eo pipefail
 export GH_PAGER=""
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 OWNER="${REPO%/*}"

--- a/.mise/tasks/pr/approve
+++ b/.mise/tasks/pr/approve
@@ -17,7 +17,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pr/create
+++ b/.mise/tasks/pr/create
@@ -8,7 +8,7 @@
 set -eo pipefail
 
 # Determine target directory and repo
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 SCRIPT_DIR="$(dirname "$0")"
 REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 

--- a/.mise/tasks/pr/list
+++ b/.mise/tasks/pr/list
@@ -8,7 +8,7 @@ set -eo pipefail
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pr/merge
+++ b/.mise/tasks/pr/merge
@@ -17,7 +17,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/pr/view
+++ b/.mise/tasks/pr/view
@@ -17,7 +17,7 @@ fi
 if [[ -n "${usage_repo:-}" ]]; then
   REPO="$usage_repo"
 else
-  TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+  TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
   SCRIPT_DIR="$(dirname "$0")"
   REPO=$("$SCRIPT_DIR/../_get-repo-slug" "$TARGET_DIR")
 fi

--- a/.mise/tasks/shell
+++ b/.mise/tasks/shell
@@ -14,7 +14,7 @@ if [ ! -d "\$REPO" ]; then
   echo "shimmer: re-run 'eval \"\\\$(mise -C /path/to/shimmer run -q shell)\"' to fix" >&2
   exit 1
 fi
-CALLER_PWD="\${CALLER_PWD:-\$PWD}" exec mise -C "\$REPO" run "\$@"
+SHIMMER_CALLER_PWD="\$PWD" exec mise -C "\$REPO" run "\$@"
 SCRIPT
 chmod +x "$BIN"
 
@@ -25,4 +25,4 @@ case ":$PATH:" in
 esac
 
 # Shell alias (captures caller's PWD for interactive use)
-echo "alias shimmer='CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"
+echo "alias shimmer='SHIMMER_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run'"

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -4,7 +4,7 @@
 set -eo pipefail
 
 # Determine target directory (caller's directory when using shimmer alias)
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 cd "$TARGET_DIR"
 
 # Validate workflows.yaml against schema

--- a/.mise/tasks/workflows/validate
+++ b/.mise/tasks/workflows/validate
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # Determine target directory (caller's directory when using shimmer alias)
-TARGET_DIR="${PROJECT_DIR:-${CALLER_PWD:-.}}"
+TARGET_DIR="${PROJECT_DIR:-${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}}"
 cd "$TARGET_DIR"
 
 check-jsonschema --schemafile "$MISE_PROJECT_ROOT/workflows.schema.json" workflows.yaml

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -110,12 +110,12 @@ setup() {
   grep -q "^wake mock-session-id-001 --headless --message review the PR --model openai-codex/gpt-5.5" "$SESSIONS_LOG"
 }
 
-@test "headless: uses SHIV_CALLER_PWD as session cwd before scrubbing" {
+@test "headless: uses SHIMMER_CALLER_PWD as session cwd before scrubbing" {
   setup_agent
-  local caller_dir="$BATS_TEST_TMPDIR/shiv-caller"
+  local caller_dir="$BATS_TEST_TMPDIR/shimmer-caller"
   mkdir -p "$caller_dir"
   unset CALLER_PWD
-  export SHIV_CALLER_PWD="$caller_dir"
+  export SHIMMER_CALLER_PWD="$caller_dir"
   mock_sessions_binary
   mock_shimmer
 
@@ -127,7 +127,8 @@ setup() {
 
 @test "headless: scrubs caller context before invoking sessions" {
   setup_agent
-  export SHIV_CALLER_PWD="/stale/shiv/caller"
+  export SHIMMER_CALLER_PWD="/stale/shimmer/caller"
+  export OTHER_CALLER_PWD="/stale/other/caller"
   mock_sessions_binary
   mock_shimmer
 
@@ -135,7 +136,8 @@ setup() {
   [ "$status" -eq 0 ]
 
   grep -q '^CALLER_PWD=$' "$SESSIONS_ENV_LOG"
-  grep -q '^SHIV_CALLER_PWD=$' "$SESSIONS_ENV_LOG"
+  grep -q '^SHIMMER_CALLER_PWD=$' "$SESSIONS_ENV_LOG"
+  grep -q '^OTHER_CALLER_PWD=$' "$SESSIONS_ENV_LOG"
 }
 
 @test "headless: session name uses full epoch timestamp" {
@@ -206,12 +208,12 @@ setup() {
   grep -q -- "--append-system-prompt" "$HARNESS_LOG"
 }
 
-@test "interactive: uses SHIV_CALLER_PWD as harness cwd before scrubbing" {
+@test "interactive: uses SHIMMER_CALLER_PWD as harness cwd before scrubbing" {
   setup_agent
-  local caller_dir="$BATS_TEST_TMPDIR/shiv-caller"
+  local caller_dir="$BATS_TEST_TMPDIR/shimmer-caller"
   mkdir -p "$caller_dir"
   unset CALLER_PWD
-  export SHIV_CALLER_PWD="$caller_dir"
+  export SHIMMER_CALLER_PWD="$caller_dir"
   mock_harness
   mock_shimmer
 
@@ -225,7 +227,8 @@ setup() {
   setup_agent
   local caller_dir="$BATS_TEST_TMPDIR/scrub-caller"
   mkdir -p "$caller_dir"
-  export SHIV_CALLER_PWD="$caller_dir"
+  export SHIMMER_CALLER_PWD="$caller_dir"
+  export OTHER_CALLER_PWD="/stale/other/caller"
   mock_harness
   mock_shimmer
 
@@ -233,7 +236,8 @@ setup() {
   [ "$status" -eq 0 ]
 
   grep -q '^CALLER_PWD=$' "$HARNESS_ENV_LOG"
-  grep -q '^SHIV_CALLER_PWD=$' "$HARNESS_ENV_LOG"
+  grep -q '^SHIMMER_CALLER_PWD=$' "$HARNESS_ENV_LOG"
+  grep -q '^OTHER_CALLER_PWD=$' "$HARNESS_ENV_LOG"
 }
 
 @test "interactive: forwards session flag to harness" {

--- a/test/agent/helpers.bash
+++ b/test/agent/helpers.bash
@@ -14,7 +14,7 @@ setup_agent() {
   export GIT_AUTHOR_NAME="$name"
   export GIT_AUTHOR_EMAIL="${name}@ricon.family"
   export AGENT_IDENTITY="You are ${name}."
-  export CALLER_PWD="$BATS_TEST_TMPDIR"
+  export SHIMMER_CALLER_PWD="$BATS_TEST_TMPDIR"
 }
 
 # Create a mock `sessions` binary on PATH.
@@ -32,7 +32,8 @@ mock_sessions_binary() {
 echo "$@" >> "$SESSIONS_LOG"
 {
   printf 'CALLER_PWD=%s\n' "${CALLER_PWD-}"
-  printf 'SHIV_CALLER_PWD=%s\n' "${SHIV_CALLER_PWD-}"
+  printf 'SHIMMER_CALLER_PWD=%s\n' "${SHIMMER_CALLER_PWD-}"
+  printf 'OTHER_CALLER_PWD=%s\n' "${OTHER_CALLER_PWD-}"
 } >> "${SESSIONS_ENV_LOG:-$SESSIONS_LOG.env}"
 case "$1" in
   new) echo "mock-session-id-001" ;;
@@ -60,7 +61,8 @@ echo "$@" >> "$HARNESS_LOG"
 {
   printf 'PWD=%s\n' "$PWD"
   printf 'CALLER_PWD=%s\n' "${CALLER_PWD-}"
-  printf 'SHIV_CALLER_PWD=%s\n' "${SHIV_CALLER_PWD-}"
+  printf 'SHIMMER_CALLER_PWD=%s\n' "${SHIMMER_CALLER_PWD-}"
+  printf 'OTHER_CALLER_PWD=%s\n' "${OTHER_CALLER_PWD-}"
 } >> "${HARNESS_ENV_LOG:-$HARNESS_LOG.env}"
 MOCK
   chmod +x "$MOCK_BIN/mock-harness"

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -109,7 +109,7 @@ set -euo pipefail
 home="$1"
 overlay="$2"
 
-eval $(CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
+eval $(SHIMMER_CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
 
 printf 'token=%s\n' "$GH_TOKEN"
 printf 'bucket=%s\n' "$B2_BUCKET"
@@ -149,7 +149,7 @@ SCRIPT
   mock_shimmer
 
   # Set old env var, verify task still works (bridge picks it up)
-  run env SHIMMER_SECRETS_PROVIDER=keychain CALLER_PWD="$TEST_HOME" mise -C "$OVERLAY" run -q as alice 2>&1
+  run env SHIMMER_SECRETS_PROVIDER=keychain SHIMMER_CALLER_PWD="$TEST_HOME" mise -C "$OVERLAY" run -q as alice 2>&1
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "export GIT_AUTHOR_NAME='alice'"
 }
@@ -226,7 +226,7 @@ overlay="$2"
 
 # Intentionally unquoted: this preserves compatibility with the historical
 # documented form, `eval $(shimmer as <agent>)`.
-eval $(CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
+eval $(SHIMMER_CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
 
 printf 'name=%s\n' "$GIT_AUTHOR_NAME"
 printf 'host=%s\n' "$GH_HOST"
@@ -256,7 +256,7 @@ overlay="$2"
 
 # Intentionally unquoted: this preserves compatibility with the historical
 # documented form, `eval $(shimmer as <agent>)`.
-eval $(CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
+eval $(SHIMMER_CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null)
 
 print -r -- "name=$GIT_AUTHOR_NAME"
 print -r -- "host=$GH_HOST"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -108,6 +108,7 @@ MOCK
 # Usage: shimmer welcome
 # Usage: shimmer as alice
 shimmer() {
-  CALLER_PWD="${TEST_HOME:-.}" mise -C "$OVERLAY" run -q "$@" 2>&1
+  local caller="${SHIMMER_CALLER_PWD:-${TEST_HOME:-.}}"
+  SHIMMER_CALLER_PWD="$caller" mise -C "$OVERLAY" run -q "$@" 2>&1
 }
 export -f shimmer


### PR DESCRIPTION
## Summary
- prefer `SHIMMER_CALLER_PWD` over legacy `CALLER_PWD` at all caller-cwd sites
- update the legacy `shimmer shell` shim/alias to set `SHIMMER_CALLER_PWD`
- scrub `CALLER_PWD` and all `*_CALLER_PWD` variables before launching long-lived agent/session/harness processes

## Verification
- `mise run test`
- `mise run test agent`
- `git diff --check`
- `codebase lint:caller-pwd-contract` across shiv/shimmer/sessions/modules/threads/codebase
- `codebase lint:shellcheck` across shiv/shimmer/sessions/modules/threads
