### PR TITLE
ci(workflows): map mention wakes by GitHub login

### DIFF
--- a/.github/templates/agent-mention-detect.py
+++ b/.github/templates/agent-mention-detect.py
@@ -110,14 +110,65 @@ def extract_mentions(body: str) -> list[str]:
     return [match.group("mention").lower() for match in MENTION_PATTERN.finditer(body)]
 
 
+def json_env_map(name: str) -> dict[str, str]:
+    """Read a JSON object environment variable as lowercase string pairs."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as error:
+        print(f"{name} must be a JSON object: {error}", file=sys.stderr)
+        sys.exit(2)
+
+    if not isinstance(parsed, dict):
+        print(f"{name} must be a JSON object", file=sys.stderr)
+        sys.exit(2)
+
+    result: dict[str, str] = {}
+    for key, value in parsed.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            print(f"{name} entries must be string:string pairs", file=sys.stderr)
+            sys.exit(2)
+        if key.strip() and value.strip():
+            result[key.strip().lower()] = value.strip().lower()
+    return result
+
+
+def build_agent_mention_map(
+    roster: list[str], configured_logins: dict[str, str]
+) -> dict[str, str]:
+    """Map GitHub mention logins to agent names."""
+    missing = [agent for agent in roster if agent not in configured_logins]
+    if missing:
+        print(
+            "AGENT_GITHUB_LOGINS missing entries for: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    agent_by_mention: dict[str, str] = {}
+    for agent in roster:
+        login = configured_logins[agent]
+        if login in agent_by_mention and agent_by_mention[login] != agent:
+            print(
+                f"duplicate GitHub login @{login} for agents "
+                f"{agent_by_mention[login]} and {agent}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        agent_by_mention[login] = agent
+    return agent_by_mention
+
+
 def match_agents(
     mentions: list[str],
     roster: list[str],
-    handle_suffix: str,
+    agent_by_mention: dict[str, str],
     aliases: list[str],
 ) -> tuple[list[str], list[str]]:
     """Map mentions to agents while preserving roster order for wake outputs."""
-    agent_by_mention = {f"{agent}{handle_suffix}": agent for agent in roster}
     matched_agents: set[str] = set()
     matched_mentions: list[str] = []
 
@@ -188,7 +239,7 @@ def main() -> int:
     event = load_event(event_path)
     roster = csv_env("AGENT_ROSTER")
     aliases = csv_env("TEAM_ALIASES")
-    handle_suffix = os.environ.get("AGENT_HANDLE_SUFFIX", "-ricon").strip().lower()
+    configured_logins = json_env_map("AGENT_GITHUB_LOGINS")
     allowed_associations = {
         association.upper() for association in csv_env("ALLOWED_ASSOCIATIONS", "OWNER,MEMBER")
     }
@@ -205,7 +256,8 @@ def main() -> int:
     body = str(event_value(event, "comment", "body"))
     stripped_body = strip_non_waking_text(body)
     mentions = extract_mentions(stripped_body)
-    matched_agents, matched_mentions = match_agents(mentions, roster, handle_suffix, aliases)
+    agent_by_mention = build_agent_mention_map(roster, configured_logins)
+    matched_agents, matched_mentions = match_agents(mentions, roster, agent_by_mention, aliases)
 
     if not matched_agents:
         set_no_wake("no agent mention found outside quotes/code", roster)

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -164,6 +164,27 @@ csv_from_lines() {
   awk 'NF { printf "%s%s", sep, $0; sep="," } END { print "" }'
 }
 
+agent_metadata_is_valid() {
+  jq -e 'type == "array" and all(.[]; type == "object" and (.name | type == "string"))' >/dev/null 2>&1
+}
+
+agent_names_from_metadata() {
+  jq -r '.[].name'
+}
+
+agent_login_map_from_metadata() {
+  jq -e -c '
+    if any(.[]; ((.github_login // "") | length) == 0) then
+      error(
+        "agent:list JSON missing github_login for: "
+        + ([.[] | select(((.github_login // "") | length) == 0) | .name] | join(", "))
+      )
+    else
+      reduce .[] as $agent ({}; .[$agent.name] = $agent.github_login)
+    end
+  '
+}
+
 replace_file_token_from_file() {
   local target_file="$1"
   local token="$2"
@@ -345,10 +366,11 @@ generate_scheduled_workflow() {
 generate_mention_workflow() {
   local agents="$1"
   local roster_csv="$2"
-  local model="$3"
-  local allowed_associations="$4"
+  local login_map_json="$3"
+  local model="$4"
+  local allowed_associations="$5"
   local output_file="$OUTPUT_DIR/agent-mention.yml"
-  local model_tmp model_yaml
+  local model_tmp model_yaml login_map_tmp login_map_yaml
 
   expect_generated_workflow_file "agent-mention.yml"
 
@@ -356,6 +378,11 @@ generate_mention_workflow() {
   printf '%s' "$model" > "$model_tmp"
   model_yaml=$(yaml_scalar_from_file "$model_tmp")
   rm "$model_tmp"
+
+  login_map_tmp=$(mktemp)
+  printf '%s' "$login_map_json" > "$login_map_tmp"
+  login_map_yaml=$(yaml_scalar_from_file "$login_map_tmp")
+  rm "$login_map_tmp"
 
   mkdir -p "$SCRIPT_DIR"
   rm -f "$SCRIPT_DIR/agent-mention-detect.nu"
@@ -406,7 +433,7 @@ WORKFLOW_EOF
         id: detect
         env:
           AGENT_ROSTER: ${roster_csv}
-          AGENT_HANDLE_SUFFIX: "-ricon"
+          AGENT_GITHUB_LOGINS: ${login_map_yaml}
           # Team fanout stays disabled until fanout limits/jitter are designed explicitly.
           TEAM_ALIASES: ""
           ALLOWED_ASSOCIATIONS: ${allowed_associations}
@@ -470,7 +497,14 @@ cp "$MISE_PROJECT_ROOT/.github/templates/agent-run.yml" "$OUTPUT_DIR/agent-run.y
 echo "Generated: agent-run.yml"
 
 # Generate per-agent workflow files from agent:list
-AGENTS=$(mise run -q agent:list -- --ci 2>/dev/null) || AGENTS=""
+AGENT_METADATA_JSON=""
+if AGENT_METADATA_CANDIDATE=$(mise run -q agent:list -- --ci --json 2>/dev/null) && printf '%s' "$AGENT_METADATA_CANDIDATE" | agent_metadata_is_valid; then
+  AGENT_METADATA_JSON="$AGENT_METADATA_CANDIDATE"
+  AGENTS=$(printf '%s' "$AGENT_METADATA_JSON" | agent_names_from_metadata)
+else
+  AGENTS=$(mise run -q agent:list -- --ci 2>/dev/null) || AGENTS=""
+fi
+
 if [[ -n "$AGENTS" ]]; then
   echo "Discovered agents: $(echo "$AGENTS" | tr '\n' ' ')"
 
@@ -520,8 +554,17 @@ if [[ "$WORKFLOW_COUNT" -gt 0 ]]; then
 fi
 
 if [[ "$MENTION_ENABLED" == "true" ]]; then
+  if [[ -z "$AGENT_METADATA_JSON" ]]; then
+    echo "Error: mention_wakes requires agent:list --ci --json records with github_login for each wakeable agent." >&2
+    echo "       The line-oriented agent:list contract is still supported for manual/scheduled workflows only." >&2
+    exit 1
+  fi
   AGENT_CSV=$(printf '%s\n' "$AGENTS" | csv_from_lines)
-  generate_mention_workflow "$AGENTS" "$AGENT_CSV" "$MENTION_MODEL" "$MENTION_ALLOWED"
+  if ! AGENT_LOGIN_MAP=$(printf '%s' "$AGENT_METADATA_JSON" | agent_login_map_from_metadata); then
+    echo "Error: mention_wakes requires github_login for every agent in agent:list --ci --json." >&2
+    exit 1
+  fi
+  generate_mention_workflow "$AGENTS" "$AGENT_CSV" "$AGENT_LOGIN_MAP" "$MENTION_MODEL" "$MENTION_ALLOWED"
   echo "Generated: agent-mention.yml"
   echo "Generated: agent-mention-detect.py"
 elif [[ "$CHECK_MODE" != "true" ]]; then

--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -174,10 +174,13 @@ agent_names_from_metadata() {
 
 agent_login_map_from_metadata() {
   jq -e -c '
-    if any(.[]; ((.github_login // "") | length) == 0) then
+    def has_valid_login:
+      (.github_login | type) == "string" and (.github_login | length) > 0;
+
+    if any(.[]; has_valid_login | not) then
       error(
-        "agent:list JSON missing github_login for: "
-        + ([.[] | select(((.github_login // "") | length) == 0) | .name] | join(", "))
+        "agent:list JSON missing string github_login for: "
+        + ([.[] | select(has_valid_login | not) | .name] | join(", "))
       )
     else
       reduce .[] as $agent ({}; .[$agent.name] = $agent.github_login)

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -59,7 +59,7 @@ Mention wake fields:
 - `model` — provider-qualified model used for mention-triggered runs.
 - `allowed_associations` — GitHub comment author associations allowed to wake agents. For public-safety, prefer `[OWNER, MEMBER]`; do not include broader associations unless the repo intentionally accepts that risk.
 
-Mention wakes use the same roster as manual workflows: `mise run agent:list -- --ci`. The generated detector is a stdlib-only Python script run with the GitHub-hosted runner's `python3`, so target repos do not need to declare an extra detector runtime. The detector maps each agent name to the textual GitHub handle `@<agent>-ricon`, ignores naked aliases like `@quick`, strips blockquotes plus fenced/inline code, and leaves team fanout disabled.
+Mention wakes use the same roster as manual workflows, but they also need GitHub login metadata. Homes that enable `mention_wakes` must implement `mise run agent:list -- --ci --json` and include `github_login` for every wakeable agent. The older line-oriented `mise run agent:list -- --ci` contract remains supported for manual and scheduled workflows only. The generated detector is a stdlib-only Python script run with the GitHub-hosted runner's `python3`, so target repos do not need to declare an extra detector runtime. The detector matches configured GitHub logins, ignores naked agent-name aliases, strips blockquotes plus fenced/inline code, and leaves team fanout disabled.
 
 ## Managing Workflows
 
@@ -197,7 +197,7 @@ shimmer sessions:backup --dry-run <session-id>...
      allowed_associations: [OWNER, MEMBER]
    ```
 
-2. Ensure `agent:list --ci` exposes only agents that should be wakeable from that repo.
+2. Ensure `agent:list --ci` exposes only agents that should be wakeable from that repo, and `agent:list --ci --json` returns records with `name`, `ci`, and `github_login` for each of them.
 
 3. Generate and check workflows:
 

--- a/test/workflows/generate.bats
+++ b/test/workflows/generate.bats
@@ -6,7 +6,7 @@ setup() {
   load ../helpers
 }
 
-ROSTER="brownie c0da iris johnson junior k7r2 quick rho x1f9"
+ROSTER="tinef schmendrik nudnik"
 
 make_target_repo() {
   TARGET_REPO="$BATS_TEST_TMPDIR/target-repo"
@@ -21,15 +21,26 @@ EOF
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash
-printf 'quick\n'
-printf 'c0da\n'
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    cat <<'JSON'
+[
+  {"name":"tinef","ci":true,"github_login":"dreckbot"},
+  {"name":"schmendrik","ci":true,"github_login":"shmegegge"}
+]
+JSON
+    exit 0
+  fi
+done
+printf 'tinef\n'
+printf 'schmendrik\n'
 EOF
   chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
 
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: daily-probe
-    agent: quick
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 15 * * *"
@@ -96,6 +107,19 @@ agent_expected() {
   return 1
 }
 
+agent_login() {
+  case "$1" in
+    tinef) printf 'dreckbot\n' ;;
+    schmendrik) printf 'shmegegge\n' ;;
+    nudnik) printf 'kvetch-master\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+agent_login_map_json() {
+  jq -n -c '{tinef: "dreckbot", schmendrik: "shmegegge", nudnik: "kvetch-master"}'
+}
+
 run_detector() {
   local body="$1"
   local association="${2:-MEMBER}"
@@ -112,7 +136,7 @@ run_detector() {
       comment: {
         html_url: "https://github.com/ricon-family/fold/issues/72#issuecomment-test",
         author_association: $association,
-        user: {login: "quick-ricon"},
+        user: {login: "dreckbot"},
         body: $body
       }
     }' > "$event_path"
@@ -121,7 +145,7 @@ run_detector() {
   GITHUB_EVENT_PATH="$event_path" \
     GITHUB_OUTPUT="$DETECTOR_OUTPUT" \
     AGENT_ROSTER="${ROSTER// /,}" \
-    AGENT_HANDLE_SUFFIX="-ricon" \
+    AGENT_GITHUB_LOGINS="$(agent_login_map_json)" \
     TEAM_ALIASES="" \
     ALLOWED_ASSOCIATIONS="OWNER,MEMBER" \
     python3 "$SHIMMER_DIR/.github/templates/agent-mention-detect.py"
@@ -183,44 +207,124 @@ assert_detector_case() {
     return 1
   }
 
-  quick_workflow="$TARGET_REPO/.github/workflows/quick.yml"
-  c0da_workflow="$TARGET_REPO/.github/workflows/c0da.yml"
+  tinef_workflow="$TARGET_REPO/.github/workflows/tinef.yml"
+  schmendrik_workflow="$TARGET_REPO/.github/workflows/schmendrik.yml"
   scheduled_workflow="$TARGET_REPO/.github/workflows/daily-probe.yml"
   mention_workflow="$TARGET_REPO/.github/workflows/agent-mention.yml"
   mention_script="$TARGET_REPO/.github/scripts/agent-mention-detect.py"
 
-  [ -f "$quick_workflow" ]
-  [ -f "$c0da_workflow" ]
+  [ -f "$tinef_workflow" ]
+  [ -f "$schmendrik_workflow" ]
   [ -f "$scheduled_workflow" ]
   [ -f "$mention_workflow" ]
   [ -f "$mention_script" ]
 
-  [ "$(yq -r '.on.workflow_dispatch.inputs.message.required' "$quick_workflow")" = "true" ]
-  [ "$(yq -r '.on.workflow_call.inputs.message.required' "$quick_workflow")" = "true" ]
-  [ "$(yq -r '.on.workflow_call.secrets.QUICK_GITHUB_PAT.required' "$quick_workflow")" = "true" ]
-  [ "$(yq -r '.jobs.run.uses' "$quick_workflow")" = "./.github/workflows/agent-run.yml" ]
-  [ "$(yq -r '.jobs.run.with.agent' "$quick_workflow")" = "quick" ]
-  [ "$(yq -r '.jobs.run.secrets.AGENT_GITHUB_PAT' "$quick_workflow")" = '${{ secrets.QUICK_GITHUB_PAT }}' ]
-  [ "$(yq -r '.jobs.run.secrets.AGENT_B2_ENDPOINT' "$quick_workflow")" = '${{ secrets.QUICK_B2_ENDPOINT }}' ]
+  [ "$(yq -r '.on.workflow_dispatch.inputs.message.required' "$tinef_workflow")" = "true" ]
+  [ "$(yq -r '.on.workflow_call.inputs.message.required' "$tinef_workflow")" = "true" ]
+  [ "$(yq -r '.on.workflow_call.secrets.TINEF_GITHUB_PAT.required' "$tinef_workflow")" = "true" ]
+  [ "$(yq -r '.jobs.run.uses' "$tinef_workflow")" = "./.github/workflows/agent-run.yml" ]
+  [ "$(yq -r '.jobs.run.with.agent' "$tinef_workflow")" = "tinef" ]
+  [ "$(yq -r '.jobs.run.secrets.AGENT_GITHUB_PAT' "$tinef_workflow")" = '${{ secrets.TINEF_GITHUB_PAT }}' ]
+  [ "$(yq -r '.jobs.run.secrets.AGENT_B2_ENDPOINT' "$tinef_workflow")" = '${{ secrets.TINEF_B2_ENDPOINT }}' ]
 
-  [ "$(yq -r '.on.workflow_call.secrets.C0DA_GITHUB_PAT.required' "$c0da_workflow")" = "true" ]
-  [ "$(yq -r '.jobs.run.secrets.AGENT_GITHUB_PAT' "$c0da_workflow")" = '${{ secrets.C0DA_GITHUB_PAT }}' ]
+  [ "$(yq -r '.on.workflow_call.secrets.SCHMENDRIK_GITHUB_PAT.required' "$schmendrik_workflow")" = "true" ]
+  [ "$(yq -r '.jobs.run.secrets.AGENT_GITHUB_PAT' "$schmendrik_workflow")" = '${{ secrets.SCHMENDRIK_GITHUB_PAT }}' ]
 
-  [ "$(yq -r '.jobs.run.uses' "$scheduled_workflow")" = "./.github/workflows/quick.yml" ]
+  [ "$(yq -r '.jobs.run.uses' "$scheduled_workflow")" = "./.github/workflows/tinef.yml" ]
   [ "$(yq -r '.jobs.run.secrets' "$scheduled_workflow")" = "inherit" ]
   ! grep -q 'AGENT_GITHUB_PAT' "$scheduled_workflow"
 
   [ "$(yq -r '.on.issue_comment.types[0]' "$mention_workflow")" = "created" ]
   ! grep -q 'jdx/mise-action' "$mention_workflow"
-  [ "$(yq -r '.jobs.detect.outputs.agent_quick' "$mention_workflow")" = '${{ steps.detect.outputs.agent_quick }}' ]
-  [ "$(yq -r '.jobs.detect.outputs.agent_c0da' "$mention_workflow")" = '${{ steps.detect.outputs.agent_c0da }}' ]
-  [ "$(yq -r '.jobs."wake-quick".uses' "$mention_workflow")" = "./.github/workflows/quick.yml" ]
-  [ "$(yq -r '.jobs."wake-c0da".uses' "$mention_workflow")" = "./.github/workflows/c0da.yml" ]
-  [ "$(yq -r '.jobs."wake-quick".secrets' "$mention_workflow")" = "inherit" ]
-  [ "$(yq -r '.jobs."wake-quick".with.model' "$mention_workflow")" = "openai-codex/gpt-5.5" ]
-  [ "$(yq -r '.jobs.detect.steps[] | select(.id == "detect") | .env.AGENT_ROSTER' "$mention_workflow")" = "quick,c0da" ]
+  [ "$(yq -r '.jobs.detect.outputs.agent_tinef' "$mention_workflow")" = '${{ steps.detect.outputs.agent_tinef }}' ]
+  [ "$(yq -r '.jobs.detect.outputs.agent_schmendrik' "$mention_workflow")" = '${{ steps.detect.outputs.agent_schmendrik }}' ]
+  [ "$(yq -r '.jobs."wake-tinef".uses' "$mention_workflow")" = "./.github/workflows/tinef.yml" ]
+  [ "$(yq -r '.jobs."wake-schmendrik".uses' "$mention_workflow")" = "./.github/workflows/schmendrik.yml" ]
+  [ "$(yq -r '.jobs."wake-tinef".secrets' "$mention_workflow")" = "inherit" ]
+  [ "$(yq -r '.jobs."wake-tinef".with.model' "$mention_workflow")" = "openai-codex/gpt-5.5" ]
+  [ "$(yq -r '.jobs.detect.steps[] | select(.id == "detect") | .env.AGENT_ROSTER' "$mention_workflow")" = "tinef,schmendrik" ]
+  yq -r '.jobs.detect.steps[] | select(.id == "detect") | .env.AGENT_GITHUB_LOGINS' "$mention_workflow" \
+    | jq -e '.tinef == "dreckbot" and .schmendrik == "shmegegge"' >/dev/null
   [ "$(yq -r '.jobs.detect.steps[] | select(.id == "detect") | .env.ALLOWED_ASSOCIATIONS' "$mention_workflow")" = "OWNER,MEMBER" ]
   [ "$(yq -r '.jobs.detect.steps[] | select(.id == "detect") | .run' "$mention_workflow")" = "python3 .github/scripts/agent-mention-detect.py" ]
+}
+
+@test "workflows:generate requires JSON GitHub logins for mention wakes" {
+  make_target_repo
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+printf 'tinef\n'
+printf 'schmendrik\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mention_wakes requires agent:list --ci --json records with github_login"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    printf '[{"name":"tinef","ci":true}]\n'
+    exit 0
+  fi
+done
+printf 'tinef\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mention_wakes requires github_login for every agent"* ]]
+}
+
+@test "workflows:generate uses agent:list JSON GitHub logins for mention wakes" {
+  make_target_repo
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    cat <<'JSON'
+[
+  {"name":"nudnik","ci":true,"github_login":"kvetch-master"},
+  {"name":"tinef","ci":true,"github_login":"dreckbot"}
+]
+JSON
+    exit 0
+  fi
+done
+printf 'nudnik\n'
+printf 'tinef\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
+workflows:
+  - name: daily-probe
+    agent: nudnik
+    model: openai-codex/gpt-5.5
+    schedule:
+      - "0 15 * * *"
+    message: "Review the daily probe."
+mention_wakes:
+  enabled: true
+  model: openai-codex/gpt-5.5
+EOF
+
+  run generate_workflows
+  [ "$status" -eq 0 ] || {
+    echo "$output" >&2
+    return 1
+  }
+
+  mention_workflow="$TARGET_REPO/.github/workflows/agent-mention.yml"
+  [ "$(yq -r '.jobs.detect.steps[] | select(.id == "detect") | .env.AGENT_ROSTER' "$mention_workflow")" = "nudnik,tinef" ]
+  yq -r '.jobs.detect.steps[] | select(.id == "detect") | .env.AGENT_GITHUB_LOGINS' "$mention_workflow" \
+    | jq -e '.nudnik == "kvetch-master" and .tinef == "dreckbot"' >/dev/null
+  [ "$(yq -r '.jobs."wake-nudnik".uses' "$mention_workflow")" = "./.github/workflows/nudnik.yml" ]
 }
 
 @test "workflows:generate --check covers mention workflow and detector script" {
@@ -253,7 +357,7 @@ assert_detector_case() {
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: weird-message
-    agent: quick
+    agent: tinef
     model: huggingface/moonshotai/Kimi-K2.6:novita
     schedule:
       - "0 15 * * *"
@@ -282,7 +386,7 @@ EOF
   [ "$(yq -r '.jobs.run' "$scheduled_workflow")" != "null" ]
   [ "$(yq -r '.jobs.pwn' "$scheduled_workflow")" = "null" ]
   [ "$(yq -r '.permissions' "$scheduled_workflow")" = "null" ]
-  [ "$(yq -r '.jobs."wake-quick".with.model' "$mention_workflow")" = "huggingface/moonshotai/Kimi-K2.6:novita" ]
+  [ "$(yq -r '.jobs."wake-tinef".with.model' "$mention_workflow")" = "huggingface/moonshotai/Kimi-K2.6:novita" ]
 }
 
 @test "workflows:generate rejects unsafe or duplicate agent names" {
@@ -290,7 +394,7 @@ EOF
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash
-printf 'quick\n'
+printf 'tinef\n'
 printf '../scripts/owned\n'
 EOF
   chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
@@ -311,14 +415,14 @@ EOF
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash
-printf 'quick\n'
-printf 'quick\n'
+printf 'tinef\n'
+printf 'tinef\n'
 EOF
   chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
 
   run generate_workflows
   [ "$status" -ne 0 ]
-  [[ "$output" == *"generated workflow name 'quick' from agent:list entry 'quick' conflicts"* ]]
+  [[ "$output" == *"generated workflow name 'tinef' from agent:list entry 'tinef' conflicts"* ]]
 }
 
 @test "workflows:generate rejects scheduled workflow name collisions and unknown agents" {
@@ -326,22 +430,22 @@ EOF
 
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
-  - name: quick
-    agent: quick
+  - name: tinef
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 15 * * *"
-    message: "Do not overwrite the quick wrapper."
+    message: "Do not overwrite the tinef wrapper."
 EOF
 
   run generate_workflows
   [ "$status" -ne 0 ]
-  [[ "$output" == *"generated workflow name 'quick' from workflow 'quick' conflicts"* ]]
+  [[ "$output" == *"generated workflow name 'tinef' from workflow 'tinef' conflicts"* ]]
 
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: agent-run
-    agent: quick
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 15 * * *"
@@ -355,13 +459,13 @@ EOF
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: repeated
-    agent: quick
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 15 * * *"
     message: "First."
   - name: repeated
-    agent: quick
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 16 * * *"
@@ -374,14 +478,14 @@ EOF
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash
-printf 'quick\n'
+printf 'tinef\n'
 EOF
   chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
 
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: daily-probe
-    agent: c0da
+    agent: schmendrik
     model: openai-codex/gpt-5.5
     schedule:
       - "0 15 * * *"
@@ -390,7 +494,7 @@ EOF
 
   run generate_workflows
   [ "$status" -ne 0 ]
-  [[ "$output" == *"workflow 'daily-probe' references agent 'c0da', but agent:list did not report that agent"* ]]
+  [[ "$output" == *"workflow 'daily-probe' references agent 'schmendrik', but agent:list did not report that agent"* ]]
 }
 
 @test "workflows:generate removes stale mention files when mention_wakes is disabled" {
@@ -400,7 +504,7 @@ EOF
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: daily-probe
-    agent: quick
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 15 * * *"
@@ -434,7 +538,7 @@ EOF
   generate_workflows
 
   [ -f "$TARGET_REPO/.github/workflows/daily-probe.yml" ]
-  [ -f "$TARGET_REPO/.github/workflows/c0da.yml" ]
+  [ -f "$TARGET_REPO/.github/workflows/schmendrik.yml" ]
 
   cat > "$TARGET_REPO/.github/workflows/manual.yml" <<'EOF'
 name: manual
@@ -445,7 +549,7 @@ EOF
   cat > "$TARGET_REPO/workflows.yaml" <<'EOF'
 workflows:
   - name: renamed-probe
-    agent: quick
+    agent: tinef
     model: openai-codex/gpt-5.5
     schedule:
       - "0 16 * * *"
@@ -454,14 +558,14 @@ EOF
 
   cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
 #!/usr/bin/env bash
-printf 'quick\n'
+printf 'tinef\n'
 EOF
   chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
 
   run generate_workflows --check
   [ "$status" -ne 0 ]
   [[ "$output" == *"Unexpected: .github/workflows/daily-probe.yml (stale generated workflow"* ]]
-  [[ "$output" == *"Unexpected: .github/workflows/c0da.yml (stale generated workflow"* ]]
+  [[ "$output" == *"Unexpected: .github/workflows/schmendrik.yml (stale generated workflow"* ]]
 
   run generate_workflows
   [ "$status" -eq 0 ] || {
@@ -470,26 +574,27 @@ EOF
   }
 
   [ -f "$TARGET_REPO/.github/workflows/renamed-probe.yml" ]
-  [ -f "$TARGET_REPO/.github/workflows/quick.yml" ]
+  [ -f "$TARGET_REPO/.github/workflows/tinef.yml" ]
   [ ! -f "$TARGET_REPO/.github/workflows/daily-probe.yml" ]
-  [ ! -f "$TARGET_REPO/.github/workflows/c0da.yml" ]
+  [ ! -f "$TARGET_REPO/.github/workflows/schmendrik.yml" ]
   [ -f "$TARGET_REPO/.github/workflows/manual.yml" ]
 }
 
 @test "agent mention detector ignores non-waking text and maps handles" {
   local agent
   for agent in $ROSTER; do
-    assert_detector_case "$agent real handle" "@$agent-ricon hello" MEMBER "$agent"
+    assert_detector_case "$agent configured login" "@$(agent_login "$agent") hello" MEMBER "$agent"
   done
 
-  assert_detector_case "multiple individual handles" "@quick-ricon @c0da-ricon" MEMBER c0da quick
-  assert_detector_case "naked quick does not match" "@quick hello" MEMBER
+  assert_detector_case "configured login is exact" "@tinef-gh hello" MEMBER
+  assert_detector_case "multiple individual handles" "@dreckbot @shmegegge" MEMBER tinef schmendrik
+  assert_detector_case "naked tinef does not match" "@tinef hello" MEMBER
   assert_detector_case "naked agents does not match" "@agents hello" MEMBER
-  assert_detector_case "team alias disabled" "@ricon-family/agents hello" MEMBER
-  assert_detector_case "quoted handle ignored" "> @quick-ricon quoted" MEMBER
-  assert_detector_case "fenced handle ignored" $'```\n@quick-ricon fenced\n```' MEMBER
-  assert_detector_case "inline code handle ignored" 'Type `@quick-ricon` only when waking quick.' MEMBER
-  assert_detector_case "nested path does not partial match" "@quick-ricon/foo no" MEMBER
-  assert_detector_case "collaborator association ignored" "@quick-ricon hello" COLLABORATOR
-  assert_detector_case "untrusted association ignored" "@quick-ricon hello" NONE
+  assert_detector_case "team alias disabled" "@faketown/agents hello" MEMBER
+  assert_detector_case "quoted handle ignored" "> @dreckbot quoted" MEMBER
+  assert_detector_case "fenced handle ignored" $'```\n@dreckbot fenced\n```' MEMBER
+  assert_detector_case "inline code handle ignored" 'Type `@dreckbot` only when waking tinef.' MEMBER
+  assert_detector_case "nested path does not partial match" "@dreckbot/foo no" MEMBER
+  assert_detector_case "collaborator association ignored" "@dreckbot hello" COLLABORATOR
+  assert_detector_case "untrusted association ignored" "@dreckbot hello" NONE
 }

--- a/test/workflows/generate.bats
+++ b/test/workflows/generate.bats
@@ -278,6 +278,22 @@ EOF
   run generate_workflows
   [ "$status" -ne 0 ]
   [[ "$output" == *"mention_wakes requires github_login for every agent"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    printf '[{"name":"tinef","ci":true,"github_login":["dreckbot"]}]\n'
+    exit 0
+  fi
+done
+printf 'tinef\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mention_wakes requires github_login for every agent"* ]]
 }
 
 @test "workflows:generate uses agent:list JSON GitHub logins for mention wakes" {


### PR DESCRIPTION
## Summary

- Lets `shimmer workflows:generate` consume `agent:list --ci --json` metadata when a home provides it.
- Generates an explicit `AGENT_GITHUB_LOGINS` map for mention wakes instead of only guessing `@<agent>-ricon`.
- Updates the mention detector to match configured GitHub logins. `mention_wakes` now requires `agent:list --ci --json` with `github_login` for each wakeable agent; line-oriented `agent:list --ci` remains supported for manual/scheduled workflows only.
- Documents the JSON metadata contract.

## Why

Fold now includes `baby-joel` in mention wakes, but his GitHub login is `baby-joel`, not `baby-joel-ricon`. The generated detector needs a real agent-name → GitHub-login map before we propagate mention wakes beyond fold. This also removes the old `-ricon` suffix assumption from shimmer core.

## Validation

```text
mise run test test/workflows/generate.bats  # 9/9 passing
mise run test                               # 175/175 passing

codebase lints run individually because this repo has lint:* tasks but no lint aggregate:
- lint:mise-settings
- lint:gum-table
- lint:bats-test-helper
- lint:bats-test-task
- lint:mcr-scope
- lint:or-true
- lint:shellcheck
```

