### PR TITLE
Remove deprecated email setup from agent CI

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -188,12 +188,6 @@ jobs:
         working-directory: /home/runner/agents/${{ inputs.agent }}/home
         run: shimmer gpg:setup ${{ inputs.agent }}
 
-      - name: Setup email
-        working-directory: /home/runner/agents/${{ inputs.agent }}/home
-        env:
-          EMAIL_PASSWORD: ${{ secrets.AGENT_EMAIL_PASSWORD }}
-        run: emails setup ${{ inputs.agent }}
-
       - name: Prepare home repo
         working-directory: /home/runner/agents/${{ inputs.agent }}/home
         env:

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -77,6 +77,8 @@ setup() {
   ! echo "$prepare_run" | grep -qF 'mise install'
   [ "$prepare_workdir" = "$agent_home" ]
   [ "$run_agent_workdir" = "$agent_home" ]
+  ! echo "$step_names" | grep -qFx 'Setup email'
+  ! grep -qF 'emails setup ${{ inputs.agent }}' "$template"
   [ -z "$backup_workdir" ]
   echo "$backup_run" | grep -qF 'Agent home not available; skipping session backup'
   echo "$backup_run" | grep -qF 'cd "$AGENT_HOME"'


### PR DESCRIPTION
## Summary

Remove the generated agent CI `Setup email` step that runs deprecated `emails setup <agent>`.

`emails setup` now exits non-zero with migration guidance, which blocks agent CI dispatch before the agent session starts. Email credentials are still forwarded through the existing `AGENT_EMAIL_PASSWORD` secret/env contract, so home-owned `agent:prepare` tasks or future explicit `emails account setup ...` paths can configure email if needed.

## Validation

- `mise run test test/agent/agent.bats`
- `mise run test test/workflows/generate.bats`
- `mise run test` — 181/181 BATS passed
- Individual configured codebase lints:
  - `codebase lint:mise-settings "$PWD"`
  - `codebase lint:gum-table "$PWD"`
  - `codebase lint:bats-test-helper "$PWD"`
  - `codebase lint:bats-test-task "$PWD"`
  - `codebase lint:mcr-scope "$PWD"`
  - `codebase lint:or-true "$PWD"`
  - `codebase lint:shellcheck "$PWD"`

Degraded/non-applicable:

- `codebase lint "$PWD"` is not available with the resolved codebase surface in this checkout; it reports no aggregate `lint` task and lists the individual lint tasks above.
- `mise run workflows:generate -- --check` currently reports missing generated `.github/workflows/<agent>.yml` files in the shimmer repo itself. That appears to be a pre-existing structural mismatch for running the generator check inside shimmer, not caused by this template-only patch.

## Follow-up

After this lands/releases, regenerate fold workflows so `ricon-family/fold/.github/workflows/agent-run.yml` no longer runs the deprecated setup step. That should unblock Brownie's CI dispatch review of `ricon-family/nvr#48`.
