### PR TITLE
Add --message-file to agent dispatch

### DIFF
--- a/.mise/tasks/agent/dispatch
+++ b/.mise/tasks/agent/dispatch
@@ -1,16 +1,42 @@
 #!/usr/bin/env bash
 #MISE description="Wake an agent by dispatching their workflow"
 #USAGE arg "<agent>" help="Agent to wake (e.g., zeke, baby-joel)"
-#USAGE arg "<message>" help="Message for the agent"
+#USAGE arg "[message]" default="" help="Message for the agent"
+#USAGE flag "--message-file <path>" default="" help="Read message for the agent from a file"
 #USAGE flag "--model <model>" default="" help="Model to use (required; provider-qualified, e.g. openai-codex/gpt-5.5)"
 #USAGE flag "--repo <repo>" default="" help="Target repository (owner/name) — skip agent discovery"
 
 set -e
 
 AGENT="${usage_agent}"
-MESSAGE="${usage_message}"
+MESSAGE="${usage_message:-}"
+MESSAGE_FILE="${usage_message_file:-}"
 MODEL="${usage_model:-}"
 REPO_FLAG="${usage_repo:-}"
+
+if [[ -n "$MESSAGE" && -n "$MESSAGE_FILE" ]]; then
+  echo "Error: provide either inline <message> or --message-file, not both" >&2
+  exit 1
+fi
+
+if [[ -n "$MESSAGE_FILE" ]]; then
+  MESSAGE_FILE_PATH="$MESSAGE_FILE"
+  case "$MESSAGE_FILE_PATH" in
+    /*) ;;
+    *) MESSAGE_FILE_PATH="${SHIMMER_CALLER_PWD:-$PWD}/$MESSAGE_FILE_PATH" ;;
+  esac
+  if [[ ! -f "$MESSAGE_FILE_PATH" || ! -r "$MESSAGE_FILE_PATH" ]]; then
+    echo "Error: cannot read --message-file: $MESSAGE_FILE" >&2
+    exit 1
+  fi
+  MESSAGE="$(cat "$MESSAGE_FILE_PATH"; printf x)"
+  MESSAGE="${MESSAGE%x}"
+fi
+
+if [[ -z "$MESSAGE" ]]; then
+  echo "Error: message is required (pass inline <message> or --message-file)" >&2
+  exit 1
+fi
 
 if [[ -z "$MODEL" ]]; then
   echo "Error: --model <provider/model> is required" >&2

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -542,3 +542,25 @@ PACKET
 '* ]]
   [[ "$log" == *"model=openai-codex/gpt-5.5"* ]]
 }
+
+@test "agent:dispatch resolves relative message file from caller cwd" {
+  mock_gh 12345
+  local caller_dir="$BATS_TEST_TMPDIR/caller"
+  mkdir -p "$caller_dir"
+  cat > "$caller_dir/dispatch-packet.md" <<'PACKET'
+Relative packet line 1
+$RELATIVE_VARS stay literal
+PACKET
+  export SHIMMER_CALLER_PWD="$caller_dir"
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo --model openai-codex/gpt-5.5 --message-file dispatch-packet.md c0da
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Woke c0da (run 12345)"* ]]
+
+  log=$(cat "$GH_LOG")
+  [[ "$log" == *$'message=Relative packet line 1
+$RELATIVE_VARS stay literal
+'* ]]
+  [[ "$log" == *"model=openai-codex/gpt-5.5"* ]]
+}

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -464,6 +464,46 @@ MOCK
   [[ "$output" == *"provider-qualified"* ]]
 }
 
+@test "agent:dispatch requires an inline message or message file" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo --model openai-codex/gpt-5.5 c0da
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"message is required"* ]]
+  [ ! -f "$GH_LOG" ]
+}
+
+@test "agent:dispatch fails when inline message and message file are both supplied" {
+  mock_gh 12345
+  printf 'file message\n' > "$BATS_TEST_TMPDIR/message.md"
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo --model openai-codex/gpt-5.5 --message-file message.md c0da "inline message"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"either inline <message> or --message-file, not both"* ]]
+  [ ! -f "$GH_LOG" ]
+}
+
+@test "agent:dispatch fails clearly when message file cannot be read" {
+  mock_gh 12345
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo --model openai-codex/gpt-5.5 --message-file missing.md c0da
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot read --message-file: missing.md"* ]]
+  [ ! -f "$GH_LOG" ]
+}
+
+@test "agent:dispatch help documents message file" {
+  mock_shimmer
+
+  run mise -C "$OVERLAY" tasks info agent:dispatch
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"flag --message-file"* ]]
+  [[ "$output" == *"Read message for the agent from a file"* ]]
+}
+
 @test "agent:dispatch preserves embedded newlines in message input" {
   mock_gh 12345
   mock_shimmer
@@ -477,5 +517,28 @@ MOCK
 
   log=$(cat "$GH_LOG")
   [[ "$log" == *$'message=line1\nline2'* ]]
+  [[ "$log" == *"model=openai-codex/gpt-5.5"* ]]
+}
+
+@test "agent:dispatch reads message from file without interpolation" {
+  mock_gh 12345
+  cat > "$BATS_TEST_TMPDIR/dispatch-packet.md" <<'PACKET'
+Please review `KnickKnackLabs/websites#30`.
+
+- Check `$VARS` are not interpolated.
+- Preserve "quotes" and bullets.
+PACKET
+  mock_shimmer
+
+  run shimmer agent:dispatch --repo test/repo --model openai-codex/gpt-5.5 --message-file "$BATS_TEST_TMPDIR/dispatch-packet.md" c0da
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Woke c0da (run 12345)"* ]]
+
+  log=$(cat "$GH_LOG")
+  [[ "$log" == *$'message=Please review `KnickKnackLabs/websites#30`.
+
+- Check `$VARS` are not interpolated.
+- Preserve "quotes" and bullets.
+'* ]]
   [[ "$log" == *"model=openai-codex/gpt-5.5"* ]]
 }


### PR DESCRIPTION
## Summary

Closes #783.

- add `--message-file <path>` to `shimmer agent:dispatch`
- keep inline message dispatch backward-compatible
- fail clearly when no message, both message sources, or unreadable file are supplied
- document the option in task help and cover it with BATS tests

## Verification

- `mise trust && mise install`
- `bash -n .mise/tasks/agent/dispatch`
- `mise run test test/agent/agent.bats` (37/37)
- `git diff --check`
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:gum-table "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:or-true "$PWD"`
- `codebase lint:shellcheck "$PWD"`

Degraded: full `mise run test` currently fails in telemetry table/status tests because the test overlay cannot resolve the repo-managed `gum` shim (`No version is set for shim: gum`). The targeted `agent:dispatch` suite passes.
