### PR TITLE
agent: check sessions after runtime path cleanup

### DIFF
--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -51,17 +51,17 @@ if [ "$HEADLESS" = "true" ]; then
   # Headless mode creates a tracked session and launches it in the background
   # via sessions new + sessions wake. The agent runs inside zmx (backgrounded),
   # and can be monitored with `sessions read`.
-  if ! command -v sessions &>/dev/null; then
-    echo "sessions not found on PATH. Install it: shiv install sessions" >&2
-    exit 1
-  fi
-
   CWD="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}"
   SESSION_NAME="${GIT_AUTHOR_NAME}-headless-$(date +%s)"
 
   # Prepare the long-lived agent runtime without discarding identity-bearing
   # environment such as GIT_AUTHOR_NAME or AGENT_IDENTITY.
   shimmer_prepare_agent_child_env
+
+  if ! command -v sessions &>/dev/null; then
+    echo "sessions not found on PATH. Install it: shiv install sessions" >&2
+    exit 1
+  fi
 
   # Create a tracked session (or resume an existing one)
   if [ -n "$SESSION" ]; then

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -230,6 +230,34 @@ setup() {
   [[ "$output" == *"sessions not found"* ]]
 }
 
+@test "headless: checks sessions availability after runtime PATH cleanup" {
+  setup_agent
+  local home="$BATS_TEST_TMPDIR/path-boundary-home"
+  local direct_sessions="$home/.local/share/mise/installs/shiv-sessions/0.4.1/bin"
+  mkdir -p "$direct_sessions"
+  cat > "$direct_sessions/sessions" <<'MOCK'
+#!/usr/bin/env bash
+echo "stale direct sessions should not run" >&2
+exit 99
+MOCK
+  chmod +x "$direct_sessions/sessions"
+
+  run env -i \
+    HOME="$home" \
+    PATH="$direct_sessions:/usr/bin:/bin" \
+    MISE_CONFIG_ROOT="$SHIMMER_DIR" \
+    GIT_AUTHOR_NAME="test-agent" \
+    GIT_AUTHOR_EMAIL="test-agent@ricon.family" \
+    AGENT_IDENTITY="You are test-agent." \
+    usage_headless="true" \
+    usage_model="openai-codex/gpt-5.5" \
+    usage_message="review the PR" \
+    bash "$SHIMMER_DIR/.mise/tasks/agent/_default"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"sessions not found on PATH"* ]]
+  [[ "$output" != *"stale direct sessions should not run"* ]]
+}
+
 @test "headless: calls sessions new + wake" {
   setup_agent
   mock_sessions_binary


### PR DESCRIPTION
Fix-it for KnickKnackLabs/shimmer#774.

The headless path checked `sessions` before calling `shimmer_prepare_agent_child_env`. With the new runtime PATH boundary, that precheck can succeed only because a direct mise install dir is still present, then the cleanup removes that same directory and `sessions new` fails as `command not found`.

This moves the availability check after cleanup so it validates the actual runtime PATH, and adds a regression for a PATH where the only `sessions` binary lives under `~/.local/share/mise/installs/...`.

Validation:

- `bash -n lib/agent-env.sh .mise/tasks/agent/_default test/agent/agent.bats`
- `mise run test agent-env agent` — 41/41
- `git diff --check`
- `mise run test` — degraded: telemetry gum/status baseline failures in this runner (`test/telemetry/list.bats:91`, `test/telemetry/status.bats:38,48`), same local class Brownie has seen on shimmer before
- `mise exec -- codebase lint:shellcheck "$PWD/lib/agent-env.sh" "$PWD/.mise/tasks/agent/_default" "$PWD/test/agent/agent.bats"`
- `mise exec -- codebase lint:bats-test-task "$PWD/test/agent/agent.bats"`
- `mise exec -- codebase lint:bats-test-helper "$PWD/test/agent/agent.bats"`
