### PR TITLE
workflows: let sessions own CLI readiness

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -180,10 +180,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sessions-cli-
 
-      - name: Build sessions CLI
-        working-directory: /home/runner/agents/${{ inputs.agent }}/home
-        run: sessions cli:build
-
       - name: Install pi
         working-directory: /home/runner/agents/${{ inputs.agent }}/home
         run: mise use -g github:badlogic/pi-mono@0.73.0

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -120,6 +120,8 @@ Trigger workflows call a per-agent entrypoint (`<agent>.yml`), and the per-agent
 
 Headless execution requires an explicit provider-qualified model. For Hugging Face routed models, use the `huggingface/...` prefix (for example `huggingface/moonshotai/Kimi-K2.6:novita`) so pi selects the Hugging Face provider and reads `HF_TOKEN`, even if other provider secrets are also present. Shimmer creates a tracked session with `sessions new` and passes the model only to `sessions wake`, matching the `sessions` v0.4 contract.
 
+The generated workflow may restore caches for `sessions`, but it does not call `sessions cli:build` directly. CLI dependency readiness belongs to the public `shimmer agent --headless` / `sessions` execution path, not to every generated agent workflow.
+
 ### Home repo `agent:prepare` hook
 
 The `Prepare home repo` step is owned by the agent's home repo. After `mise trust && mise install` in the home, the workflow runs:

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -138,6 +138,15 @@ setup() {
   ! grep -qF 'AGENT_MATRIX_PASSWORD' "$generator"
 }
 
+@test "workflow: does not eagerly build sessions CLI" {
+  template="$SHIMMER_DIR/.github/templates/agent-run.yml"
+
+  step_names=$(yq -r '.jobs.run.steps[].name' "$template")
+
+  ! echo "$step_names" | grep -qFx 'Build sessions CLI'
+  ! grep -qF 'sessions cli:build' "$template"
+}
+
 @test "workflow: backs up sessions after agent run" {
   template="$SHIMMER_DIR/.github/templates/agent-run.yml"
 


### PR DESCRIPTION
## Summary

- Removes the eager `sessions cli:build` step from the generated agent-run workflow.
- Leaves sessions cache restore in place, but lets `shimmer agent --headless` / `sessions` own CLI dependency readiness.
- Documents the boundary and adds a workflow-template regression test.

## Why

A `ricon-family/fold#117` CI smoke cloned Junior's home correctly, then failed before the agent ran because the generated workflow invoked `sessions cli:build` from the agent home context:

```text
mise ERROR No version is set for shim: sessions
```

That step is a leaked implementation detail. `shimmer agent --headless` already delegates to `sessions new` + `sessions wake`, and `sessions run` already owns first-run CLI dependency setup.

Follow-up for sessions-side polish: KnickKnackLabs/sessions#111.

## Validation

- `mise run test agent`
- `mise run test` — 181/181
- `git diff --check`
