### PR TITLE
fix: remove agent identity prompt contract

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -263,8 +263,8 @@ jobs:
 
           echo "Working directory: $(pwd)"
 
-          # shimmer as sets identity env vars (AGENT_IDENTITY, GIT_AUTHOR_*, GH_TOKEN, etc.)
-          # shimmer agent --headless delegates to sessions run for execution
+          # shimmer as sets selected-agent env vars (GIT_AUTHOR_*, GH_TOKEN, etc.)
+          # shimmer agent --headless delegates to sessions wake for execution
           eval "$(shimmer as "$AGENT")"
 
           # Configure gh as git credential helper so shiv can clone private repos

--- a/.mise/tasks/_agent-preview
+++ b/.mise/tasks/_agent-preview
@@ -5,61 +5,8 @@
 set -eo pipefail
 
 AGENT="$1"
-AGENT_HOME_DIR="$2"
 
 echo "$AGENT@ricon.family"
 echo ""
-
-# Identity snippet via the home's agent:identity task. Empty on missing task
-# or other failure — the file check below handles the absence gracefully.
-IDENTITY_FILE=$(mise -C "$AGENT_HOME_DIR" run -q agent:identity "$AGENT" 2>/dev/null) || IDENTITY_FILE=""
-if [ -n "$IDENTITY_FILE" ] && [ -f "$IDENTITY_FILE" ]; then
-  # Skip frontmatter, show first 8 content lines
-  in_fm=false past_fm=false count=0
-  while IFS= read -r line; do
-    if ! $past_fm; then
-      if [[ "$line" == "---" ]]; then
-        if $in_fm; then past_fm=true; fi
-        in_fm=true
-        continue
-      fi
-      $in_fm && continue
-      past_fm=true
-    fi
-    [ -z "$line" ] && [ "$count" -eq 0 ] && continue
-    echo "$line"
-    count=$((count + 1))
-    [ "$count" -ge 8 ] && break
-  done < "$IDENTITY_FILE"
-  echo ""
-fi
-
-# Workspace info
-WORKSPACE="$HOME/agents/$AGENT"
-if [ -d "$WORKSPACE" ]; then
-  # Home repo / zettelkasten
-  if [ -d "$WORKSPACE/home" ]; then
-    ZETTEL_DIR="$WORKSPACE/home"
-  else
-    ZETTEL_DIR="$WORKSPACE/zettelkasten"
-  fi
-  if [ -d "$ZETTEL_DIR" ]; then
-    NOTE_COUNT=$(find "$ZETTEL_DIR/notes" -mindepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
-    SESSION_COUNT=$(find "$ZETTEL_DIR/sessions" -mindepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
-    echo "Home repo: ${NOTE_COUNT} notes, ${SESSION_COUNT} sessions"
-  fi
-
-  # Repos in workspace
-  REPOS=$(find "$WORKSPACE" -maxdepth 2 -name ".git" -type d 2>/dev/null | while read -r gitdir; do
-    basename "$(dirname "$gitdir")"
-  done | sort)
-  if [ -n "$REPOS" ]; then
-    echo ""
-    echo "Repos:"
-    echo "$REPOS" | while read -r repo; do
-      echo "  $repo"
-    done
-  fi
-else
-  echo "(no workspace)"
-fi
+echo "Preview placeholder"
+echo "Future preview should show operator-useful agent context here, such as recent sessions, active desks, home readiness, and current work."

--- a/.mise/tasks/agent/_default
+++ b/.mise/tasks/agent/_default
@@ -24,11 +24,6 @@ if [ -z "$GIT_AUTHOR_NAME" ]; then
   exit 1
 fi
 
-if [ -z "$AGENT_IDENTITY" ]; then
-  echo "AGENT_IDENTITY not set. Run: eval \$(shimmer as <agent>)" >&2
-  exit 1
-fi
-
 # Headless mode requires a message
 if [ "$HEADLESS" = "true" ] && [ -z "$MESSAGE" ]; then
   echo "Error: --headless requires a message" >&2
@@ -54,8 +49,8 @@ if [ "$HEADLESS" = "true" ]; then
   CWD="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-.}}"
   SESSION_NAME="${GIT_AUTHOR_NAME}-headless-$(date +%s)"
 
-  # Prepare the long-lived agent runtime without discarding identity-bearing
-  # environment such as GIT_AUTHOR_NAME or AGENT_IDENTITY.
+  # Prepare the long-lived agent runtime without discarding selected-agent
+  # environment such as GIT_AUTHOR_NAME.
   shimmer_prepare_agent_child_env
 
   if ! command -v sessions &>/dev/null; then
@@ -87,10 +82,7 @@ else
     exit 1
   fi
 
-  ARGS=(--append-system-prompt "$AGENT_IDENTITY
-
-## Session Context
-This is a local interactive session started via \`shimmer agent\`. A human is present and directing you.")
+  ARGS=()
   [ -n "$SESSION" ] && ARGS+=(--session "$SESSION")
   [ -n "$MESSAGE" ] && ARGS+=("$MESSAGE")
   exec "$HARNESS" "${ARGS[@]}"

--- a/.mise/tasks/as
+++ b/.mise/tasks/as
@@ -13,7 +13,6 @@ CALLER_DIR="${SHIMMER_CALLER_PWD:-${CALLER_PWD:-$(pwd)}}"
 AGENT_HOME_DIR=$(git -C "$CALLER_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CALLER_DIR")
 
 AGENT="${usage_agent:-}"
-IDENTITY=""
 AGENTS_ROOT="${SHIMMER_AGENTS_ROOT:-$HOME/agents}"
 
 # Prefer the caller home's authoritative agent:list task. When a concrete
@@ -99,16 +98,6 @@ shell_quote() {
   printf "'%s'" "$value"
 }
 
-ansi_c_quote() {
-  local value="$1"
-  value=${value//\\/\\\\}
-  value=${value//$'\n'/\\n}
-  value=${value//$'\r'/\\r}
-  value=${value//$'\t'/\\t}
-  value=${value//\'/\\\'}
-  printf "\$'%s'" "$value"
-}
-
 emit() {
   printf '%s;\n' "$1"
 }
@@ -146,13 +135,13 @@ if ! echo "$AGENTS" | grep -qx "$AGENT"; then
   exit 1
 fi
 
-# Clear all identity vars first to prevent stale values from a previous
+# Clear vars managed by this command first to prevent stale values from a previous
 # `shimmer as` from leaking through if any resolution step below fails.
 # This must come before PAT resolution — if secrets lookup exits early,
-# eval still clears the previous session's vars. GIT_CONFIG_* is intentionally
-# not cleared: caller-provided transient config must be preserved, and shimmer
-# appends later identity overrides below so the active agent wins.
-emit "unset AGENT_IDENTITY B2_BUCKET"
+# eval still clears the previous session's managed vars. GIT_CONFIG_* is
+# intentionally not cleared: caller-provided transient config must be preserved,
+# and shimmer appends later identity overrides below so the active agent wins.
+emit "unset B2_BUCKET"
 emit "unset GH_HOST GH_TOKEN"
 emit "unset GIT_AUTHOR_EMAIL GIT_COMMITTER_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_NAME"
 emit "unset AGENT_HOME"
@@ -196,20 +185,6 @@ emit "export GIT_CONFIG_COUNT=$(shell_quote "$NEXT_GIT_CONFIG_INDEX")"
 B2_BUCKET=$(secrets get "$AGENT/b2-bucket" 2>/dev/null) || B2_BUCKET=""
 if [ -n "$B2_BUCKET" ]; then
   emit "export B2_BUCKET=$(shell_quote "$B2_BUCKET")"
-fi
-
-# Resolve agent identity content via the home's agent:identity task.
-# Agent home may not provide an agent:identity task — the conditional below
-# prints a notice in that case.
-IDENTITY=$(mise -C "$AGENT_HOME_DIR" run -q agent:identity "$AGENT" 2>/dev/null) || IDENTITY=""
-if [ -n "$IDENTITY" ]; then
-  # Export as encoded ANSI-C quoting so unquoted command substitution
-  # (`eval $(shimmer as agent)`) cannot collapse literal newlines inside
-  # AGENT_IDENTITY before eval sees the command stream.
-  emit "export AGENT_IDENTITY=$(ansi_c_quote "$IDENTITY")"
-else
-  echo "# Note: agent home has no agent:identity task — AGENT_IDENTITY not set" >&2
-  echo "# (was cleared above to prevent stale values)" >&2
 fi
 
 # Print info to stderr so it doesn't interfere with eval

--- a/test/agent-env/agent-env.bats
+++ b/test/agent-env/agent-env.bats
@@ -7,10 +7,9 @@ setup() {
   source "$SHIMMER_DIR/lib/agent-env.sh"
 }
 
-@test "agent env: preserves identity while scrubbing task-scoped env" {
+@test "agent env: preserves selected-agent auth while scrubbing task-scoped env" {
   export GIT_AUTHOR_NAME="c0da"
   export GIT_AUTHOR_EMAIL="c0da@ricon.family"
-  export AGENT_IDENTITY="You are c0da."
   export GH_TOKEN="ghp_identity_token"
   export CALLER_PWD="/stale/caller"
   export SHIMMER_CALLER_PWD="/stale/shimmer"
@@ -27,7 +26,6 @@ setup() {
 
   [ "${GIT_AUTHOR_NAME}" = "c0da" ]
   [ "${GIT_AUTHOR_EMAIL}" = "c0da@ricon.family" ]
-  [ "${AGENT_IDENTITY}" = "You are c0da." ]
   [ "${GH_TOKEN}" = "ghp_identity_token" ]
   [ -z "${CALLER_PWD-}" ]
   [ -z "${SHIMMER_CALLER_PWD-}" ]

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -103,7 +103,6 @@ setup() {
 
 @test "headless: fails without GIT_AUTHOR_NAME" {
   unset GIT_AUTHOR_NAME
-  export AGENT_IDENTITY="test"
   mock_shimmer
 
   run shimmer agent --headless "do something"
@@ -111,14 +110,14 @@ setup() {
   [[ "$output" == *"No agent identity"* ]]
 }
 
-@test "headless: fails without AGENT_IDENTITY" {
-  export GIT_AUTHOR_NAME="test-agent"
-  unset AGENT_IDENTITY
+@test "headless: does not require legacy identity env" {
+  setup_agent
+  mock_sessions_binary
   mock_shimmer
 
-  run shimmer agent --headless "do something"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"AGENT_IDENTITY not set"* ]]
+  run shimmer agent --headless --model "openai-codex/gpt-5.5" "do something"
+  [ "$status" -eq 0 ]
+  grep -q "^wake mock-session-id-001 --headless --message do something --model openai-codex/gpt-5.5" "$SESSIONS_LOG"
 }
 
 # --- Headless mode ---
@@ -180,7 +179,6 @@ MOCK
     MISE_CONFIG_ROOT="$SHIMMER_DIR" \
     GIT_AUTHOR_NAME="test-agent" \
     GIT_AUTHOR_EMAIL="test-agent@ricon.family" \
-    AGENT_IDENTITY="You are test-agent." \
     usage_headless="true" \
     usage_model="openai-codex/gpt-5.5" \
     usage_message="review the PR" \
@@ -260,7 +258,6 @@ MOCK
   grep -q '^usage_message=$' "$SESSIONS_ENV_LOG"
   grep -q '^GIT_AUTHOR_NAME=test-agent$' "$SESSIONS_ENV_LOG"
   grep -q '^GIT_AUTHOR_EMAIL=test-agent@ricon.family$' "$SESSIONS_ENV_LOG"
-  grep -q '^AGENT_IDENTITY=You are test-agent\.$' "$SESSIONS_ENV_LOG"
   grep -q '^PATH=.*/before' "$SESSIONS_ENV_LOG"
   ! grep -q "^PATH=.*$stale_sessions" "$SESSIONS_ENV_LOG"
   ! grep -q "^PATH=.*$current_sessions" "$SESSIONS_ENV_LOG"
@@ -322,7 +319,7 @@ MOCK
 
 # --- Interactive mode ---
 
-@test "interactive: calls harness with agent identity" {
+@test "interactive: calls harness without prompt injection" {
   setup_agent
   mock_harness
   mock_shimmer
@@ -330,8 +327,7 @@ MOCK
   run shimmer agent
   [ "$status" -eq 0 ]
 
-  # harness was called with --append-system-prompt
-  grep -q -- "--append-system-prompt" "$HARNESS_LOG"
+  ! grep -q -- "--append-system-prompt" "$HARNESS_LOG"
 }
 
 @test "interactive: ignores inherited usage env from parent task" {
@@ -345,7 +341,7 @@ MOCK
   run shimmer agent
   [ "$status" -eq 0 ]
 
-  grep -q -- "--append-system-prompt" "$HARNESS_LOG"
+  ! grep -q -- "--append-system-prompt" "$HARNESS_LOG"
   ! grep -q "stale parent message" "$HARNESS_LOG"
 }
 
@@ -406,7 +402,6 @@ MOCK
   grep -q '^usage_message=$' "$HARNESS_ENV_LOG"
   grep -q '^GIT_AUTHOR_NAME=test-agent$' "$HARNESS_ENV_LOG"
   grep -q '^GIT_AUTHOR_EMAIL=test-agent@ricon.family$' "$HARNESS_ENV_LOG"
-  grep -q '^AGENT_IDENTITY=You are test-agent\.$' "$HARNESS_ENV_LOG"
   grep -q '^PATH=.*/before' "$HARNESS_ENV_LOG"
   ! grep -q "^PATH=.*$stale_sessions" "$HARNESS_ENV_LOG"
   ! grep -q "^PATH=.*$current_sessions" "$HARNESS_ENV_LOG"

--- a/test/agent/helpers.bash
+++ b/test/agent/helpers.bash
@@ -7,13 +7,12 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../ci" && pwd)/helpers.bash"
 
-# Set up minimal agent identity environment.
+# Set up minimal selected-agent environment.
 # Usage: setup_agent [name]
 setup_agent() {
   local name="${1:-test-agent}"
   export GIT_AUTHOR_NAME="$name"
   export GIT_AUTHOR_EMAIL="${name}@ricon.family"
-  export AGENT_IDENTITY="You are ${name}."
   export SHIMMER_CALLER_PWD="$BATS_TEST_TMPDIR"
 }
 
@@ -42,7 +41,6 @@ echo "$@" >> "$SESSIONS_LOG"
   printf 'usage_message=%s\n' "${usage_message-}"
   printf 'GIT_AUTHOR_NAME=%s\n' "${GIT_AUTHOR_NAME-}"
   printf 'GIT_AUTHOR_EMAIL=%s\n' "${GIT_AUTHOR_EMAIL-}"
-  printf 'AGENT_IDENTITY=%s\n' "${AGENT_IDENTITY-}"
   printf 'PATH=%s\n' "${PATH-}"
 } >> "${SESSIONS_ENV_LOG:-$SESSIONS_LOG.env}"
 case "$1" in
@@ -82,7 +80,6 @@ echo "$@" >> "$HARNESS_LOG"
   printf 'usage_message=%s\n' "${usage_message-}"
   printf 'GIT_AUTHOR_NAME=%s\n' "${GIT_AUTHOR_NAME-}"
   printf 'GIT_AUTHOR_EMAIL=%s\n' "${GIT_AUTHOR_EMAIL-}"
-  printf 'AGENT_IDENTITY=%s\n' "${AGENT_IDENTITY-}"
   printf 'PATH=%s\n' "${PATH-}"
 } >> "${HARNESS_ENV_LOG:-$HARNESS_LOG.env}"
 MOCK

--- a/test/as/as.bats
+++ b/test/as/as.bats
@@ -18,13 +18,6 @@ teardown() {
   echo "$output" | grep -qx "bob"
 }
 
-@test "discovery: agent:identity returns content, not path" {
-  setup_test_home "alice"
-  run mise -C "$TEST_HOME" run -q agent:identity alice
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"You are alice."* ]]
-}
-
 # ============ Full as flow (secrets binary mocked) ============
 
 @test "as: test helper clears ambient Git config overrides" {
@@ -63,15 +56,14 @@ teardown() {
   echo "$output" | grep -q "$(basename "$TEST_HOME")"
 }
 
-@test "as: AGENT_IDENTITY contains identity content" {
+@test "as: does not export prompt text" {
   setup_test_home "alice"
   mock_secrets_binary
   mock_shimmer
 
   run shimmer as alice
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "export AGENT_IDENTITY="
-  echo "$output" | grep -q "You are alice."
+  [[ "$output" != *"You are alice."* ]]
 }
 
 @test "as: falls back to private home when caller repo has no agent:list" {
@@ -317,22 +309,6 @@ SCRIPT
   [ "$first_unset" -lt "$first_export" ]
 }
 
-@test "as: eval clears stale AGENT_IDENTITY from previous session" {
-  setup_test_home "alice" "bob"
-  mock_secrets_binary
-  mock_shimmer
-
-  # Simulate: previous session set AGENT_IDENTITY to bob
-  export AGENT_IDENTITY="You are bob."
-
-  # Switch to alice via eval
-  eval "$(shimmer as alice 2>/dev/null)"
-
-  # Should be alice's identity, not bob's
-  [[ "$AGENT_IDENTITY" == *"You are alice."* ]]
-  [[ "$AGENT_IDENTITY" != *"You are bob."* ]]
-}
-
 @test "as: eval clears stale B2_BUCKET when new agent has none" {
   setup_test_home "alice"
   mock_secrets_binary "alice/github-pat=ghp_fake"
@@ -366,7 +342,6 @@ eval $(SHIMMER_CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null
 
 printf 'name=%s\n' "$GIT_AUTHOR_NAME"
 printf 'host=%s\n' "$GH_HOST"
-printf 'identity=%s\n' "$AGENT_IDENTITY"
 SCRIPT
   chmod +x "$script"
 
@@ -374,7 +349,6 @@ SCRIPT
   [ "$status" -eq 0 ]
   [[ "$output" == *"name=alice"* ]]
   [[ "$output" == *"host=github.com"* ]]
-  [[ "$output" == *"You are alice."* ]]
 }
 
 @test "as: unquoted eval works in zsh" {
@@ -396,14 +370,12 @@ eval $(SHIMMER_CALLER_PWD="$home" mise -C "$overlay" run -q as alice 2>/dev/null
 
 print -r -- "name=$GIT_AUTHOR_NAME"
 print -r -- "host=$GH_HOST"
-print -r -- "identity=$AGENT_IDENTITY"
 SCRIPT
 
   run zsh "$script" "$TEST_HOME" "$OVERLAY"
   [ "$status" -eq 0 ]
   [[ "$output" == *"name=alice"* ]]
   [[ "$output" == *"host=github.com"* ]]
-  [[ "$output" == *"You are alice."* ]]
 }
 
 # ============ Validation (no mocks — fails before secrets) ============
@@ -426,7 +398,7 @@ SCRIPT
   [[ "$output" == *"bob"* ]]
 }
 
-@test "as: fails when agent:list fails even if identity resolves" {
+@test "as: fails when agent:list fails" {
   setup_test_home "alice"
   cat > "$TEST_HOME/.mise/tasks/agent/list" <<'TASK'
 #!/usr/bin/env bash
@@ -447,24 +419,14 @@ TASK
   [[ "$output" != *"You are alice."* ]]
 }
 
-@test "as: rejects agent omitted from list even if identity file exists" {
+@test "as: rejects agent omitted from list" {
   setup_test_home "alice"
-  cat > "$TEST_HOME/notes/charlie.md" <<'EOF'
----
-title: charlie
-tags: [agent, identity]
----
-
-# charlie
-You are charlie.
-EOF
   mock_shimmer
 
   run shimmer as charlie
   [ "$status" -ne 0 ]
   [[ "$output" == *"Unknown agent: charlie"* ]]
   [[ "$output" == *"alice"* ]]
-  [[ "$output" != *"You are charlie."* ]]
 }
 
 # ============ Missing agent:list (no mocks, no overlay) ============

--- a/test/as/helpers.bash
+++ b/test/as/helpers.bash
@@ -1,12 +1,12 @@
 # Helpers for shimmer `as` BATS tests
 #
-# Suite-specific: setup_test_home with agent:list, agent:identity, and identity files.
+# Suite-specific: setup_test_home with agent:list and private signing homes.
 # Shared helpers (mock_task, mock_shimmer, shimmer wrapper) loaded from test/helpers.bash.
 
 # shellcheck source=test/helpers.bash
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/helpers.bash"
 
-# Create a test home with agent:list, agent:identity, and identity files.
+# Create a test home with agent:list and private agent homes with signing config.
 # Does NOT create an overlay — tests build their own with mock_shimmer.
 # Usage: setup_test_home [agent_names...]
 setup_test_home() {
@@ -25,38 +25,12 @@ $(printf 'echo "%s"\n' "${agents[@]}")
 TASK
   chmod +x "$TEST_HOME/.mise/tasks/agent/list"
 
-  # agent:identity — returns content, not path
-  cat > "$TEST_HOME/.mise/tasks/agent/identity" <<'TASK'
-#!/usr/bin/env bash
-#MISE description="Output identity content"
-AGENT="$1"
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-IDENTITY_FILE="$DIR/notes/$AGENT.md"
-if [ -f "$IDENTITY_FILE" ]; then
-  cat "$IDENTITY_FILE"
-else
-  echo "Error: no identity for $AGENT" >&2
-  exit 1
-fi
-TASK
-  chmod +x "$TEST_HOME/.mise/tasks/agent/identity"
-
   TEST_AGENTS_ROOT="$BATS_TEST_TMPDIR/agents-root-$$"
   export TEST_AGENTS_ROOT
   export SHIMMER_AGENTS_ROOT="$TEST_AGENTS_ROOT"
 
-  # Identity files + private agent homes with signing config.
+  # Private agent homes with signing config.
   for agent in "${agents[@]}"; do
-    cat > "$TEST_HOME/notes/$agent.md" <<EOF
----
-title: $agent
-tags: [agent, identity]
----
-
-# $agent
-You are $agent.
-EOF
-
     mkdir -p "$TEST_AGENTS_ROOT/$agent/home"
     git -C "$TEST_AGENTS_ROOT/$agent/home" init -q -b main
     git -C "$TEST_AGENTS_ROOT/$agent/home" config user.name "$agent"


### PR DESCRIPTION
## Summary

- remove shimmer's legacy prompt-identity contract: no `agent:identity` lookup and no prompt identity env export/requirement
- stop implicit `--append-system-prompt` injection from `shimmer agent`; the harness now relies on cwd context such as `AGENTS.md`
- replace the current `shimmer as` picker preview with a placeholder for future operator-useful agent context, avoiding home/path guessing
- update tests around `shimmer as`, `shimmer agent`, runtime env boundaries, and workflow template comments

## Validation

- `bash -n .mise/tasks/agent/_default .mise/tasks/as .mise/tasks/_agent-preview lib/agent-env.sh test/agent/helpers.bash test/as/helpers.bash test/helpers.bash`
- `grep -R "AGENT_IDENTITY\|agent:identity" -n .` (no matches)
- `git diff --check`
- `mise run test test/workflows/generate.bats test/agent/agent.bats test/as/as.bats test/agent-env/agent-env.bats` (79/79)
- `mise run test` (179/179)
- `codebase lint:mise-settings "$PWD"`
- `codebase lint:gum-table "$PWD"`
- `codebase lint:mcr-scope "$PWD"`
- `codebase lint:bats-test-helper "$PWD"`
- `codebase lint:bats-test-task "$PWD"`
- `codebase lint:shellcheck "$PWD"`
- `codebase lint:or-true "$PWD"`

## Notes

This makes shimmer identity/auth transport prompt-neutral. If we later need explicit prompt injection through shimmer, that should be a new explicit flag/contract rather than an ambient env dependency.

Brownie did an adversarial review and agreed with the direction, but requested a legacy `AGENT_IDENTITY` scrubber for long-lived shell migration. Or decided not to retain any `AGENT_IDENTITY` knowledge in shimmer; this branch only adopted Brownie's stale workflow-template comment correction.
