### PR TITLE
workflows: wake CI agents from home

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -51,13 +51,15 @@ jobs:
     timeout-minutes: 20
     env:
       REPO_NAME: ${{ github.event.repository.name }}
-      WORK_DIR: /home/runner/agents/${{ inputs.agent }}/${{ github.event.repository.name }}
+      AGENT_HOME: /home/runner/agents/${{ inputs.agent }}/home
+      CALLER_REPO: ${{ github.repository }}
+      CALLER_REPO_PATH: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
       # Nested shiv package installs run their own mise commands.
       MISE_EXPERIMENTAL: "1"
     defaults:
       run:
-        working-directory: /home/runner/agents/${{ inputs.agent }}/${{ github.event.repository.name }}
+        working-directory: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
     steps:
       - name: Checkout current repo
         uses: actions/checkout@v6
@@ -68,8 +70,8 @@ jobs:
       - name: Setup workspace
         working-directory: ${{ github.workspace }}
         run: |
-          mkdir -p "$(dirname "$WORK_DIR")"
-          mv repo "$WORK_DIR"
+          mkdir -p "$(dirname "$CALLER_REPO_PATH")"
+          mv repo "$CALLER_REPO_PATH"
 
       - name: Resolve mise version
         id: mise-version
@@ -173,19 +175,26 @@ jobs:
           EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
         run: emails setup ${{ inputs.agent }}
 
+      - name: Resolve agent GitHub login
+        run: |
+          set -euo pipefail
+          login=$(gh api user --jq .login)
+          if [[ -z "$login" || ! "$login" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+            echo "::error::Could not resolve a valid GitHub login from the agent token"
+            exit 1
+          fi
+          echo "AGENT_GITHUB_LOGIN=$login" >> "$GITHUB_ENV"
+          echo "BROWSER_GITHUB_COM_USERNAME=$login" >> "$GITHUB_ENV"
+          echo "Agent GitHub login: $login"
+
       - name: Clone home repo
         run: |
-          HOME_DIR="$HOME/agents/${{ inputs.agent }}/home"
-          HOME_REPO="${{ inputs.agent }}-ricon/home"
-          LEGACY_REPO="${{ inputs.agent }}-ricon/zettelkasten"
+          HOME_DIR="$AGENT_HOME"
+          HOME_REPO="$AGENT_GITHUB_LOGIN/home"
 
-          if gh repo view "$HOME_REPO" --json name > /dev/null 2>&1; then
-            REPO="$HOME_REPO"
-          elif gh repo view "$LEGACY_REPO" --json name > /dev/null 2>&1; then
-            REPO="$LEGACY_REPO"
-          else
-            echo "No home repo found for ${{ inputs.agent }}, skipping"
-            exit 0
+          if ! gh repo view "$HOME_REPO" --json name > /dev/null 2>&1; then
+            echo "::error::No home repo found for $AGENT_GITHUB_LOGIN at $HOME_REPO"
+            exit 1
           fi
 
           if [ -d "$HOME_DIR/.git" ]; then
@@ -193,9 +202,9 @@ jobs:
             exit 0
           fi
 
-          echo "Cloning home repo from $REPO..."
+          echo "Cloning home repo from $HOME_REPO..."
           mkdir -p "$(dirname "$HOME_DIR")"
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$HOME_DIR"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${HOME_REPO}.git" "$HOME_DIR"
           echo "Home repo available at $HOME_DIR"
 
       - name: Prepare home repo
@@ -204,7 +213,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          HOME_DIR="$HOME/agents/${{ inputs.agent }}/home"
+          HOME_DIR="$AGENT_HOME"
           if [ ! -d "$HOME_DIR/.git" ]; then
             echo "Home repo not present at $HOME_DIR; skipping home preparation"
             exit 0
@@ -248,12 +257,12 @@ jobs:
           echo "PI_CODING_AGENT_DIR=$PI_AGENT_DIR" >> "$GITHUB_ENV"
 
       - name: Run agent
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           AGENT: ${{ inputs.agent }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BROWSER_GITHUB_COM_PASSWORD: ${{ secrets.AGENT_GITHUB_PASSWORD }}
-          BROWSER_GITHUB_COM_USERNAME: ${{ inputs.agent }}-ricon
           DISPATCH_CONTEXT: ${{ github.triggering_actor }}
           INPUT_MESSAGE: ${{ inputs.message }}
           INPUT_MODEL: ${{ inputs.model }}
@@ -309,7 +318,7 @@ jobs:
           echo ""
           echo "--- Disk usage ---"
           df -h / | tail -1
-          du -sh "$WORK_DIR" 2>/dev/null || true
+          du -sh "$CALLER_REPO_PATH" 2>/dev/null || true
           du -sh "$HOME/agents" 2>/dev/null || true
           echo ""
           echo "--- mise status ---"

--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -50,29 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      REPO_NAME: ${{ github.event.repository.name }}
       AGENT_HOME: /home/runner/agents/${{ inputs.agent }}/home
-      CALLER_REPO: ${{ github.repository }}
-      CALLER_REPO_PATH: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
+      DISPATCH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
       # Nested shiv package installs run their own mise commands.
       MISE_EXPERIMENTAL: "1"
-    defaults:
-      run:
-        working-directory: /home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}
     steps:
-      - name: Checkout current repo
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.AGENT_GITHUB_PAT }}
-          path: repo
-
-      - name: Setup workspace
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir -p "$(dirname "$CALLER_REPO_PATH")"
-          mv repo "$CALLER_REPO_PATH"
-
       - name: Resolve mise version
         id: mise-version
         run: |
@@ -89,44 +72,9 @@ jobs:
         uses: jdx/mise-action@v4
         with:
           version: ${{ steps.mise-version.outputs.version }}
-          install: true
+          install: false
         env:
           GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_PAT }}
-
-      - name: Install project tools
-        env:
-          MISE_JOBS: 1  # Serialize — vfox-shiv bootstrap isn't parallel-safe yet
-        run: |
-          mise trust
-          mise install
-
-      - name: Trust shiv package configs
-        run: |
-          while IFS= read -r -d '' config; do
-            mise trust -q "$config"
-          done < <(find "$HOME/.local/share/mise/installs" -path '*/packages/*/mise.toml' -print0)
-
-      - name: Compute sessions CLI cache key
-        id: sessions
-        run: |
-          SESSIONS_DIR="$(mise where shiv:sessions)/packages/sessions"
-          echo "mix-lock-hash=$(sha256sum "$SESSIONS_DIR/cli/mix.lock" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache sessions CLI build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/_build
-            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/deps
-          key: ${{ runner.os }}-sessions-cli-${{ steps.sessions.outputs.mix-lock-hash }}
-          restore-keys: |
-            ${{ runner.os }}-sessions-cli-
-
-      - name: Build sessions CLI
-        run: sessions cli:build
-
-      - name: Install pi
-        run: mise use -g github:badlogic/pi-mono@0.73.0
 
       - name: Setup secrets for env provider
         env:
@@ -167,14 +115,6 @@ jobs:
 
           echo "SECRETS_PROVIDER=env" >> "$GITHUB_ENV"
 
-      - name: Setup GPG
-        run: shimmer gpg:setup ${{ inputs.agent }}
-
-      - name: Setup email
-        env:
-          EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
-        run: emails setup ${{ inputs.agent }}
-
       - name: Resolve agent GitHub login
         run: |
           set -euo pipefail
@@ -207,34 +147,69 @@ jobs:
           git clone "https://x-access-token:${GH_TOKEN}@github.com/${HOME_REPO}.git" "$HOME_DIR"
           echo "Home repo available at $HOME_DIR"
 
+      - name: Install home tools
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        env:
+          MISE_JOBS: 1  # Serialize — vfox-shiv bootstrap isn't parallel-safe yet
+        run: |
+          gh auth setup-git
+          mise trust
+          mise install
+
+      - name: Trust shiv package configs
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: |
+          while IFS= read -r -d '' config; do
+            mise trust -q "$config"
+          done < <(find "$HOME/.local/share/mise/installs" -path '*/packages/*/mise.toml' -print0)
+
+      - name: Compute sessions CLI cache key
+        id: sessions
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: |
+          SESSIONS_DIR="$(mise where shiv:sessions)/packages/sessions"
+          echo "mix-lock-hash=$(sha256sum "$SESSIONS_DIR/cli/mix.lock" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache sessions CLI build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/_build
+            ~/.local/share/mise/installs/shiv-sessions/*/packages/sessions/cli/deps
+          key: ${{ runner.os }}-sessions-cli-${{ steps.sessions.outputs.mix-lock-hash }}
+          restore-keys: |
+            ${{ runner.os }}-sessions-cli-
+
+      - name: Build sessions CLI
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: sessions cli:build
+
+      - name: Install pi
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: mise use -g github:badlogic/pi-mono@0.73.0
+
+      - name: Setup GPG
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        run: shimmer gpg:setup ${{ inputs.agent }}
+
+      - name: Setup email
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
+        env:
+          EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
+        run: emails setup ${{ inputs.agent }}
+
       - name: Prepare home repo
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           MISE_JOBS: 1
         run: |
           set -euo pipefail
 
-          HOME_DIR="$AGENT_HOME"
-          if [ ! -d "$HOME_DIR/.git" ]; then
-            echo "Home repo not present at $HOME_DIR; skipping home preparation"
-            exit 0
-          fi
-
-          cd "$HOME_DIR"
           gh auth setup-git
-          mise trust
-          mise install
-
           if mise tasks info agent:prepare >/dev/null 2>&1; then
             mise run agent:prepare
           else
             echo "::warning::No agent:prepare task found in home repo; skipping home-specific preparation. Add an agent:prepare task to silence this warning."
-          fi
-
-      - name: Unlock caller repo notes
-        run: |
-          if [ -d ".git-crypt" ]; then
-            rudi install
-            notes unlock || echo "Warning: notes unlock failed — encrypted files may not be readable"
           fi
 
       - name: Setup pi auth
@@ -298,6 +273,7 @@ jobs:
 
       - name: Back up sessions
         if: always()
+        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           AGENT: ${{ inputs.agent }}
         run: |
@@ -318,7 +294,7 @@ jobs:
           echo ""
           echo "--- Disk usage ---"
           df -h / | tail -1
-          du -sh "$CALLER_REPO_PATH" 2>/dev/null || true
+          du -sh "$AGENT_HOME" 2>/dev/null || true
           du -sh "$HOME/agents" 2>/dev/null || true
           echo ""
           echo "--- mise status ---"

--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -273,10 +273,15 @@ jobs:
 
       - name: Back up sessions
         if: always()
-        working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:
           AGENT: ${{ inputs.agent }}
         run: |
+          if [ ! -d "$AGENT_HOME" ]; then
+            echo "Agent home not available; skipping session backup"
+            exit 0
+          fi
+
+          cd "$AGENT_HOME"
           if ! command -v shimmer >/dev/null 2>&1; then
             echo "shimmer not available; skipping session backup"
             exit 0

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -48,6 +48,7 @@ setup() {
   prepare_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | ."working-directory" // ""' "$template")
   run_agent_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | ."working-directory" // ""' "$template")
   backup_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Back up sessions") | ."working-directory" // ""' "$template")
+  backup_run=$(yq -r '.jobs.run.steps[] | select(.name == "Back up sessions") | .run // ""' "$template")
   browser_username=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | .env.BROWSER_GITHUB_COM_USERNAME // ""' "$template")
 
   [ "$agent_home" = '/home/runner/agents/${{ inputs.agent }}/home' ]
@@ -76,7 +77,9 @@ setup() {
   ! echo "$prepare_run" | grep -qF 'mise install'
   [ "$prepare_workdir" = "$agent_home" ]
   [ "$run_agent_workdir" = "$agent_home" ]
-  [ "$backup_workdir" = "$agent_home" ]
+  [ -z "$backup_workdir" ]
+  echo "$backup_run" | grep -qF 'Agent home not available; skipping session backup'
+  echo "$backup_run" | grep -qF 'cd "$AGENT_HOME"'
   [ -z "$browser_username" ]
   grep -qF 'du -sh "$AGENT_HOME"' "$template"
 }

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -29,6 +29,41 @@ setup() {
   ! echo "$run_block" | grep -qF 'modules init'
 }
 
+@test "workflow: runs agents from home and exposes caller repo context" {
+  template="$SHIMMER_DIR/.github/templates/agent-run.yml"
+
+  agent_home=$(yq -r '.jobs.run.env.AGENT_HOME // ""' "$template")
+  caller_repo=$(yq -r '.jobs.run.env.CALLER_REPO // ""' "$template")
+  caller_repo_path=$(yq -r '.jobs.run.env.CALLER_REPO_PATH // ""' "$template")
+  work_dir=$(yq -r '.jobs.run.env.WORK_DIR // ""' "$template")
+  default_workdir=$(yq -r '.jobs.run.defaults.run.working-directory // ""' "$template")
+  setup_run=$(yq -r '.jobs.run.steps[] | select(.name == "Setup workspace") | .run // ""' "$template")
+  resolve_login_run=$(yq -r '.jobs.run.steps[] | select(.name == "Resolve agent GitHub login") | .run // ""' "$template")
+  clone_run=$(yq -r '.jobs.run.steps[] | select(.name == "Clone home repo") | .run // ""' "$template")
+  prepare_run=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run // ""' "$template")
+  run_agent_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | ."working-directory" // ""' "$template")
+  browser_username=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | .env.BROWSER_GITHUB_COM_USERNAME // ""' "$template")
+
+  [ "$agent_home" = '/home/runner/agents/${{ inputs.agent }}/home' ]
+  [ "$caller_repo" = '${{ github.repository }}' ]
+  [ "$caller_repo_path" = '/home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}' ]
+  [ -z "$work_dir" ]
+  [ "$default_workdir" = "$caller_repo_path" ]
+  echo "$setup_run" | grep -qF 'mv repo "$CALLER_REPO_PATH"'
+  echo "$resolve_login_run" | grep -qF 'gh api user --jq .login'
+  echo "$resolve_login_run" | grep -qF 'AGENT_GITHUB_LOGIN=$login'
+  echo "$resolve_login_run" | grep -qF 'BROWSER_GITHUB_COM_USERNAME=$login'
+  echo "$clone_run" | grep -qF 'HOME_DIR="$AGENT_HOME"'
+  echo "$clone_run" | grep -qF 'HOME_REPO="$AGENT_GITHUB_LOGIN/home"'
+  echo "$clone_run" | grep -qF '::error::No home repo found'
+  ! echo "$clone_run" | grep -qF 'zettelkasten'
+  ! grep -qF -- '-ricon' "$template"
+  [ -z "$browser_username" ]
+  echo "$prepare_run" | grep -qF 'HOME_DIR="$AGENT_HOME"'
+  grep -qF 'du -sh "$CALLER_REPO_PATH"' "$template"
+  [ "$run_agent_workdir" = "$agent_home" ]
+}
+
 @test "workflow: mise action uses resolved current version" {
   template="$SHIMMER_DIR/.github/templates/agent-run.yml"
 

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -29,27 +29,39 @@ setup() {
   ! echo "$run_block" | grep -qF 'modules init'
 }
 
-@test "workflow: runs agents from home and exposes caller repo context" {
+@test "workflow: runs agents from home without checking out the dispatch repo" {
   template="$SHIMMER_DIR/.github/templates/agent-run.yml"
 
   agent_home=$(yq -r '.jobs.run.env.AGENT_HOME // ""' "$template")
+  dispatch_repo=$(yq -r '.jobs.run.env.DISPATCH_REPO // ""' "$template")
   caller_repo=$(yq -r '.jobs.run.env.CALLER_REPO // ""' "$template")
   caller_repo_path=$(yq -r '.jobs.run.env.CALLER_REPO_PATH // ""' "$template")
   work_dir=$(yq -r '.jobs.run.env.WORK_DIR // ""' "$template")
   default_workdir=$(yq -r '.jobs.run.defaults.run.working-directory // ""' "$template")
-  setup_run=$(yq -r '.jobs.run.steps[] | select(.name == "Setup workspace") | .run // ""' "$template")
+  step_names=$(yq -r '.jobs.run.steps[].name' "$template")
+  mise_install=$(yq -r '.jobs.run.steps[] | select(.name == "Set up mise") | .with.install' "$template")
   resolve_login_run=$(yq -r '.jobs.run.steps[] | select(.name == "Resolve agent GitHub login") | .run // ""' "$template")
   clone_run=$(yq -r '.jobs.run.steps[] | select(.name == "Clone home repo") | .run // ""' "$template")
+  install_home_run=$(yq -r '.jobs.run.steps[] | select(.name == "Install home tools") | .run // ""' "$template")
+  install_home_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Install home tools") | ."working-directory" // ""' "$template")
   prepare_run=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | .run // ""' "$template")
+  prepare_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Prepare home repo") | ."working-directory" // ""' "$template")
   run_agent_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | ."working-directory" // ""' "$template")
+  backup_workdir=$(yq -r '.jobs.run.steps[] | select(.name == "Back up sessions") | ."working-directory" // ""' "$template")
   browser_username=$(yq -r '.jobs.run.steps[] | select(.name == "Run agent") | .env.BROWSER_GITHUB_COM_USERNAME // ""' "$template")
 
   [ "$agent_home" = '/home/runner/agents/${{ inputs.agent }}/home' ]
-  [ "$caller_repo" = '${{ github.repository }}' ]
-  [ "$caller_repo_path" = '/home/runner/agents/${{ inputs.agent }}/caller/${{ github.event.repository.name }}' ]
+  [ "$dispatch_repo" = '${{ github.repository }}' ]
+  [ -z "$caller_repo" ]
+  [ -z "$caller_repo_path" ]
   [ -z "$work_dir" ]
-  [ "$default_workdir" = "$caller_repo_path" ]
-  echo "$setup_run" | grep -qF 'mv repo "$CALLER_REPO_PATH"'
+  [ -z "$default_workdir" ]
+  [ "$mise_install" = "false" ]
+  ! echo "$step_names" | grep -qFx 'Checkout current repo'
+  ! echo "$step_names" | grep -qFx 'Setup workspace'
+  ! echo "$step_names" | grep -qFx 'Unlock caller repo notes'
+  ! grep -qF '/caller/' "$template"
+  ! grep -qF 'actions/checkout' "$template"
   echo "$resolve_login_run" | grep -qF 'gh api user --jq .login'
   echo "$resolve_login_run" | grep -qF 'AGENT_GITHUB_LOGIN=$login'
   echo "$resolve_login_run" | grep -qF 'BROWSER_GITHUB_COM_USERNAME=$login'
@@ -58,10 +70,15 @@ setup() {
   echo "$clone_run" | grep -qF '::error::No home repo found'
   ! echo "$clone_run" | grep -qF 'zettelkasten'
   ! grep -qF -- '-ricon' "$template"
-  [ -z "$browser_username" ]
-  echo "$prepare_run" | grep -qF 'HOME_DIR="$AGENT_HOME"'
-  grep -qF 'du -sh "$CALLER_REPO_PATH"' "$template"
+  [ "$install_home_workdir" = "$agent_home" ]
+  echo "$install_home_run" | grep -qF 'mise install'
+  echo "$prepare_run" | grep -qF 'mise run agent:prepare'
+  ! echo "$prepare_run" | grep -qF 'mise install'
+  [ "$prepare_workdir" = "$agent_home" ]
   [ "$run_agent_workdir" = "$agent_home" ]
+  [ "$backup_workdir" = "$agent_home" ]
+  [ -z "$browser_username" ]
+  grep -qF 'du -sh "$AGENT_HOME"' "$template"
 }
 
 @test "workflow: mise action uses resolved current version" {


### PR DESCRIPTION
## Summary

- change generated agent-run workflows to clone only the agent home repo and run the agent from `~/agents/<agent>/home`
- remove the dispatch/triggering repo checkout entirely; the triggering repo is metadata via `DISPATCH_REPO`, not a workspace
- install tools from the cloned home repo before running `agent:prepare`
- resolve the agent GitHub login from the CI PAT and clone `<login>/home`, removing `-ricon` / legacy home assumptions
- keep session backup best-effort if the home clone failed before `AGENT_HOME` exists

## Validation

- `mise run test agent`
- `mise run test workflows`
- `mise run test` — 180/180

## Notes

Tracks the source-template side of ricon-family/fold#117.

Regenerating fold's committed workflows from current shimmer is currently blocked by ricon-family/fold#98 not being merged: fold main does not yet provide `agent:list --ci --json` metadata required by the current mention-wake generator.
