### PR TITLE
Isolate agent runtime PATH from launcher mise tools

### DIFF
--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -51,17 +51,17 @@ if [ "$HEADLESS" = "true" ]; then
   # Headless mode creates a tracked session and launches it in the background
   # via sessions new + sessions wake. The agent runs inside zmx (backgrounded),
   # and can be monitored with `sessions read`.
-  if ! command -v sessions &>/dev/null; then
-    echo "sessions not found on PATH. Install it: shiv install sessions" >&2
-    exit 1
-  fi
-
   CWD="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}"
   SESSION_NAME="${GIT_AUTHOR_NAME}-headless-$(date +%s)"
 
   # Prepare the long-lived agent runtime without discarding identity-bearing
   # environment such as GIT_AUTHOR_NAME or AGENT_IDENTITY.
   shimmer_prepare_agent_child_env
+
+  if ! command -v sessions &>/dev/null; then
+    echo "sessions not found on PATH. Install it: shiv install sessions" >&2
+    exit 1
+  fi
 
   # Create a tracked session (or resume an existing one)
   if [ -n "$SESSION" ]; then

--- a/lib/agent-env.sh
+++ b/lib/agent-env.sh
@@ -36,63 +36,47 @@ shimmer_scrub_mise_task_env() {
   done < <(compgen -e)
 }
 
-shimmer_mise_install_tool() {
+shimmer_path_contains() {
+  local needle="$1"
+  local path_rest entry
+  path_rest="${PATH:-}:"
+
+  while [ -n "$path_rest" ]; do
+    entry="${path_rest%%:*}"
+    path_rest="${path_rest#*:}"
+    [ "$entry" = "$needle" ] && return 0
+  done
+
+  return 1
+}
+
+shimmer_append_path_if_missing() {
   local entry="$1"
-  local installs="$2"
-  local rest
+  [ -n "$entry" ] || return 0
+  shimmer_path_contains "$entry" && return 0
 
-  case "$entry" in
-    "$installs"/*/*)
-      rest="${entry#"$installs"/}"
-      printf '%s\n' "${rest%%/*}"
-      ;;
-  esac
+  if [ -n "${PATH:-}" ]; then
+    export PATH="$PATH:$entry"
+  else
+    export PATH="$entry"
+  fi
 }
 
-shimmer_mise_install_version() {
-  local entry="$1"
-  local installs="$2"
-  local rest tool version
-
-  case "$entry" in
-    "$installs"/*/*)
-      rest="${entry#"$installs"/}"
-      tool="${rest%%/*}"
-      rest="${rest#"$tool"/}"
-      version="${rest%%/*}"
-      printf '%s\n' "$version"
-      ;;
-  esac
-}
-
-shimmer_selected_mise_install_version() {
-  local tool="$1"
-  local installs="$2"
-  shift 2
-
-  local entry entry_tool version
-  while [ "$#" -gt 0 ]; do
-    entry="$1"
-    shift
-    if ! entry_tool="$(shimmer_mise_install_tool "$entry" "$installs")"; then
-      entry_tool=""
-    fi
-    [ "$entry_tool" = "$tool" ] || continue
-    if ! version="$(shimmer_mise_install_version "$entry" "$installs")"; then
-      version=""
-    fi
-    printf '%s\n' "$version"
-  done | tail -1
-}
-
-# Collapse stale mise install PATH entries by tool name, keeping every entry for
-# the last-seen version of each tool. This preserves ordinary inherited PATH
-# entries and same-version multi-path tools (for example Elixir's bin plus
-# .mix/escripts), while letting a later home-specific mise env overlay beat stale
-# shimmer-launch tool dirs such as shiv-sessions/0.4.1 when shiv-sessions/0.4.3
-# is also present later in PATH.
-shimmer_prune_mise_install_path_duplicates() {
-  local data_dir installs path_rest entry
+# Cross the boundary from shimmer's mise task into a long-lived agent runtime.
+#
+# The launcher task may have direct mise install directories on PATH, such as
+# ~/.local/share/mise/installs/shiv-sessions/0.4.1/bin. Those directories are
+# activation artifacts for the launcher repo, not part of the agent runtime
+# contract. If they survive, they can shadow later repo-specific `mise exec`
+# tool selections for the entire interactive session.
+#
+# Do not reset wholesale to __MISE_ORIG_PATH here: callers/tests may have
+# intentionally prepended non-mise directories for harnesses, wrappers, or
+# mocks. Preserve ordinary PATH entries, remove direct mise install entries,
+# and make the stable command surfaces available through mise shims and
+# ~/.local/bin.
+shimmer_prepare_agent_runtime_path() {
+  local data_dir installs path_rest entry new_path
   if ! data_dir="$(shimmer_mise_data_dir)"; then
     data_dir=""
   fi
@@ -100,47 +84,30 @@ shimmer_prune_mise_install_path_duplicates() {
 
   installs="$data_dir/installs"
   path_rest="${PATH:-}:"
-  local entries=()
+  new_path=""
 
   while [ -n "$path_rest" ]; do
     entry="${path_rest%%:*}"
     path_rest="${path_rest#*:}"
-    entries+=("$entry")
-  done
 
-  local kept=() i tool version selected_version new_path
-  for ((i = 0; i < ${#entries[@]}; i++)); do
-    entry="${entries[$i]}"
-    if ! tool="$(shimmer_mise_install_tool "$entry" "$installs")"; then
-      tool=""
-    fi
+    case "$entry" in
+      "$installs"/*) continue ;;
+    esac
 
-    if [ -n "$tool" ]; then
-      if ! version="$(shimmer_mise_install_version "$entry" "$installs")"; then
-        version=""
-      fi
-      if ! selected_version="$(shimmer_selected_mise_install_version "$tool" "$installs" "${entries[@]}")"; then
-        selected_version=""
-      fi
-      [ "$version" != "$selected_version" ] && continue
-    fi
-
-    kept+=("$entry")
-  done
-
-  new_path=""
-  for entry in ${kept[@]+"${kept[@]}"}; do
     if [ -z "$new_path" ]; then
       new_path="$entry"
     else
       new_path="$new_path:$entry"
     fi
   done
+
   export PATH="$new_path"
+  shimmer_append_path_if_missing "$data_dir/shims"
+  [ -n "${HOME:-}" ] && shimmer_append_path_if_missing "$HOME/.local/bin"
 }
 
 shimmer_prepare_agent_child_env() {
   shimmer_scrub_caller_pwd_env
   shimmer_scrub_mise_task_env
-  shimmer_prune_mise_install_path_duplicates
+  shimmer_prepare_agent_runtime_path
 }

--- a/test/agent-env/agent-env.bats
+++ b/test/agent-env/agent-env.bats
@@ -41,53 +41,54 @@ setup() {
   [ -z "${usage_model-}" ]
 }
 
-@test "agent env: prunes stale duplicate mise install dirs by tool key" {
+@test "agent env: removes direct mise install dirs at runtime boundary" {
   export HOME="$BATS_TEST_TMPDIR/home"
-  local installs="$HOME/.local/share/mise/installs"
+  local data_dir="$HOME/.local/share/mise"
+  local installs="$data_dir/installs"
   local old_sessions="$installs/shiv-sessions/0.4.1/bin"
-  local new_sessions="$installs/shiv-sessions/0.4.3/bin"
-  local old_threads="$installs/shiv-threads/0.2.1/bin"
-  local new_threads="$installs/shiv-threads/0.3.0/bin"
+  local new_sessions="$installs/shiv-sessions/0.4.4/bin"
+  local threads="$installs/shiv-threads/0.3.0/bin"
+  local nested_bats="$installs/bats/1.13.0/bats-core-1.13.0/bin"
 
-  export PATH="/usr/bin:/bin:$old_sessions:/custom/bin:$new_sessions:$old_threads:$new_threads:/tail/bin"
+  export PATH="/mock/bin:$old_sessions:/custom/bin:$new_sessions:$threads:$nested_bats:/tail/bin:/usr/bin:/bin"
 
-  shimmer_prune_mise_install_path_duplicates
+  shimmer_prepare_agent_runtime_path
 
   [[ ":$PATH:" != *":$old_sessions:"* ]]
-  [[ ":$PATH:" != *":$old_threads:"* ]]
-  [[ ":$PATH:" == *":$new_sessions:"* ]]
-  [[ ":$PATH:" == *":$new_threads:"* ]]
+  [[ ":$PATH:" != *":$new_sessions:"* ]]
+  [[ ":$PATH:" != *":$threads:"* ]]
+  [[ ":$PATH:" != *":$nested_bats:"* ]]
+  [[ ":$PATH:" == *":/mock/bin:"* ]]
   [[ ":$PATH:" == *":/custom/bin:"* ]]
   [[ ":$PATH:" == *":/tail/bin:"* ]]
+  [[ ":$PATH:" == *":$data_dir/shims:"* ]]
+  [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]
 }
 
-@test "agent env: keeps non-duplicate mise install dirs" {
+@test "agent env: removes single stale mise install dir without requiring duplicate" {
   export HOME="$BATS_TEST_TMPDIR/home"
   local installs="$HOME/.local/share/mise/installs"
-  local only_sessions="$installs/shiv-sessions/0.4.3/bin"
-  local only_notes="$installs/shiv-notes/0.8.8/bin"
+  local stale_sessions="$installs/shiv-sessions/0.4.1/bin"
 
-  export PATH="$only_sessions:/usr/bin:/bin:$only_notes"
+  export PATH="/mock/bin:$stale_sessions:/usr/bin:/bin"
 
-  shimmer_prune_mise_install_path_duplicates
+  shimmer_prepare_agent_runtime_path
 
-  [[ ":$PATH:" == *":$only_sessions:"* ]]
-  [[ ":$PATH:" == *":$only_notes:"* ]]
+  [[ ":$PATH:" != *":$stale_sessions:"* ]]
+  [[ ":$PATH:" == *":/mock/bin:"* ]]
   [[ ":$PATH:" == *":/usr/bin:"* ]]
+  [[ ":$PATH:" == *":/bin:"* ]]
 }
 
-@test "agent env: preserves multiple entries for the selected mise install version" {
+@test "agent env: preserves non-mise path order and does not duplicate stable entries" {
   export HOME="$BATS_TEST_TMPDIR/home"
-  local installs="$HOME/.local/share/mise/installs"
-  local old_elixir="$installs/elixir/1.18/bin"
-  local new_elixir_bin="$installs/elixir/1.19/bin"
-  local new_elixir_mix="$installs/elixir/1.19/.mix/escripts"
+  local data_dir="$HOME/.local/share/mise"
+  local shims="$data_dir/shims"
+  local local_bin="$HOME/.local/bin"
 
-  export PATH="$old_elixir:/usr/bin:/bin:$new_elixir_bin:$new_elixir_mix"
+  export PATH="/mock/bin:$shims:/custom/bin:$local_bin:/tail/bin:/usr/bin:/bin"
 
-  shimmer_prune_mise_install_path_duplicates
+  shimmer_prepare_agent_runtime_path
 
-  [[ ":$PATH:" != *":$old_elixir:"* ]]
-  [[ ":$PATH:" == *":$new_elixir_bin:"* ]]
-  [[ ":$PATH:" == *":$new_elixir_mix:"* ]]
+  [ "$PATH" = "/mock/bin:$shims:/custom/bin:$local_bin:/tail/bin:/usr/bin:/bin" ]
 }

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -230,6 +230,34 @@ setup() {
   [[ "$output" == *"sessions not found"* ]]
 }
 
+@test "headless: checks sessions availability after runtime PATH cleanup" {
+  setup_agent
+  local home="$BATS_TEST_TMPDIR/path-boundary-home"
+  local direct_sessions="$home/.local/share/mise/installs/shiv-sessions/0.4.1/bin"
+  mkdir -p "$direct_sessions"
+  cat > "$direct_sessions/sessions" <<'MOCK'
+#!/usr/bin/env bash
+echo "stale direct sessions should not run" >&2
+exit 99
+MOCK
+  chmod +x "$direct_sessions/sessions"
+
+  run env -i \
+    HOME="$home" \
+    PATH="$direct_sessions:/usr/bin:/bin" \
+    MISE_CONFIG_ROOT="$SHIMMER_DIR" \
+    GIT_AUTHOR_NAME="test-agent" \
+    GIT_AUTHOR_EMAIL="test-agent@ricon.family" \
+    AGENT_IDENTITY="You are test-agent." \
+    usage_headless="true" \
+    usage_model="openai-codex/gpt-5.5" \
+    usage_message="review the PR" \
+    bash "$SHIMMER_DIR/.mise/tasks/agent/_default"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"sessions not found on PATH"* ]]
+  [[ "$output" != *"stale direct sessions should not run"* ]]
+}
+
 @test "headless: calls sessions new + wake" {
   setup_agent
   mock_sessions_binary

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -278,12 +278,12 @@ setup() {
   grep -q '^OTHER_CALLER_PWD=$' "$SESSIONS_ENV_LOG"
 }
 
-@test "headless: removes stale mise task env and duplicate install PATH before invoking sessions" {
+@test "headless: removes mise task env and direct install PATH before invoking sessions" {
   setup_agent
   local installs="$HOME/.local/share/mise/installs"
-  local old_tool="$installs/shiv-stale-tool/0.1/bin"
-  local new_tool="$installs/shiv-stale-tool/0.2/bin"
-  export PATH="$old_tool:/before:$new_tool:$PATH"
+  local stale_sessions="$installs/shiv-sessions/0.4.1/bin"
+  local current_sessions="$installs/shiv-sessions/0.4.4/bin"
+  export PATH="$stale_sessions:/before:$current_sessions:$PATH"
   export MISE_PROJECT_ROOT="/stale/project"
   export MISE_ORIGINAL_CWD="/stale/original"
   mock_sessions_binary
@@ -301,8 +301,9 @@ setup() {
   grep -q '^GIT_AUTHOR_NAME=test-agent$' "$SESSIONS_ENV_LOG"
   grep -q '^GIT_AUTHOR_EMAIL=test-agent@ricon.family$' "$SESSIONS_ENV_LOG"
   grep -q '^AGENT_IDENTITY=You are test-agent\.$' "$SESSIONS_ENV_LOG"
-  grep -q "^PATH=.*$new_tool" "$SESSIONS_ENV_LOG"
-  ! grep -q "^PATH=.*$old_tool" "$SESSIONS_ENV_LOG"
+  grep -q '^PATH=.*/before' "$SESSIONS_ENV_LOG"
+  ! grep -q "^PATH=.*$stale_sessions" "$SESSIONS_ENV_LOG"
+  ! grep -q "^PATH=.*$current_sessions" "$SESSIONS_ENV_LOG"
 }
 
 @test "headless: session name uses full epoch timestamp" {
@@ -420,15 +421,15 @@ setup() {
   grep -q '^OTHER_CALLER_PWD=$' "$HARNESS_ENV_LOG"
 }
 
-@test "interactive: removes stale mise task env and duplicate install PATH before invoking harness" {
+@test "interactive: removes mise task env and direct install PATH before invoking harness" {
   setup_agent
   local caller_dir="$BATS_TEST_TMPDIR/scrub-caller"
   mkdir -p "$caller_dir"
   export SHIMMER_CALLER_PWD="$caller_dir"
   local installs="$HOME/.local/share/mise/installs"
-  local old_tool="$installs/shiv-stale-tool/0.1/bin"
-  local new_tool="$installs/shiv-stale-tool/0.2/bin"
-  export PATH="$old_tool:/before:$new_tool:$PATH"
+  local stale_sessions="$installs/shiv-sessions/0.4.1/bin"
+  local current_sessions="$installs/shiv-sessions/0.4.4/bin"
+  export PATH="$stale_sessions:/before:$current_sessions:$PATH"
   export MISE_PROJECT_ROOT="/stale/project"
   export MISE_ORIGINAL_CWD="/stale/original"
   mock_harness
@@ -446,8 +447,9 @@ setup() {
   grep -q '^GIT_AUTHOR_NAME=test-agent$' "$HARNESS_ENV_LOG"
   grep -q '^GIT_AUTHOR_EMAIL=test-agent@ricon.family$' "$HARNESS_ENV_LOG"
   grep -q '^AGENT_IDENTITY=You are test-agent\.$' "$HARNESS_ENV_LOG"
-  grep -q "^PATH=.*$new_tool" "$HARNESS_ENV_LOG"
-  ! grep -q "^PATH=.*$old_tool" "$HARNESS_ENV_LOG"
+  grep -q '^PATH=.*/before' "$HARNESS_ENV_LOG"
+  ! grep -q "^PATH=.*$stale_sessions" "$HARNESS_ENV_LOG"
+  ! grep -q "^PATH=.*$current_sessions" "$HARNESS_ENV_LOG"
 }
 
 @test "interactive: forwards session flag to harness" {

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -252,7 +252,7 @@ MOCK
     usage_headless="true" \
     usage_model="openai-codex/gpt-5.5" \
     usage_message="review the PR" \
-    bash "$SHIMMER_DIR/.mise/tasks/agent/_default"
+    bash "$SHIMMER_DIR/.mise/tasks/agent/_default" # codebase:ignore bats-test-helper — intentional direct invocation to isolate post-cleanup PATH without mise-added shims
   [ "$status" -ne 0 ]
   [[ "$output" == *"sessions not found on PATH"* ]]
   [[ "$output" != *"stale direct sessions should not run"* ]]


### PR DESCRIPTION
## Summary

Tighten the `shimmer agent` runtime environment boundary so long-lived agent sessions do not inherit direct mise install directories from the launcher task.

Previously `lib/agent-env.sh` only pruned duplicate mise install versions by tool key. That helped when both old and new versions were already in PATH, but it did not fix the common long-lived-shell failure mode:

1. `shimmer agent` starts as a mise task from the launcher repo.
2. The launcher's activated PATH contains a direct tool bin, e.g. `~/.local/share/mise/installs/shiv-sessions/0.4.1/bin`.
3. The interactive agent shell inherits that direct bin for the rest of the session.
4. Later, inside another repo, `mise exec` can add `shiv-sessions/0.4.4/bin` after the inherited path, so bare `sessions` still resolves to stale `0.4.1`.

This PR replaces duplicate-version pruning with a real runtime boundary: remove direct `~/.local/share/mise/installs/...` PATH entries before handing off to the agent runtime, while preserving ordinary PATH entries and ensuring stable command surfaces remain available via mise shims and `~/.local/bin`.

## What changed

- Add `shimmer_prepare_agent_runtime_path`:
  - removes any PATH entry under the active mise data dir's `installs/` tree;
  - preserves non-mise entries such as mock bins, harness wrappers, `/usr/bin`, and caller-prepended dirs;
  - appends `$MISE_DATA_DIR/shims` (or the default mise shims path) if missing;
  - appends `$HOME/.local/bin` if missing.
- Keep existing identity/caller/task env cleanup behavior.
- Cover both headless and interactive `shimmer agent` handoff paths.

## Validation

- `bash -n lib/agent-env.sh .mise/tasks/agent/_default`
- `mise run test agent-env agent` — 40/40
- Codebase lint subtasks with explicit targets:
  - `mise-settings`
  - `gum-table`
  - `bats-test-helper`
  - `bats-test-task`
  - `mcr-scope`
  - `or-true`
  - `shellcheck`
- `mise run test` — 163/163
- Manual subshell smoke: stale `shiv-sessions/0.4.1/bin` and current `0.4.4/bin` were removed, PATH resolved `sessions` through mise shims, and `sessions wait --help` worked.
