### PR TITLE
fix: clear stale signing config without key

### DIFF
--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -184,7 +184,10 @@ if [ -n "$SIGNING_KEY" ]; then
   emit_git_config_entry "commit.gpgsign" "true"
   emit_git_config_entry "tag.gpgsign" "true"
 else
-  echo "# Warning: no signing key found for $AGENT under $AGENTS_ROOT/$AGENT; Git signing key override not emitted" >&2
+  emit_git_config_entry "user.signingkey" ""
+  emit_git_config_entry "commit.gpgsign" "false"
+  emit_git_config_entry "tag.gpgsign" "false"
+  echo "# Warning: no signing key found for $AGENT under $AGENTS_ROOT/$AGENT; Git signing disabled to avoid stale signing-key overrides" >&2
 fi
 emit "export GIT_CONFIG_COUNT=$(shell_quote "$NEXT_GIT_CONFIG_INDEX")"
 

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -208,7 +208,7 @@ SCRIPT
   [ "$(git -C "$repo" config user.signingkey)" = "TESTKEY-bob" ]
 }
 
-@test "as: warns and skips signing overrides when agent signing key is missing" {
+@test "as: disables signing overrides when agent signing key is missing" {
   setup_test_home "alice"
   rm -rf "$TEST_AGENTS_ROOT/alice"
   mock_secrets_binary "alice/github-pat=ghp_fake"
@@ -218,15 +218,33 @@ SCRIPT
   [ "$status" -eq 0 ]
   [[ "$output" == *"Warning: no signing key found for alice"* ]]
   echo "$output" | grep -q "export GIT_CONFIG_KEY_0='user.name'"
-  echo "$output" | grep -q "export GIT_CONFIG_COUNT='2'"
-  if echo "$output" | grep -q "user.signingkey"; then
-    echo "unexpected signing key override" >&2
-    return 1
-  fi
-  if echo "$output" | grep -q "commit.gpgsign"; then
-    echo "unexpected commit signing override" >&2
-    return 1
-  fi
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_2='user.signingkey'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_2=''"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_3='commit.gpgsign'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_3='false'"
+  echo "$output" | grep -q "export GIT_CONFIG_KEY_4='tag.gpgsign'"
+  echo "$output" | grep -q "export GIT_CONFIG_VALUE_4='false'"
+  echo "$output" | grep -q "export GIT_CONFIG_COUNT='5'"
+}
+
+@test "as: missing signing key does not keep previous agent signing overrides" {
+  setup_test_home "alice" "bob"
+  rm -rf "$TEST_AGENTS_ROOT/bob"
+  mock_secrets_binary "alice/github-pat=ghp_alice" "bob/github-pat=ghp_bob"
+  mock_shimmer
+
+  local repo="$BATS_TEST_TMPDIR/work-repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+
+  eval "$(shimmer as alice 2>/dev/null)"
+  eval "$(shimmer as bob 2>/dev/null)"
+
+  [ "$(git -C "$repo" config user.name)" = "bob" ]
+  [ "$(git -C "$repo" config user.email)" = "bob@ricon.family" ]
+  [ "$(git -C "$repo" config --get user.signingkey)" = "" ]
+  [ "$(git -C "$repo" config commit.gpgsign)" = "false" ]
+  [ "$(git -C "$repo" config tag.gpgsign)" = "false" ]
 }
 
 @test "as: exports B2_BUCKET when available" {


### PR DESCRIPTION
Fix-it for #759.\n\nWhen switching from an agent with signing overrides to an agent whose signing key cannot be resolved, the original branch preserved the previous GIT_CONFIG_* signing entries. This branch appends empty/false signing overrides in the missing-key path so Git does not keep using the prior agent's key.\n\nVerification:\n- mise run test test/as/as.bats\n- MISE_CONFIG_ROOT=$PWD MISE_PROJECT_ROOT=$PWD ./.mise/tasks/test\n- bash -n .mise/tasks/as test/as/as.bats test/as/helpers.bash\n- codebase lint:mise-settings / bats-test-task / bats-test-helper / mcr-scope / or-true / shellcheck / gum-table\n- git diff --check origin/main...HEAD