### PR TITLE
ci: pass Hugging Face token to agent runs

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -24,6 +24,8 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: false
+      HF_TOKEN:
+        required: false
       PI_AUTH_JSON:
         required: false
       AGENT_GITHUB_PAT:
@@ -105,7 +107,7 @@ jobs:
         run: sessions cli:build
 
       - name: Install pi
-        run: mise use -g github:badlogic/pi-mono@0.70.5
+        run: mise use -g github:badlogic/pi-mono@0.73.0
 
       - name: Setup secrets for env provider
         env:
@@ -247,6 +249,7 @@ jobs:
         env:
           AGENT: ${{ inputs.agent }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BROWSER_GITHUB_COM_PASSWORD: ${{ secrets.AGENT_GITHUB_PASSWORD }}
           BROWSER_GITHUB_COM_USERNAME: ${{ inputs.agent }}-ricon
           DISPATCH_CONTEXT: ${{ github.triggering_actor }}

--- a/.github/templates/agent-scheduled.yml
+++ b/.github/templates/agent-scheduled.yml
@@ -18,6 +18,7 @@ jobs:
       model: ${MODEL}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
       PI_AUTH_JSON: ${{ secrets.PI_AUTH_JSON }}
       AGENT_GITHUB_PAT: ${{ secrets.${AGENT_UPPER}_GITHUB_PAT }}
       AGENT_GPG_PRIVATE_KEY: ${{ secrets.${AGENT_UPPER}_GPG_PRIVATE_KEY }}

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -74,6 +74,7 @@ jobs:
       model: \${{ inputs.model }}
     secrets:
       ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}
+      HF_TOKEN: \${{ secrets.HF_TOKEN }}
       PI_AUTH_JSON: \${{ secrets.PI_AUTH_JSON }}
       AGENT_GITHUB_PAT: \${{ secrets.${AGENT_UPPER}_GITHUB_PAT }}
       AGENT_GPG_PRIVATE_KEY: \${{ secrets.${AGENT_UPPER}_GPG_PRIVATE_KEY }}

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -92,14 +92,14 @@ Generated workflows call the reusable `agent-run.yml` workflow, which:
 3. Sets up agent credentials (GPG, email, Matrix, GitHub, optional blob storage).
 4. Clones the agent home repo.
 5. Prepares the home repo via the `agent:prepare` hook (see below).
-6. Restores pi auth when `PI_AUTH_JSON` is configured.
+6. Exposes provider API keys from workflow secrets (`ANTHROPIC_API_KEY`, `HF_TOKEN`) and restores pi auth when `PI_AUTH_JSON` is configured.
 7. Runs:
 
    ```bash
    shimmer agent --headless --timeout "$RUN_TIMEOUT" --model "$INPUT_MODEL" "$INPUT_MESSAGE"
    ```
 
-Headless execution requires an explicit provider-qualified model. Shimmer creates a tracked session with `sessions new` and passes the model only to `sessions wake`, matching the `sessions` v0.4.0 contract.
+Headless execution requires an explicit provider-qualified model. For Hugging Face routed models, use the `huggingface/...` prefix (for example `huggingface/moonshotai/Kimi-K2.6:novita`) so pi selects the Hugging Face provider and reads `HF_TOKEN`, even if other provider secrets are also present. Shimmer creates a tracked session with `sessions new` and passes the model only to `sessions wake`, matching the `sessions` v0.4.0 contract.
 
 ### Home repo `agent:prepare` hook
 

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -29,6 +29,28 @@ setup() {
   ! echo "$run_block" | grep -qF 'modules init'
 }
 
+@test "workflow: exposes Hugging Face auth to pi" {
+  template="$SHIMMER_DIR/.github/templates/agent-run.yml"
+
+  hf_token_declared=$(yq -r '.on.workflow_call.secrets.HF_TOKEN | has("required")' "$template")
+  hf_token_required=$(yq -r '.on.workflow_call.secrets.HF_TOKEN.required' "$template")
+  run_env=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | .env.HF_TOKEN // ""' "$template")
+  pi_install=$(yq -r '.jobs.run.steps[] | select(.name == "Install pi") | .run // ""' "$template")
+
+  [ "$hf_token_declared" = "true" ]
+  [ "$hf_token_required" = "false" ]
+  [ "$run_env" = '${{ secrets.HF_TOKEN }}' ]
+  echo "$pi_install" | grep -qF 'github:badlogic/pi-mono@0.73.0'
+}
+
+@test "workflow: generated callers forward Hugging Face token" {
+  scheduled_template="$SHIMMER_DIR/.github/templates/agent-scheduled.yml"
+  generator="$SHIMMER_DIR/.mise/tasks/workflows/generate"
+
+  grep -qF 'HF_TOKEN: ${{ secrets.HF_TOKEN }}' "$scheduled_template"
+  grep -qF 'HF_TOKEN: \${{ secrets.HF_TOKEN }}' "$generator"
+}
+
 # --- Identity checks ---
 
 @test "headless: fails without GIT_AUTHOR_NAME" {


### PR DESCRIPTION
## Summary

Add first-class Hugging Face token wiring for CI agent runs.

| Layer | Change |
|---|---|
| reusable workflow | accepts optional `HF_TOKEN` secret |
| agent run env | exposes `HF_TOKEN` to pi |
| generated manual workflows | forward `${{ secrets.HF_TOKEN }}` |
| scheduled workflow template | forwards `${{ secrets.HF_TOKEN }}` |
| pi install | bumps CI pi pin from `0.70.5` to `0.73.0` |
| docs/tests | document provider-qualified HF model strings; add structural YAML tests |

Provider routing is by model prefix. CI dispatches should use strings like:

```text
huggingface/deepseek-ai/DeepSeek-V4-Pro:novita
```

## Verification

| Check | Result |
|---|---|
| `mise run test` in shimmer | ✅ 140/140 pass |
| local pi isolated env-only with auth key | ✅ `huggingface/deepseek-ai/DeepSeek-V4-Pro:novita` works |
| `baby-joel/home` CI smoke | ✅ run 25355616736 |
| `ricon-family/den` CI smoke | ✅ run 25356004079 |
| `ricon-family/fold` CI smoke | ✅ run 25356054032 |

## Notes

Two pre-existing local hygiene checks are not clean in the shimmer worktree:

- `mise run setup` fails in git worktrees because `.git` is a file, not a directory.
- direct `codebase lint:shellcheck .` reports existing fixture/self-lint findings unrelated to this change.