### PR TITLE
Harden generated mise version resolution

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Resolve mise version
         id: mise-version
         run: |
-          version=$(curl -fsSL https://mise.jdx.dev/VERSION)
+          version=$(curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors https://mise.jdx.dev/VERSION)
+          version=${version%$'\r'}
           if [[ ! "$version" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Unexpected mise version: $version"
             exit 1

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -37,7 +37,8 @@ setup() {
   mise_version=$(yq -r '.jobs.run.steps[] | select(.name == "Set up mise") | .with.version // ""' "$template")
 
   [ "$resolve_id" = "mise-version" ]
-  echo "$resolve_step" | grep -qF 'curl -fsSL https://mise.jdx.dev/VERSION'
+  echo "$resolve_step" | grep -qF 'curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors https://mise.jdx.dev/VERSION'
+  echo "$resolve_step" | grep -qF 'version=${version%$'"'"'\r'"'"'}'
   echo "$resolve_step" | grep -qF 'Unexpected mise version'
   echo "$resolve_step" | grep -qF 'GITHUB_OUTPUT'
   [ "$mise_version" = '${{ steps.mise-version.outputs.version }}' ]


### PR DESCRIPTION
## Summary

- bound and retry the generated `curl` call to `https://mise.jdx.dev/VERSION`
- tolerate a CRLF version response without weakening the existing version-format guard
- update the workflow template assertion for the hardened command

## Verification

- `mise run test test/agent/agent.bats --filter 'mise action uses resolved current version'`
- `mise run test test/agent/agent.bats --filter 'mise action uses resolved current version|home preparation|Hugging Face'`
- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/*.yml .github/templates/agent-run.yml`
- `git diff --check`

## Note

This is a fix-it PR against #764 from an adversarial review pass.
