### PR TITLE
Resolve current mise in agent workflows

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Resolve mise version
         id: mise-version
         run: |
-          version=$(curl -fsSL https://mise.jdx.dev/VERSION)
+          version=$(curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors https://mise.jdx.dev/VERSION)
+          version=${version%$'\r'}
           if [[ ! "$version" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Unexpected mise version: $version"
             exit 1

--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -73,9 +73,21 @@ jobs:
           mkdir -p "$(dirname "$WORK_DIR")"
           mv repo "$WORK_DIR"
 
+      - name: Resolve mise version
+        id: mise-version
+        run: |
+          version=$(curl -fsSL https://mise.jdx.dev/VERSION)
+          if [[ ! "$version" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unexpected mise version: $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved mise version: $version"
+
       - name: Set up mise
         uses: jdx/mise-action@v4
         with:
+          version: ${{ steps.mise-version.outputs.version }}
           install: true
         env:
           GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -37,7 +37,8 @@ setup() {
   mise_version=$(yq -r '.jobs.run.steps[] | select(.name == "Set up mise") | .with.version // ""' "$template")
 
   [ "$resolve_id" = "mise-version" ]
-  echo "$resolve_step" | grep -qF 'curl -fsSL https://mise.jdx.dev/VERSION'
+  echo "$resolve_step" | grep -qF 'curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors https://mise.jdx.dev/VERSION'
+  echo "$resolve_step" | grep -qF 'version=${version%$'"'"'\r'"'"'}'
   echo "$resolve_step" | grep -qF 'Unexpected mise version'
   echo "$resolve_step" | grep -qF 'GITHUB_OUTPUT'
   [ "$mise_version" = '${{ steps.mise-version.outputs.version }}' ]

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -29,6 +29,20 @@ setup() {
   ! echo "$run_block" | grep -qF 'modules init'
 }
 
+@test "workflow: mise action uses resolved current version" {
+  template="$SHIMMER_DIR/.github/templates/agent-run.yml"
+
+  resolve_step=$(yq -r '.jobs.run.steps[] | select(.name == "Resolve mise version") | .run // ""' "$template")
+  resolve_id=$(yq -r '.jobs.run.steps[] | select(.name == "Resolve mise version") | .id // ""' "$template")
+  mise_version=$(yq -r '.jobs.run.steps[] | select(.name == "Set up mise") | .with.version // ""' "$template")
+
+  [ "$resolve_id" = "mise-version" ]
+  echo "$resolve_step" | grep -qF 'curl -fsSL https://mise.jdx.dev/VERSION'
+  echo "$resolve_step" | grep -qF 'Unexpected mise version'
+  echo "$resolve_step" | grep -qF 'GITHUB_OUTPUT'
+  [ "$mise_version" = '${{ steps.mise-version.outputs.version }}' ]
+}
+
 @test "workflow: exposes Hugging Face auth to pi" {
   template="$SHIMMER_DIR/.github/templates/agent-run.yml"
 

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -27,6 +27,12 @@ teardown() {
 
 # ============ Full as flow (secrets binary mocked) ============
 
+@test "as: test helper clears ambient Git config overrides" {
+  [ -z "${GIT_CONFIG_COUNT:-}" ]
+  [ -z "${GIT_CONFIG_KEY_0:-}" ]
+  [ -z "${GIT_CONFIG_VALUE_0:-}" ]
+}
+
 @test "as: outputs export statements for valid agent" {
   setup_test_home "alice" "bob"
   mock_secrets_binary "alice/github-pat=ghp_fake_test_token"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -14,6 +14,22 @@
 # codebase tool's lint:mcr-scope rule enforces this pattern.
 SHIMMER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Agent sessions inject command-scope git config via GIT_CONFIG_* so real
+# workspace commits use the active agent identity/signing key. Tests should not
+# inherit that ambient launch context: suites that exercise `shimmer as` need to
+# start from a predictable empty command-scope config, and can still set their
+# own GIT_CONFIG_* values inside individual tests.
+_clear_ambient_git_config_for_tests() {
+  local name _value
+  unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
+  while IFS='=' read -r name _value; do
+    case "$name" in
+      GIT_CONFIG_KEY_*|GIT_CONFIG_VALUE_*) unset "$name" ;;
+    esac
+  done < <(env)
+}
+_clear_ambient_git_config_for_tests
+
 # Create a mock task file. Call this before mock_shimmer.
 # Usage: mock_task "email/quota" 'echo "Usage: 50%"'
 mock_task() {


### PR DESCRIPTION
## Summary

- resolve the current mise release from `https://mise.jdx.dev/VERSION` in generated agent workflows
- pass that resolved version to `jdx/mise-action@v4` so mise-action's cache key includes the binary version and stale cached mise binaries do not persist indefinitely
- scrub ambient `GIT_CONFIG_*` command-scope config from shimmer BATS helpers so local agent sessions do not pollute `shimmer as` tests

Fixes ricon-family/fold#65 at the template source. After this lands, fold/den workflows should be regenerated.

## Verification

- `mise run test test/agent/agent.bats --filter 'mise action uses resolved current version|home preparation|Hugging Face'`
- `env GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=ambient-agent GIT_CONFIG_KEY_1=commit.gpgsign GIT_CONFIG_VALUE_1=true mise run test test/as/as.bats --filter 'test helper clears ambient Git config|outputs export statements|appends Git config overrides'`
- `mise run test` — 148/148 incl. expected skip
- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/*.yml .github/templates/agent-run.yml`
- `bash -n test/helpers.bash`
- `git diff --check`
- codebase lint subtasks by absolute repo path:
  - `lint:mise-settings`
  - `lint:gum-table`
  - `lint:bats-test-helper`
  - `lint:bats-test-task`
  - `lint:mcr-scope`
  - `lint:or-true`
  - `lint:shellcheck`

## Notes

I first tried `actionlint .github/workflows/*.yml .github/templates/*.yml`, but `agent-scheduled.yml` is a template containing the raw `__SCHEDULE_ENTRIES__` placeholder and is not valid standalone YAML. The concrete generated workflows and `agent-run.yml` template pass actionlint.

I also tried aggregate `codebase lint .`, but shimmer currently pins codebase 0.2.0, which exposes only `lint:*` subtasks; I ran those subtasks against the absolute repo path instead.
