### PR TITLE
workflows: reject generated workflow name collisions

### DIFF
--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -34,6 +34,8 @@ SCRIPT_DIR="$OUTPUT_ROOT/scripts"
 
 mkdir -p "$OUTPUT_DIR"
 
+GENERATED_WORKFLOW_NAMES=$'agent-run\nagent-mention\n'
+
 agent_secret_prefix() {
   printf '%s' "$1" | tr '[:lower:]-' '[:upper:]_'
 }
@@ -45,8 +47,8 @@ agent_output_name() {
 validate_agent_name() {
   local agent="$1"
 
-  if [[ ! "$agent" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
-    echo "Error: invalid agent name '$agent' from agent:list; expected ^[a-z0-9][a-z0-9-]*$" >&2
+  if [[ ! "$agent" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+    echo "Error: invalid agent name '$agent' from agent:list; expected ^[a-z][a-z0-9]*(-[a-z0-9]+)*$" >&2
     exit 1
   fi
 
@@ -56,6 +58,37 @@ validate_agent_name() {
       exit 1
       ;;
   esac
+}
+
+validate_workflow_name() {
+  local name="$1"
+
+  if [[ ! "$name" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "Error: invalid workflow name '$name' from workflows.yaml; expected ^[a-z0-9][a-z0-9-]*$" >&2
+    exit 1
+  fi
+}
+
+workflow_name_in_use() {
+  local needle="$1"
+  local workflow_name
+  while IFS= read -r workflow_name; do
+    [[ -z "$workflow_name" ]] && continue
+    [[ "$workflow_name" == "$needle" ]] && return 0
+  done <<< "$GENERATED_WORKFLOW_NAMES"
+  return 1
+}
+
+reserve_workflow_name() {
+  local name="$1"
+  local source="$2"
+
+  if workflow_name_in_use "$name"; then
+    echo "Error: generated workflow name '$name' from $source conflicts with another generated workflow" >&2
+    exit 1
+  fi
+
+  GENERATED_WORKFLOW_NAMES+="${name}"$'\n'
 }
 
 agent_in_roster() {
@@ -128,7 +161,7 @@ generate_agent_workflow() {
 # Source: shimmer workflows generate
 # Regenerate: shimmer workflows generate
 
-name: ${agent}
+name: '${agent}'
 
 on:
   workflow_dispatch:
@@ -179,7 +212,7 @@ jobs:
   run:
     uses: ./.github/workflows/agent-run.yml
     with:
-      agent: ${agent}
+      agent: '${agent}'
       message: \${{ inputs.message }}
       model: \${{ inputs.model }}
     secrets:
@@ -199,13 +232,15 @@ WORKFLOW_EOF
 
 generate_scheduled_workflow() {
   local index="$1"
-  local name agent message model schedule_count schedule_entries schedule_tmp message_tmp model_tmp output_file cron
-  local message_yaml model_yaml
+  local name agent message model schedule_count schedule_entries schedule_tmp name_tmp message_tmp model_tmp output_file cron
+  local name_yaml message_yaml model_yaml
 
   name=$(yq -r ".workflows[$index].name" workflows.yaml)
   agent=$(yq -r ".workflows[$index].agent" workflows.yaml)
   message=$(yq -r ".workflows[$index].message" workflows.yaml)
   model=$(yq -r ".workflows[$index].model" workflows.yaml)
+  validate_workflow_name "$name"
+  reserve_workflow_name "$name" "workflow '$name'"
   if [[ -z "$model" || "$model" == "null" ]]; then
     echo "Error: workflow '$name' is missing required model" >&2
     exit 1
@@ -224,10 +259,18 @@ generate_scheduled_workflow() {
   done
 
   output_file="$OUTPUT_DIR/${name}.yml"
-  export NAME="$name" AGENT="$agent"
+  export AGENT="$agent"
 
   # shellcheck disable=SC2016  # envsubst's allow-list argument: literal ${VAR} tokens are the contract.
-  envsubst '${NAME} ${AGENT}' < "$SCHEDULED_TEMPLATE" > "$output_file"
+  envsubst '${AGENT}' < "$SCHEDULED_TEMPLATE" > "$output_file"
+
+  name_tmp=$(mktemp)
+  printf '%s' "$name" > "$name_tmp"
+  name_yaml=$(yaml_scalar_from_file "$name_tmp")
+  printf '%s' "$name_yaml" > "$name_tmp"
+  # shellcheck disable=SC2016  # Replace the literal ${NAME} placeholder after envsubst.
+  replace_file_token_from_file "$output_file" '${NAME}' "$name_tmp"
+  rm "$name_tmp"
 
   message_tmp=$(mktemp)
   printf '%s' "$message" > "$message_tmp"
@@ -385,6 +428,7 @@ if [[ -n "$AGENTS" ]]; then
   while IFS= read -r agent; do
     [[ -z "$agent" ]] && continue
     validate_agent_name "$agent"
+    reserve_workflow_name "$agent" "agent:list entry '$agent'"
     generate_agent_workflow "$agent"
     echo "Generated: ${agent}.yml"
     AGENT_COUNT=$((AGENT_COUNT + 1))

--- a/test/workflows/generate.bats
+++ b/test/workflows/generate.bats
@@ -285,7 +285,7 @@ EOF
   [ "$(yq -r '.jobs."wake-quick".with.model' "$mention_workflow")" = "huggingface/moonshotai/Kimi-K2.6:novita" ]
 }
 
-@test "workflows:generate rejects unsafe agent names and unknown scheduled agents" {
+@test "workflows:generate rejects unsafe or duplicate agent names" {
   make_target_repo
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
@@ -298,6 +298,79 @@ EOF
   run generate_workflows
   [ "$status" -ne 0 ]
   [[ "$output" == *"invalid agent name '../scripts/owned'"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf '123\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid agent name '123'"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf 'quick\n'
+printf 'quick\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'quick' from agent:list entry 'quick' conflicts"* ]]
+}
+
+@test "workflows:generate rejects scheduled workflow name collisions and unknown agents" {
+  make_target_repo
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: quick
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Do not overwrite the quick wrapper."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'quick' from workflow 'quick' conflicts"* ]]
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: agent-run
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Do not overwrite the reusable runner."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'agent-run' from workflow 'agent-run' conflicts"* ]]
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: repeated
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "First."
+  - name: repeated
+    agent: quick
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 16 * * *"
+    message: "Second."
+EOF
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"generated workflow name 'repeated' from workflow 'repeated' conflicts"* ]]
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash

--- a/workflows.schema.json
+++ b/workflows.schema.json
@@ -28,7 +28,8 @@
         },
         "agent": {
           "type": "string",
-          "description": "Agent to run (e.g., c0da, quick)"
+          "description": "Agent to run (e.g., c0da, quick)",
+          "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
         },
         "schedule": {
           "type": "array",


### PR DESCRIPTION
Fix-it for the adversarial review of #779.

Findings fixed:

1. Agent names like `123` passed Brownie's new validator but generated invalid GitHub expressions such as `${{ secrets.123_GITHUB_PAT }}`. Tightened agent names to start with a letter and avoid empty hyphen segments.
2. Scheduled workflow names could still overwrite generated base/per-agent workflows (`agent-run`, `agent-mention`, or `quick`) and duplicate scheduled workflow names could overwrite each other. Added generated workflow name reservation/collision checks.
3. Added schema validation for scheduled `agent` names to match the generator-side contract.

Validation run locally:

- `bash -n .mise/tasks/workflows/generate`
- `python3 -m py_compile .github/templates/agent-mention-detect.py`
- `mise run test workflows` — 7/7
- adversarial replay probes for digit-start agent, per-agent collision, and `agent-run` collision
- `git diff --check`

Full suite not rerun before opening this fix-it because the session is being hopped at 98% context; next session should run full validation after merging/applying.
