### PR TITLE
fix: ignore empty variadic test args

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -20,6 +20,11 @@ resolved=()
 has_target=false
 
 for arg in ${args[@]+"${args[@]}"}; do
+  # Some mise versions pass the empty default for variadic args as a quoted
+  # empty string (''), which xargs parses into one empty argument. Do not treat
+  # that as the test directory target, or `mise run test` becomes a 0-test run.
+  [ -n "$arg" ] || continue
+
   if [[ "$arg" != -* && "$arg" != *.bats && -d "$TEST_DIR/$arg" ]]; then
     resolved+=("$TEST_DIR/$arg")
     has_target=true


### PR DESCRIPTION
## Summary

- skip empty parsed variadic args in the test task
- prevent older mise/usage output for the empty default from turning `mise run test` into a zero-test run

## Validation

- `mise run test as`
- `env -u usage_headless -u usage_message -u usage_model -u usage_timeout -u usage_meta -u usage_session -u usage_session_id -u usage_cwd mise run test` — 146 tests passed
- `bash -n .mise/tasks/test`
- `git diff --check origin/c0da/as-git-config-overrides...HEAD`