### PR TITLE
fix(workflows): require string GitHub login metadata

### DIFF
--- a/.mise/tasks/workflows/generate
+++ b/.mise/tasks/workflows/generate
@@ -174,10 +174,13 @@ agent_names_from_metadata() {
 
 agent_login_map_from_metadata() {
   jq -e -c '
-    if any(.[]; ((.github_login // "") | length) == 0) then
+    def has_valid_login:
+      (.github_login | type) == "string" and (.github_login | length) > 0;
+
+    if any(.[]; has_valid_login | not) then
       error(
-        "agent:list JSON missing github_login for: "
-        + ([.[] | select(((.github_login // "") | length) == 0) | .name] | join(", "))
+        "agent:list JSON missing string github_login for: "
+        + ([.[] | select(has_valid_login | not) | .name] | join(", "))
       )
     else
       reduce .[] as $agent ({}; .[$agent.name] = $agent.github_login)

--- a/test/workflows/generate.bats
+++ b/test/workflows/generate.bats
@@ -278,6 +278,22 @@ EOF
   run generate_workflows
   [ "$status" -ne 0 ]
   [[ "$output" == *"mention_wakes requires github_login for every agent"* ]]
+
+  cat > "$TARGET_REPO/.mise/tasks/agent/list" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    printf '[{"name":"tinef","ci":true,"github_login":["dreckbot"]}]\n'
+    exit 0
+  fi
+done
+printf 'tinef\n'
+EOF
+  chmod +x "$TARGET_REPO/.mise/tasks/agent/list"
+
+  run generate_workflows
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mention_wakes requires github_login for every agent"* ]]
 }
 
 @test "workflows:generate uses agent:list JSON GitHub logins for mention wakes" {


### PR DESCRIPTION
Fix-it for KnickKnackLabs/shimmer#786.

The latest delta correctly makes mention wakes require explicit GitHub login metadata, but the generator only checked that `github_login` had non-zero `length`. JSON arrays/objects can satisfy that and generate `AGENT_GITHUB_LOGINS` values that the detector later rejects at runtime (`entries must be string:string pairs`).

This makes the generator reject non-string or empty `github_login` values up front and adds a regression with the new fake-name fixture.

Validation:
- `bash -n .mise/tasks/workflows/generate`
- `mise run test test/workflows/generate.bats` — 10/10 passed
- `git diff --check`
