### PR TITLE
Harden generated workflow YAML inputs

### DIFF
--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -34,6 +34,8 @@ SCRIPT_DIR="$OUTPUT_ROOT/scripts"
 
 mkdir -p "$OUTPUT_DIR"
 
+GENERATED_WORKFLOW_NAMES=$'agent-run\nagent-mention\n'
+
 agent_secret_prefix() {
   printf '%s' "$1" | tr '[:lower:]-' '[:upper:]_'
 }
@@ -45,8 +47,8 @@ agent_output_name() {
 validate_agent_name() {
   local agent="$1"
 
-  if [[ ! "$agent" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
-    echo "Error: invalid agent name '$agent' from agent:list; expected ^[a-z0-9][a-z0-9-]*$" >&2
+  if [[ ! "$agent" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+    echo "Error: invalid agent name '$agent' from agent:list; expected ^[a-z][a-z0-9]*(-[a-z0-9]+)*$" >&2
     exit 1
   fi
 
@@ -56,6 +58,37 @@ validate_agent_name() {
       exit 1
       ;;
   esac
+}
+
+validate_workflow_name() {
+  local name="$1"
+
+  if [[ ! "$name" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "Error: invalid workflow name '$name' from workflows.yaml; expected ^[a-z0-9][a-z0-9-]*$" >&2
+    exit 1
+  fi
+}
+
+workflow_name_in_use() {
+  local needle="$1"
+  local workflow_name
+  while IFS= read -r workflow_name; do
+    [[ -z "$workflow_name" ]] && continue
+    [[ "$workflow_name" == "$needle" ]] && return 0
+  done <<< "$GENERATED_WORKFLOW_NAMES"
+  return 1
+}
+
+reserve_workflow_name() {
+  local name="$1"
+  local source="$2"
+
+  if workflow_name_in_use "$name"; then
+    echo "Error: generated workflow name '$name' from $source conflicts with another generated workflow" >&2
+    exit 1
+  fi
+
+  GENERATED_WORKFLOW_NAMES+="${name}"$'\n'
 }
 
 agent_in_roster() {
@@ -128,7 +161,7 @@ generate_agent_workflow() {
 # Source: shimmer workflows generate
 # Regenerate: shimmer workflows generate
 
-name: ${agent}
+name: '${agent}'
 
 on:
   workflow_dispatch:
@@ -179,7 +212,7 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent: ${agent}
+      agent: '${agent}'
       message: \${{ inputs.message }}
       model: \${{ inputs.model }}
     secrets:
@@ -199,13 +232,15 @@ WORKFLOW_EOF
 
 generate_scheduled_workflow() {
   local index="$1"
-  local name agent message model schedule_count schedule_entries schedule_tmp message_tmp model_tmp output_file cron
-  local message_yaml model_yaml
+  local name agent message model schedule_count schedule_entries schedule_tmp name_tmp message_tmp model_tmp output_file cron
+  local name_yaml message_yaml model_yaml
 
   name=$(yq -r ".workflows[$index].name" workflows.yaml)
   agent=$(yq -r ".workflows[$index].agent" workflows.yaml)
   message=$(yq -r ".workflows[$index].message" workflows.yaml)
   model=$(yq -r ".workflows[$index].model" workflows.yaml)
+  validate_workflow_name "$name"
+  reserve_workflow_name "$name" "workflow '$name'"
   if [[ -z "$model" || "$model" == "null" ]]; then
     echo "Error: workflow '$name' is missing required model" >&2
     exit 1
@@ -224,10 +259,18 @@ generate_scheduled_workflow() {
   done
 
   output_file="$OUTPUT_DIR/${name}.yml"
-  export NAME="$name" AGENT="$agent"
+  export AGENT="$agent"
 
   # shellcheck disable=SC2016  # envsubst's allow-list argument: literal ${VAR} tokens are the contract.
-  envsubst '${NAME} ${AGENT}' < "$SCHEDULED_TEMPLATE" > "$output_file"
+  envsubst '${AGENT}' < "$SCHEDULED_TEMPLATE" > "$output_file"
+
+  name_tmp=$(mktemp)
+  printf '%s' "$name" > "$name_tmp"
+  name_yaml=$(yaml_scalar_from_file "$name_tmp")
+  printf '%s' "$name_yaml" > "$name_tmp"
+  # shellcheck disable=SC2016  # Replace the literal ${NAME} placeholder after envsubst.
+  replace_file_token_from_file "$output_file" '${NAME}' "$name_tmp"
+  rm "$name_tmp"
 
   message_tmp=$(mktemp)
   printf '%s' "$message" > "$message_tmp"
@@ -385,6 +428,7 @@ if [[ -n "$AGENTS" ]]; then
   while IFS= read -r agent; do
     [[ -z "$agent" ]] && continue
     validate_agent_name "$agent"
+    reserve_workflow_name "$agent" "agent:list entry '$agent'"
     generate_agent_workflow "$agent"
     echo "Generated: ${agent}.yml"
     AGENT_COUNT=$((AGENT_COUNT + 1))

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -42,6 +42,44 @@ agent_output_name() {
   printf '%s' "$1" | tr '-' '_'
 }
 
+validate_agent_name() {
+  local agent="$1"
+
+  if [[ ! "$agent" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "Error: invalid agent name '$agent' from agent:list; expected ^[a-z0-9][a-z0-9-]*$" >&2
+    exit 1
+  fi
+
+  case "$agent" in
+    agent-run|agent-mention)
+      echo "Error: invalid agent name '$agent' from agent:list; name is reserved by generated workflows" >&2
+      exit 1
+      ;;
+  esac
+}
+
+agent_in_roster() {
+  local needle="$1"
+  local agent
+  while IFS= read -r agent; do
+    [[ -z "$agent" ]] && continue
+    [[ "$agent" == "$needle" ]] && return 0
+  done <<< "$AGENTS"
+  return 1
+}
+
+yaml_scalar_from_file() {
+  local value_file="$1"
+
+  python3 - "$value_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+print(json.dumps(Path(sys.argv[1]).read_text(encoding="utf-8")))
+PY
+}
+
 csv_from_lines() {
   awk 'NF { printf "%s%s", sep, $0; sep="," } END { print "" }'
 }
@@ -161,7 +199,8 @@ WORKFLOW_EOF
 
 generate_scheduled_workflow() {
   local index="$1"
-  local name agent message model schedule_count schedule_entries schedule_tmp message_tmp output_file cron
+  local name agent message model schedule_count schedule_entries schedule_tmp message_tmp model_tmp output_file cron
+  local message_yaml model_yaml
 
   name=$(yq -r ".workflows[$index].name" workflows.yaml)
   agent=$(yq -r ".workflows[$index].agent" workflows.yaml)
@@ -169,6 +208,11 @@ generate_scheduled_workflow() {
   model=$(yq -r ".workflows[$index].model" workflows.yaml)
   if [[ -z "$model" || "$model" == "null" ]]; then
     echo "Error: workflow '$name' is missing required model" >&2
+    exit 1
+  fi
+  validate_agent_name "$agent"
+  if ! agent_in_roster "$agent"; then
+    echo "Error: workflow '$name' references agent '$agent', but agent:list did not report that agent" >&2
     exit 1
   fi
 
@@ -180,16 +224,26 @@ generate_scheduled_workflow() {
   done
 
   output_file="$OUTPUT_DIR/${name}.yml"
-  export NAME="$name" AGENT="$agent" MODEL="$model"
+  export NAME="$name" AGENT="$agent"
 
   # shellcheck disable=SC2016  # envsubst's allow-list argument: literal ${VAR} tokens are the contract.
-  envsubst '${NAME} ${AGENT} ${MODEL}' < "$SCHEDULED_TEMPLATE" > "$output_file"
+  envsubst '${NAME} ${AGENT}' < "$SCHEDULED_TEMPLATE" > "$output_file"
 
   message_tmp=$(mktemp)
   printf '%s' "$message" > "$message_tmp"
+  message_yaml=$(yaml_scalar_from_file "$message_tmp")
+  printf '%s' "$message_yaml" > "$message_tmp"
   # shellcheck disable=SC2016  # Replace the literal ${MESSAGE} placeholder after envsubst.
   replace_file_token_from_file "$output_file" '${MESSAGE}' "$message_tmp"
   rm "$message_tmp"
+
+  model_tmp=$(mktemp)
+  printf '%s' "$model" > "$model_tmp"
+  model_yaml=$(yaml_scalar_from_file "$model_tmp")
+  printf '%s' "$model_yaml" > "$model_tmp"
+  # shellcheck disable=SC2016  # Replace the literal ${MODEL} placeholder after envsubst.
+  replace_file_token_from_file "$output_file" '${MODEL}' "$model_tmp"
+  rm "$model_tmp"
 
   schedule_tmp=$(mktemp)
   printf '%s' "$schedule_entries" > "$schedule_tmp"
@@ -203,6 +257,12 @@ generate_mention_workflow() {
   local model="$3"
   local allowed_associations="$4"
   local output_file="$OUTPUT_DIR/agent-mention.yml"
+  local model_tmp model_yaml
+
+  model_tmp=$(mktemp)
+  printf '%s' "$model" > "$model_tmp"
+  model_yaml=$(yaml_scalar_from_file "$model_tmp")
+  rm "$model_tmp"
 
   mkdir -p "$SCRIPT_DIR"
   rm -f "$SCRIPT_DIR/agent-mention-detect.nu"
@@ -290,7 +350,7 @@ WORKFLOW_EOF
     uses: ./.github/workflows/${agent}.yml
     with:
       message: \${{ needs.detect.outputs.message }}
-      model: ${model}
+      model: ${model_yaml}
     secrets: inherit
 WORKFLOW_EOF
   done <<< "$agents"
@@ -324,6 +384,7 @@ if [[ -n "$AGENTS" ]]; then
   AGENT_COUNT=0
   while IFS= read -r agent; do
     [[ -z "$agent" ]] && continue
+    validate_agent_name "$agent"
     generate_agent_workflow "$agent"
     echo "Generated: ${agent}.yml"
     AGENT_COUNT=$((AGENT_COUNT + 1))

--- a/test/workflows/generate.bats
+++ b/test/workflows/generate.bats
@@ -247,6 +247,79 @@ assert_detector_case() {
   [[ "$output" == *"Differs: .github/scripts/agent-mention-detect.py"* ]]
 }
 
+@test "workflows:generate quotes scheduled message and model as YAML scalars" {
+  make_target_repo
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: weird-message
+    agent: quick
+    model: huggingface/moonshotai/Kimi-K2.6:novita
+    schedule:
+      - "0 15 * * *"
+    message: |
+      line one
+      permissions: write-all
+      jobs:
+        pwn:
+          runs-on: ubuntu-latest
+mention_wakes:
+  enabled: true
+  model: huggingface/moonshotai/Kimi-K2.6:novita
+EOF
+
+  run generate_workflows
+  [ "$status" -eq 0 ] || {
+    echo "$output" >&2
+    return 1
+  }
+
+  scheduled_workflow="$TARGET_REPO/.github/workflows/weird-message.yml"
+  mention_workflow="$TARGET_REPO/.github/workflows/agent-mention.yml"
+
+  [ "$(yq -r '.jobs.run.with.message' "$scheduled_workflow")" = $'line one\npermissions: write-all\njobs:\n  pwn:\n    runs-on: ubuntu-latest' ]
+  [ "$(yq -r '.jobs.run.with.model' "$scheduled_workflow")" = "huggingface/moonshotai/Kimi-K2.6:novita" ]
+  [ "$(yq -r '.jobs.run' "$scheduled_workflow")" != "null" ]
+  [ "$(yq -r '.jobs.pwn' "$scheduled_workflow")" = "null" ]
+  [ "$(yq -r '.permissions' "$scheduled_workflow")" = "null" ]
+  [ "$(yq -r '.jobs."wake-quick".with.model' "$mention_workflow")" = "huggingface/moonshotai/Kimi-K2.6:novita" ]
+}
+
+@test "workflows:generate rejects unsafe agent names and unknown scheduled agents" {
+  make_target_repo
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf 'quick\n'
+printf '../scripts/owned\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid agent name '../scripts/owned'"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf 'quick\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: daily-probe
+    agent: c0da
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Review the daily probe."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"workflow 'daily-probe' references agent 'c0da', but agent:list did not report that agent"* ]]
+}
+
 @test "workflows:generate removes stale mention files when mention_wakes is disabled" {
   make_target_repo
   generate_workflows

--- a/test/workflows/generate.bats
+++ b/test/workflows/generate.bats
@@ -285,7 +285,7 @@ EOF
   [ "$(yq -r '.jobs."wake-quick".with.model' "$mention_workflow")" = "huggingface/moonshotai/Kimi-K2.6:novita" ]
 }
 
-@test "workflows:generate rejects unsafe agent names and unknown scheduled agents" {
+@test "workflows:generate rejects unsafe or duplicate agent names" {
   make_target_repo
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
@@ -298,6 +298,79 @@ EOF
   run generate_workflows
   [ "$status" -ne 0 ]
   [[ "$output" == *"invalid agent name '../scripts/owned'"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf '123\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid agent name '123'"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf 'quick\n'
+printf 'quick\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'quick' from agent:list entry 'quick' conflicts"* ]]
+}
+
+@test "workflows:generate rejects scheduled workflow name collisions and unknown agents" {
+  make_target_repo
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: quick
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Do not overwrite the quick wrapper."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'quick' from workflow 'quick' conflicts"* ]]
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: agent-run
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Do not overwrite the reusable runner."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'agent-run' from workflow 'agent-run' conflicts"* ]]
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: repeated
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "First."
+  - name: repeated
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 16 * * *"
+    message: "Second."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'repeated' from workflow 'repeated' conflicts"* ]]
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -90,7 +90,7 @@
     "provider_qualified_model": {
       "type": "string",
       "description": "Provider-qualified model to use (for example: openai-codex/gpt-5.5)",
-      "pattern": "^[a-z0-9][a-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._:-]*$",
+      "pattern": "^[a-z0-9][a-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._:/-]*$",
       "examples": [
         "openai-codex/gpt-5.5",
         "github-copilot/gpt-5.5",

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -28,7 +28,8 @@
         },
         "agent": {
           "type": "string",
-          "description": "Agent to run (e.g., c0da, quick)"
+          "description": "Agent to run (e.g., c0da, quick)",
+          "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
         },
         "schedule": {
           "type": "array",


### PR DESCRIPTION
Fix-it for KnickKnackLabs/shimmer#777 adversarial review.

This hardens the generator against workflow-generation input hazards:

- JSON/YAML-quote scheduled `message` and generated `model` values before inserting them into workflow YAML, so multiline messages or colon-bearing values stay scalar inputs instead of corrupting the generated workflow.
- Validate `agent:list` names before using them as filenames/job IDs/secret prefixes, reserve generated workflow names, and reject scheduled workflows that reference agents not emitted by `agent:list`.
- Fix the workflow schema model regex so the documented `huggingface/moonshotai/Kimi-K2.6:novita` example actually validates.

Validation:

- `bash -n .mise/tasks/workflows/generate`
- `mise run test workflows` (6/6)
- full `mise run test` (170/170) with the installed gum binary directory prepended because the ambient gum shim is inactive; unmodified full suite failed in telemetry table tests before that workaround.
- `python3 -m py_compile .github/templates/agent-mention-detect.py`
- generated temp workflows `actionlint` with `shellcheck@0.11.0`
- `git diff --check`
