### PR TITLE
fix: apply agent git identity overrides

### DIFF
--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -184,7 +184,10 @@ if [ -n "$SIGNING_KEY" ]; then
   emit_git_config_entry "commit.gpgsign" "true"
   emit_git_config_entry "tag.gpgsign" "true"
 else
-  echo "# Warning: no signing key found for $AGENT under $AGENTS_ROOT/$AGENT; Git signing key override not emitted" >&2
+  emit_git_config_entry "user.signingkey" ""
+  emit_git_config_entry "commit.gpgsign" "false"
+  emit_git_config_entry "tag.gpgsign" "false"
+  echo "# Warning: no signing key found for $AGENT under $AGENTS_ROOT/$AGENT; Git signing disabled to avoid stale signing key overrides" >&2
 fi
 emit "export GIT_CONFIG_COUNT=$(shell_quote "$NEXT_GIT_CONFIG_INDEX")"
 

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Switch to an agent's identity for local work"
-#USAGE arg "[agent]" help="Agent to switch to (omit for interactive picker)"
+#USAGE arg "[agent]" default="" help="Agent to switch to (omit for interactive picker)"
 
-set -e
+set -euo pipefail
 
 # Bridge env var during migration: shimmer callers may still set SHIMMER_SECRETS_PROVIDER
 export SECRETS_PROVIDER="${SECRETS_PROVIDER:-${SHIMMER_SECRETS_PROVIDER:-}}"
@@ -12,21 +12,30 @@ CALLER_DIR="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-$(pwd)}}"
 # Resolve the agent home (the repo the user is calling from)
 AGENT_HOME_DIR=$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")
 
-AGENT="$usage_agent"
+AGENT="${usage_agent:-}"
 IDENTITY=""
+AGENTS_ROOT="${SHIMMER_AGENTS_ROOT:-$HOME/agents}"
 
-# Delegate agent discovery to the home's agent:list task. This is mandatory:
-# agent:list is the authoritative set of agents supported by this home.
+# Prefer the caller home's authoritative agent:list task. When a concrete
+# agent is specified from an arbitrary repo or a private home that does not
+# expose agent:list, fall back to that agent's private home under AGENTS_ROOT.
 AGENT_LIST_ERR=$(mktemp)
 if ! AGENTS=$(mise -C "$AGENT_HOME_DIR" run -q agent:list 2>"$AGENT_LIST_ERR"); then
-  echo "Error: could not list agents." >&2
-  echo "Does $AGENT_HOME_DIR provide an 'agent:list' task?" >&2
-  if [ -s "$AGENT_LIST_ERR" ]; then
-    echo "agent:list stderr:" >&2
-    sed 's/^/  /' "$AGENT_LIST_ERR" >&2
+  private_agent_home="$AGENTS_ROOT/$AGENT/home"
+  if [ -n "$AGENT" ] && [ ! -e "$AGENT_HOME_DIR/.mise/tasks/agent/list" ] && [ -d "$private_agent_home" ]; then
+    AGENTS="$AGENT"
+    AGENT_HOME_DIR="$private_agent_home"
+    echo "# Note: $CALLER_DIR does not provide agent:list; using $AGENT_HOME_DIR" >&2
+  else
+    echo "Error: could not list agents." >&2
+    echo "Does $AGENT_HOME_DIR provide an 'agent:list' task?" >&2
+    if [ -s "$AGENT_LIST_ERR" ]; then
+      echo "agent:list stderr:" >&2
+      sed 's/^/  /' "$AGENT_LIST_ERR" >&2
+    fi
+    rm -f "$AGENT_LIST_ERR"
+    exit 1
   fi
-  rm -f "$AGENT_LIST_ERR"
-  exit 1
 fi
 rm -f "$AGENT_LIST_ERR"
 
@@ -76,6 +85,13 @@ if [ -z "$AGENT" ]; then
 fi
 
 EMAIL="${AGENT}@ricon.family"
+NEXT_GIT_CONFIG_INDEX="${GIT_CONFIG_COUNT:-0}"
+case "$NEXT_GIT_CONFIG_INDEX" in
+  ''|*[!0-9]*)
+    echo "# Warning: GIT_CONFIG_COUNT is not numeric; resetting transient Git config index" >&2
+    NEXT_GIT_CONFIG_INDEX=0
+    ;;
+esac
 
 shell_quote() {
   local value="$1"
@@ -97,6 +113,32 @@ emit() {
   printf '%s;\n' "$1"
 }
 
+resolve_signing_key() {
+  local agent="$1"
+  local private_home="$AGENTS_ROOT/$agent/home"
+  local agent_gitconfig="$AGENTS_ROOT/$agent/.gitconfig"
+
+  if [ -f "$private_home/.git/config" ]; then
+    git config --file "$private_home/.git/config" --get user.signingkey 2>/dev/null && return 0
+  fi
+
+  if [ -f "$agent_gitconfig" ]; then
+    git config --file "$agent_gitconfig" --get user.signingkey 2>/dev/null && return 0
+  fi
+
+  return 1
+}
+
+emit_git_config_entry() {
+  local key="$1"
+  local value="$2"
+  local index="$NEXT_GIT_CONFIG_INDEX"
+
+  emit "export GIT_CONFIG_KEY_$index=$(shell_quote "$key")"
+  emit "export GIT_CONFIG_VALUE_$index=$(shell_quote "$value")"
+  NEXT_GIT_CONFIG_INDEX=$((NEXT_GIT_CONFIG_INDEX + 1))
+}
+
 # Validate agent against the authoritative home-provided agent list.
 if ! echo "$AGENTS" | grep -qx "$AGENT"; then
   echo "Unknown agent: $AGENT" >&2
@@ -107,7 +149,9 @@ fi
 # Clear all identity vars first to prevent stale values from a previous
 # `shimmer as` from leaking through if any resolution step below fails.
 # This must come before PAT resolution — if secrets lookup exits early,
-# eval still clears the previous session's vars.
+# eval still clears the previous session's vars. GIT_CONFIG_* is intentionally
+# not cleared: caller-provided transient config must be preserved, and shimmer
+# appends later identity overrides below so the active agent wins.
 emit "unset AGENT_IDENTITY B2_BUCKET"
 emit "unset GH_HOST GH_TOKEN"
 emit "unset GIT_AUTHOR_EMAIL GIT_COMMITTER_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_NAME"
@@ -131,6 +175,18 @@ emit "export GIT_COMMITTER_EMAIL=$(shell_quote "$EMAIL")"
 emit "export GIT_AUTHOR_NAME=$(shell_quote "$AGENT")"
 emit "export GIT_COMMITTER_NAME=$(shell_quote "$AGENT")"
 emit "export AGENT_HOME=$(shell_quote "$AGENT_HOME_DIR")"
+
+SIGNING_KEY=$(resolve_signing_key "$AGENT") || SIGNING_KEY=""
+emit_git_config_entry "user.name" "$AGENT"
+emit_git_config_entry "user.email" "$EMAIL"
+if [ -n "$SIGNING_KEY" ]; then
+  emit_git_config_entry "user.signingkey" "$SIGNING_KEY"
+  emit_git_config_entry "commit.gpgsign" "true"
+  emit_git_config_entry "tag.gpgsign" "true"
+else
+  echo "# Warning: no signing key found for $AGENT under $AGENTS_ROOT/$AGENT; Git signing key override not emitted" >&2
+fi
+emit "export GIT_CONFIG_COUNT=$(shell_quote "$NEXT_GIT_CONFIG_INDEX")"
 
 # Optional: B2 blob storage bucket (don't fail if not configured).
 # Empty on missing or provider failure; conditional export below handles it.

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -20,6 +20,11 @@ resolved=()
 has_target=false
 
 for arg in ${args[@]+"${args[@]}"}; do
+  # Some mise versions pass the empty default for variadic args as a quoted
+  # empty string (''), which xargs parses into one empty argument. Do not treat
+  # that as the test directory target, or `mise run test` becomes a 0-test run.
+  [ -n "$arg" ] || continue
+
   if [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
     resolved+=("$TEST_DIR/$arg")
     has_target=true

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS test suite"
-#USAGE arg "[args]..." var=true help="Test suites, files, or bats flags"
-#USAGE example "all"    "mise run test"
-#USAGE example "suite"  "mise run test gpg"
-#USAGE example "file"   "mise run test test/gpg/gpg.bats"
-#USAGE example "filter" "mise run test -- --filter 'strip_wrapping'"
-set -eo pipefail
+#USAGE arg "[args]" var=#true default="" help="Test suites, files, or bats flags"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test gpg" header="Run a specific suite directory"
+#USAGE example "mise run test test/gpg/gpg.bats" header="Run a specific file"
+#USAGE example "mise run test gpg --filter strip_wrapping" header="Filter within a suite"
+set -euo pipefail
 
 TEST_DIR="$MISE_CONFIG_ROOT/test"
 
 args=()
+if [ -n "${usage_args:-}" ]; then
+  while IFS= read -r arg; do
+    args+=("$arg")
+  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
+fi
+
+resolved=()
 has_target=false
 
-for arg in "$@"; do
+for arg in ${args[@]+"${args[@]}"}; do
   if [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
-    args+=("$TEST_DIR/$arg")
+    resolved+=("$TEST_DIR/$arg")
     has_target=true
   else
     [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
-    args+=("$arg")
+    resolved+=("$arg")
   fi
 done
 
 if ! $has_target; then
-  args+=("--recursive" "$TEST_DIR/")
+  resolved+=("--recursive" "$TEST_DIR/")
 fi
 
-bats "${args[@]}"
+bats "${resolved[@]}"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This project uses [mise](https://mise.jdx.dev/) for task management. Run `shimme
 
 ### Identity
 
-- `shimmer as <agent>` - Switch to an agent's identity for local work (use with `eval`)
+- `shimmer as <agent>` - Switch to an agent's identity for local work (use with `eval`); also appends transient Git config so commits/tags use the active agent's name, email, and signing key
 - `shimmer whoami` - Show current git and GitHub identity
 
 Example:

--- a/docs/agent-local.md
+++ b/docs/agent-local.md
@@ -120,13 +120,23 @@ mise run gpg:setup <agent>
 
 ### Wrong signing key used
 
-Check for local git config overrides:
+`eval "$(shimmer as <agent>)"` appends transient Git config overrides for the active agent's `user.name`, `user.email`, `user.signingkey`, `commit.gpgsign`, and `tag.gpgsign`. Verify the active shell first:
+
 ```bash
-git config --local user.signingkey
+shimmer whoami
+git config user.signingkey
 ```
 
-If set, remove it to use the global config:
+If the signing key is still wrong, check for missing agent GPG setup:
+
 ```bash
+shimmer gpg:status <agent>
+```
+
+Older shells or repos without the transient overrides may still be affected by local git config overrides:
+
+```bash
+git config --local user.signingkey
 git config --local --unset user.signingkey
 ```
 

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -208,7 +208,7 @@ SCRIPT
   [ "$(git -C "$repo" config user.signingkey)" = "TESTKEY-bob" ]
 }
 
-@test "as: warns and skips signing overrides when agent signing key is missing" {
+@test "as: disables signing overrides when agent signing key is missing" {
   setup_test_home "alice"
   rm -rf "$TEST_AGENTS_ROOT/alice"
   mock_secrets_binary "alice/github-pat=ghp_fake"
@@ -218,15 +218,32 @@ SCRIPT
   [ "$status" -eq 0 ]
   [[ "$output" == *"Warning: no signing key found for alice"* ]]
   echo "$output" | grep -q "export GIT_CONFIG_KEY_0='user.name'"
-  echo "$output" | grep -q "export GIT_CONFIG_COUNT='2'"
-  if echo "$output" | grep -q "user.signingkey"; then
-    echo "unexpected signing key override" >&2
-    return 1
-  fi
-  if echo "$output" | grep -q "commit.gpgsign"; then
-    echo "unexpected commit signing override" >&2
-    return 1
-  fi
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_2='user.signingkey'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_2=''"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_3='commit.gpgsign'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_3='false'"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_4='tag.gpgsign'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_4='false'"
+  echo "$output" | grep -q "export GIT_CONFIG_COUNT='5'"
+}
+
+@test "as: missing signing key does not reuse previous agent signing overrides" {
+  setup_test_home "alice" "bob"
+  rm -rf "$TEST_AGENTS_ROOT/bob"
+  mock_secrets_binary "alice/github-pat=ghp_alice" "bob/github-pat=ghp_bob"
+  mock_shimmer
+
+  local repo="$BATS_TEST_TMPDIR/work-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+
+  eval "$(shimmer as alice 2>/dev/null)"
+  eval "$(shimmer as bob 2>/dev/null)"
+
+  [ "$(git -C "$repo" config user.name)" = "bob" ]
+  [ "$(git -C "$repo" config user.signingkey)" = "" ]
+  [ "$(git -C "$repo" config commit.gpgsign)" = "false" ]
+  [ "$(git -C "$repo" config tag.gpgsign)" = "false" ]
 }
 
 @test "as: exports B2_BUCKET when available" {

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -5,7 +5,7 @@ setup() {
 }
 
 teardown() {
-  rm -rf "$TEST_HOME" "$OVERLAY" "$BATS_TEST_TMPDIR/mocks-$$" "$BATS_TEST_TMPDIR/mock-bin-$$"
+  rm -rf "$TEST_HOME" "$OVERLAY" "$TEST_AGENTS_ROOT" "$BATS_TEST_TMPDIR/mocks-$$" "$BATS_TEST_TMPDIR/mock-bin-$$"
 }
 
 # ============ Agent discovery (no mocks needed) ============
@@ -37,6 +37,13 @@ teardown() {
   echo "$output" | grep -q "export GIT_AUTHOR_NAME='alice'"
   echo "$output" | grep -q "export GIT_AUTHOR_EMAIL='alice@ricon.family'"
   echo "$output" | grep -q "export GH_TOKEN='ghp_fake_test_token'"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_0='user.name'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_0='alice'"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_2='user.signingkey'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_2='TESTKEY-alice'"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_3='commit.gpgsign'"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_4='tag.gpgsign'"
+  echo "$output" | grep -q "export GIT_CONFIG_COUNT='5'"
 }
 
 @test "as: sets AGENT_HOME to the home directory" {
@@ -59,6 +66,22 @@ teardown() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "export AGENT_IDENTITY="
   echo "$output" | grep -q "You are alice."
+}
+
+@test "as: falls back to private home when caller repo has no agent:list" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  local caller="$BATS_TEST_TMPDIR/plain-repo"
+  mkdir -p "$caller"
+  git -C "$caller" init -q -b main
+
+  run env SHIMMER_CALLER_PWD="$caller" mise -C "$OVERLAY" run -q as alice 2>&1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"does not provide agent:list; using"* ]]
+  echo "$output" | grep -q "export AGENT_HOME='$TEST_AGENTS_ROOT/alice/home'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_2='TESTKEY-alice'"
 }
 
 @test "as: works for each agent independently" {
@@ -122,6 +145,90 @@ SCRIPT
   [[ "$output" == *"bucket=bucket'quoted"* ]]
 }
 
+@test "as: eval makes Git config use active agent signing identity in other repos" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  local repo="$BATS_TEST_TMPDIR/work-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.name "Wrong Name"
+  git -C "$repo" config user.email "wrong@example.invalid"
+  git -C "$repo" config user.signingkey "WRONGKEY"
+  git -C "$repo" config commit.gpgsign false
+
+  eval "$(shimmer as alice 2>/dev/null)"
+
+  [ "$(git -C "$repo" config user.name)" = "alice" ]
+  [ "$(git -C "$repo" config user.email)" = "alice@ricon.family" ]
+  [ "$(git -C "$repo" config user.signingkey)" = "TESTKEY-alice" ]
+  [ "$(git -C "$repo" config commit.gpgsign)" = "true" ]
+  [ "$(git -C "$repo" config tag.gpgsign)" = "true" ]
+}
+
+@test "as: appends Git config overrides without dropping existing entries" {
+  setup_test_home "alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  local repo="$BATS_TEST_TMPDIR/work-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="core.editor"
+  export GIT_CONFIG_VALUE_0="vim"
+
+  eval "$(shimmer as alice 2>/dev/null)"
+
+  [ "$GIT_CONFIG_COUNT" = "6" ]
+  [ "$GIT_CONFIG_KEY_0" = "core.editor" ]
+  [ "$GIT_CONFIG_VALUE_0" = "vim" ]
+  [ "$(git -C "$repo" config core.editor)" = "vim" ]
+  [ "$(git -C "$repo" config user.signingkey)" = "TESTKEY-alice" ]
+
+  unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+}
+
+@test "as: switching agents makes later Git config overrides win" {
+  setup_test_home "alice" "bob"
+  mock_secrets_binary "alice/github-pat=ghp_alice" "bob/github-pat=ghp_bob"
+  mock_shimmer
+
+  local repo="$BATS_TEST_TMPDIR/work-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+
+  eval "$(shimmer as alice 2>/dev/null)"
+  eval "$(shimmer as bob 2>/dev/null)"
+
+  [ "$(git -C "$repo" config user.name)" = "bob" ]
+  [ "$(git -C "$repo" config user.email)" = "bob@ricon.family" ]
+  [ "$(git -C "$repo" config user.signingkey)" = "TESTKEY-bob" ]
+}
+
+@test "as: warns and skips signing overrides when agent signing key is missing" {
+  setup_test_home "alice"
+  rm -rf "$TEST_AGENTS_ROOT/alice"
+  mock_secrets_binary "alice/github-pat=ghp_fake"
+  mock_shimmer
+
+  run shimmer as alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Warning: no signing key found for alice"* ]]
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_0='user.name'"
+  echo "$output" | grep -q "export GIT_CONFIG_COUNT='2'"
+  if echo "$output" | grep -q "user.signingkey"; then
+    echo "unexpected signing key override" >&2
+    return 1
+  fi
+  if echo "$output" | grep -q "commit.gpgsign"; then
+    echo "unexpected commit signing override" >&2
+    return 1
+  fi
+}
+
 @test "as: exports B2_BUCKET when available" {
   setup_test_home "alice"
   mock_secrets_binary "alice/github-pat=ghp_fake" "alice/b2-bucket=my-bucket"
@@ -140,7 +247,10 @@ SCRIPT
   run shimmer as alice
   [ "$status" -eq 0 ]
   # Should NOT contain B2_BUCKET export
-  ! echo "$output" | grep -q "export B2_BUCKET="
+  if echo "$output" | grep -q "export B2_BUCKET="; then
+    echo "unexpected B2_BUCKET export" >&2
+    return 1
+  fi
 }
 
 @test "as: bridges SHIMMER_SECRETS_PROVIDER to SECRETS_PROVIDER" {
@@ -168,6 +278,9 @@ SCRIPT
   # Every exported var should be unset first
   local var
   for var in $(echo "$output" | grep -oE "export [A-Z_]+" | awk '{print $2}' | sort -u); do
+    case "$var" in
+      GIT_CONFIG_*) continue ;;
+    esac
     echo "$output" | grep -q "unset.*$var" || {
       echo "exported var $var is not unset" >&2
       return 1

--- a/test/as/helpers.bash
+++ b/test/as/helpers.bash
@@ -3,6 +3,7 @@
 # Suite-specific: setup_test_home with agent:list, agent:identity, and identity files.
 # Shared helpers (mock_task, mock_shimmer, shimmer wrapper) loaded from test/helpers.bash.
 
+# shellcheck source=test/helpers.bash
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
 
 # Create a test home with agent:list, agent:identity, and identity files.
@@ -40,7 +41,11 @@ fi
 TASK
   chmod +x "$TEST_HOME/.mise/tasks/agent/identity"
 
-  # Identity files
+  TEST_AGENTS_ROOT="$BATS_TEST_TMPDIR/agents-root-$$"
+  export TEST_AGENTS_ROOT
+  export SHIMMER_AGENTS_ROOT="$TEST_AGENTS_ROOT"
+
+  # Identity files + private agent homes with signing config.
   for agent in "${agents[@]}"; do
     cat > "$TEST_HOME/notes/$agent.md" <<EOF
 ---
@@ -51,6 +56,14 @@ tags: [agent, identity]
 # $agent
 You are $agent.
 EOF
+
+    mkdir -p "$TEST_AGENTS_ROOT/$agent/home"
+    git -C "$TEST_AGENTS_ROOT/$agent/home" init -q -b main
+    git -C "$TEST_AGENTS_ROOT/$agent/home" config user.name "$agent"
+    git -C "$TEST_AGENTS_ROOT/$agent/home" config user.email "$agent@ricon.family"
+    git -C "$TEST_AGENTS_ROOT/$agent/home" config user.signingkey "TESTKEY-$agent"
+    git -C "$TEST_AGENTS_ROOT/$agent/home" config commit.gpgsign true
+    git -C "$TEST_AGENTS_ROOT/$agent/home" config tag.gpgsign true
   done
 
   # Git init


### PR DESCRIPTION
## Summary

- make `shimmer as <agent>` append transient Git config overrides for active agent identity/signing
- resolve signing keys from each agent's private home config, not the caller repo
- let specified agents fall back to their private home when the caller repo has no `agent:list`
- modernize the `test` mise task to the current variadic-args pattern

## Why

The new fold `git pre-push` task exposed that shared or foreign worktrees (notably Or home) can keep using the repo/global signing key even when `GIT_AUTHOR_*` and `GIT_COMMITTER_*` are set for an agent. This makes ordinary `git commit` sign with the wrong identity.

`shimmer as` is the right boundary to fix that: the identity switch should set both Git author/committer env and transient Git config.

## Validation

- `mise run test` — 145 tests passed
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:shellcheck "$PWD"`
- `codebase lint:gum-table "$PWD"`
- smoke: `eval "$(SHIMMER_CALLER_PWD=/tmp/c0da.d/h mise run as c0da)"` makes `git -C /tmp/c0da.d/o config user.signingkey` report c0da's key, and fold `git pre-push` no longer warns about Or-home signing-key mismatch
