### PR TITLE
test: document direct agent cleanup regression

### DIFF
--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -252,7 +252,7 @@ MOCK
     usage_headless="true" \
     usage_model="openai-codex/gpt-5.5" \
     usage_message="review the PR" \
-    bash "$SHIMMER_DIR/.mise/tasks/agent/_default"
+    bash "$SHIMMER_DIR/.mise/tasks/agent/_default" # codebase:ignore bats-test-helper — intentional direct invocation to isolate post-cleanup PATH without mise-added shims
   [ "$status" -ne 0 ]
   [[ "$output" == *"sessions not found on PATH"* ]]
   [[ "$output" != *"stale direct sessions should not run"* ]]


### PR DESCRIPTION
Follow-up to #774 re-review.

The direct task invocation in the new post-cleanup headless regression is intentional: running through the normal `mise run` overlay would make repo shims/tools available again, which hides the direct-only `sessions` install path this test is trying to reject. The codebase `bats-test-helper` lint needs a narrow inline ignore for that one line.

Validation:
- `mise run test agent-env agent` — 41/41
- explicit codebase lint subtasks by absolute target — pass
- `git diff --check origin/main...HEAD` — pass
