### PR TITLE
Install KKL Pi in generated agent workflows

### DIFF
--- a/.github/templates/agent-run.yml
+++ b/.github/templates/agent-run.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Install pi
         working-directory: /home/runner/agents/${{ inputs.agent }}/home
-        run: mise use -g github:badlogic/pi-mono@0.73.0
+        run: mise use -g github:KnickKnackLabs/pi@v0.80.3-kkl.1
 
       - name: Setup GPG
         working-directory: /home/runner/agents/${{ inputs.agent }}/home

--- a/test/agent/agent.bats
+++ b/test/agent/agent.bats
@@ -112,7 +112,7 @@ setup() {
   [ "$hf_token_declared" = "true" ]
   [ "$hf_token_required" = "false" ]
   [ "$run_env" = '${{ secrets.HF_TOKEN }}' ]
-  echo "$pi_install" | grep -qF 'github:badlogic/pi-mono@0.73.0'
+  echo "$pi_install" | grep -qF 'github:KnickKnackLabs/pi@v0.80.3-kkl.1'
 }
 
 @test "workflow: generated per-agent wrappers forward Hugging Face and B2 tokens" {


### PR DESCRIPTION
## Summary

Update generated agent workflows to install the KKL Pi release that contains autonomous self-rewind support.

- replace `github:badlogic/pi-mono@0.73.0` with `github:KnickKnackLabs/pi@v0.80.3-kkl.1`
- update the workflow template assertion in `test/agent/agent.bats`

## Why

Hosted agent wakes still install the old upstream Pi in generated `agent-run.yml`. The new self-rewind path depends on KKL Pi `v0.80.3-kkl.1`, including exact tree summaries and terminal queued extension commands.

This pairs with `KnickKnackLabs/sessions#117`, which makes `sessions` own/resolve the Pi harness version locally.

## Validation

```sh
cd ~/agents/brownie/shimmer && mise run test test/agent/agent.bats
# 40 passed

cd ~/agents/brownie/shimmer && mise run test test/workflows/generate.bats
# 10 passed

cd ~/agents/brownie/shimmer && mise run test
# 181 passed

cd ~/agents/brownie/shimmer && readme build --check
# README.md is up to date.

cd ~/agents/brownie/shimmer && codebase lint "$PWD"
# all 9 lint rule(s) passed

cd ~/agents/brownie/shimmer && git diff --check
```
