### PR TITLE
fix: fail configured session backup on list errors

### DIFF
--- a/.mise/tasks/sessions/backup
+++ b/.mise/tasks/sessions/backup
@@ -51,10 +51,10 @@ collect_all_sessions() {
   sessions_err=$(mktemp)
 
   if ! sessions_json=$(sessions list --all --json --limit "$LIMIT" 2>"$sessions_err"); then
-    printf_status "could not list sessions; skipping"
+    printf_error "could not list sessions"
     sed 's/^/[sessions:backup] sessions: /' "$sessions_err" >&2
     rm -f "$sessions_err"
-    exit 0
+    exit 1
   fi
   rm -f "$sessions_err"
 
@@ -156,17 +156,27 @@ backup_one_session() {
   blobs put "$latest_key" "$archive"
 }
 
-require_command jq
-require_command sessions
-
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/shimmer-sessions-backup.XXXXXX")
 
 parse_session_args
-if [ "$ALL" = "true" ]; then
-  collect_all_sessions
-elif [ ${#SESSION_IDS[@]} -eq 0 ]; then
+if [ "$ALL" != "true" ] && [ ${#SESSION_IDS[@]} -eq 0 ]; then
   printf_error "provide session IDs or pass --all"
   exit 1
+fi
+
+if [ "$DRY_RUN" != "true" ]; then
+  if ! ensure_blob_env; then
+    printf_status "B2 credentials not configured; skipping session backup"
+    exit 0
+  fi
+else
+  printf_status "dry run; not uploading"
+fi
+
+require_command sessions
+if [ "$ALL" = "true" ]; then
+  require_command jq
+  collect_all_sessions
 fi
 
 if [ ${#SESSION_IDS[@]} -eq 0 ]; then
@@ -175,18 +185,11 @@ if [ ${#SESSION_IDS[@]} -eq 0 ]; then
 fi
 
 if [ "$DRY_RUN" != "true" ]; then
-  if ! ensure_blob_env; then
-    printf_status "B2 credentials not configured; skipping session backup"
-    exit 0
-  fi
-
   trust_blobs_package_config
   require_command blobs
 
   printf_status "ensuring blob alias $B2_ALIAS"
   blobs setup >&2
-else
-  printf_status "dry run; not uploading"
 fi
 
 for session_id in "${SESSION_IDS[@]}"; do

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -133,14 +133,27 @@ setup() {
   grep -q '^put sessions/session-002/latest\.tar\.gz .*$' "$BLOBS_LOG"
 }
 
-@test "sessions:backup skips upload when credentials are absent" {
-  mock_sessions_backup_tools '[{"session_id":"session-001"}]'
+@test "sessions:backup skips before session inspection when credentials are absent" {
+  mock_sessions_backup_tools '__FAIL__'
   export AGENT="missing-agent"
   mock_shimmer
 
   run shimmer sessions:backup --all
   [ "$status" -eq 0 ]
   [[ "$output" == *"B2 credentials not configured; skipping session backup"* ]]
+  [ ! -f "$SESSIONS_LOG" ]
+  [ ! -f "$BLOBS_LOG" ]
+}
+
+@test "sessions:backup fails when configured backup cannot list sessions" {
+  mock_sessions_backup_tools '__FAIL__'
+  export AGENT="test-agent"
+  mock_shimmer
+
+  run shimmer sessions:backup --all
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not list sessions"* ]]
+  [[ "$output" == *"mock list failure"* ]]
   grep -q '^list --all --json --limit 10000$' "$SESSIONS_LOG"
   [ ! -f "$BLOBS_LOG" ]
 }

--- a/test/agent/helpers.bash
+++ b/test/agent/helpers.bash
@@ -60,6 +60,10 @@ mock_sessions_backup_tools() {
 echo "$@" >> "$SESSIONS_LOG"
 case "$1" in
   list)
+    if [ "$SESSIONS_LIST_JSON" = "__FAIL__" ]; then
+      echo "mock list failure" >&2
+      exit 42
+    fi
     printf '%s\n' "$SESSIONS_LIST_JSON"
     ;;
   export)


### PR DESCRIPTION
Fix-it for #767.

Changes:
- skip before invoking `sessions` when B2 credentials are absent
- fail configured `--all` backups when `sessions list` fails instead of treating it as a clean skip
- keep `blobs setup` inside `sessions:backup`, but only after credentials exist and sessions are actually selected for upload
- add regressions for absent credentials and list failures

Verification:
- `mise run test agent --filter 'sessions:backup'`
- `bash -n .mise/tasks/sessions/backup test/agent/helpers.bash test/agent/agent.bats`
- `git diff --check`
- `mise exec -- codebase lint:shellcheck "$PWD"`
